### PR TITLE
Story 0A.4: ESLint & Prettier Configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "semi": true
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,67 @@
+const tsParser = require('@typescript-eslint/parser');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+
+module.exports = [
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/', 'webpack.config.js', 'jest.config.js', 'jest.ci.config.js'],
+  },
+  // Source files (src/**/*.ts)
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.json',
+        ecmaVersion: 2022,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'no-console': ['error', { allow: ['error', 'warn'] }],
+    },
+  },
+  // CLI files — console.log allowed
+  {
+    files: ['cli/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.cli.json',
+        ecmaVersion: 2022,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      // CLI communicates via stdout, not MCP stdio — console.log is safe
+    },
+  },
+  // Test files
+  {
+    files: ['tests/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.test.json',
+        ecmaVersion: 2022,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+];


### PR DESCRIPTION
## Summary
ESLint flat config (v10) + Prettier for code quality.

## Changes
- `eslint.config.js`: TypeScript rules, no-console (MCP safety), CLI override
- `.prettierrc`: Single quotes, trailing commas
- `.editorconfig`: 2-space indent, LF

## Verification
- [ ] `npm run lint` passes with 0 errors
- [ ] `console.log` in src/ → lint error
- [ ] `console.log` in cli/ → allowed (override)

## Post-Deployment Success Criteria
- [ ] Lint runs in CI and blocks on errors
- [ ] MCP stdio safety enforced (no console.log in src/)

Resolves #18
🤖 Generated with [Claude Code](https://claude.com/claude-code)