### PR TITLE
Epic 1A: SimulatorManager — Complete xcrun simctl Wrapper

### DIFF
--- a/src/simulator/index.ts
+++ b/src/simulator/index.ts
@@ -1,0 +1,10 @@
+export { SimulatorManager, DeviceNotFoundError, BootTimeoutError, ShutdownTimeoutError, DeviceNotBootedError, ScreenshotTimeoutError } from './manager';
+export { SimctlExecutor, SimctlError } from './simctl';
+export { DEVICE_PRESETS, resolvePreset } from './presets';
+export type { SimulatorDevice, SimulatorRuntime, DevicePreset } from './types';
+export { checkXcodeInstallation } from './xcode-check';
+export type { XcodeCheckResult } from './xcode-check';
+export { SimulatorPool, InsufficientResourcesError } from './pool';
+export type { PooledSimulator, SimulatorPoolOptions } from './pool';
+export { BatchExecutor } from './batch';
+export type { BatchResult } from './batch';

--- a/src/simulator/manager.ts
+++ b/src/simulator/manager.ts
@@ -1,0 +1,364 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { SimctlExecutor } from './simctl';
+import { SimulatorDevice, SimulatorRuntime } from './types';
+import { DEVICE_PRESETS } from './presets';
+import { DEFAULT_SIMULATOR_BOOT_TIMEOUT_MS, DEFAULT_SIMULATOR_SHUTDOWN_TIMEOUT_MS, DEFAULT_SCREENSHOT_TIMEOUT_MS } from '../config/defaults';
+
+interface SimctlListResult {
+  devices: Record<string, Array<{
+    udid: string;
+    name: string;
+    state: string;
+    isAvailable: boolean;
+  }>>;
+  runtimes: Array<{
+    identifier: string;
+    version: string;
+    isAvailable: boolean;
+    platform: string;
+  }>;
+}
+
+export class SimulatorManager {
+  private simctl = new SimctlExecutor();
+
+  async listDevices(): Promise<SimulatorDevice[]> {
+    const result = await this.simctl.execJson<SimctlListResult>(['list', 'devices']);
+    const devices: SimulatorDevice[] = [];
+
+    for (const [runtimeId, deviceList] of Object.entries(result.devices)) {
+      const version = runtimeId.match(/iOS-(\d+)-(\d+)/);
+      const runtimeVersion = version ? `${version[1]}.${version[2]}` : 'unknown';
+
+      for (const device of deviceList) {
+        if (device.isAvailable) {
+          devices.push({
+            udid: device.udid,
+            name: device.name,
+            state: device.state as SimulatorDevice['state'],
+            isAvailable: device.isAvailable,
+            runtime: runtimeId,
+            runtimeVersion,
+          });
+        }
+      }
+    }
+
+    return devices;
+  }
+
+  async listRuntimes(): Promise<SimulatorRuntime[]> {
+    const result = await this.simctl.execJson<SimctlListResult>(['list', 'runtimes']);
+    return result.runtimes.filter(r => r.isAvailable);
+  }
+
+  async listBooted(): Promise<SimulatorDevice[]> {
+    const devices = await this.listDevices();
+    return devices.filter(d => d.state === 'Booted');
+  }
+
+  async getDevice(deviceId: string): Promise<SimulatorDevice | null> {
+    const devices = await this.listDevices();
+    return devices.find(d => d.udid === deviceId) ?? null;
+  }
+
+  /**
+   * Resolve a preset key or device name to an actual device.
+   * Tries: exact UDID match → preset name match → fuzzy name match
+   */
+  async resolveDevice(presetKey: string): Promise<SimulatorDevice> {
+    const devices = await this.listDevices();
+
+    // 1. Exact UDID match
+    const byUdid = devices.find(d => d.udid === presetKey);
+    if (byUdid) return byUdid;
+
+    // 2. Preset name match
+    const preset = DEVICE_PRESETS[presetKey];
+    if (preset) {
+      const exact = devices.find(d => d.name === preset.name);
+      if (exact) return exact;
+    }
+
+    // 3. Case-insensitive substring match
+    const lower = presetKey.toLowerCase();
+    const substring = devices.find(d => d.name.toLowerCase().includes(lower));
+    if (substring) return substring;
+
+    // 4. Fuzzy: split words, match all keywords
+    const keywords = lower.split(/[\s-]+/);
+    const fuzzy = devices.find(d => {
+      const dLower = d.name.toLowerCase();
+      return keywords.every(kw => dLower.includes(kw));
+    });
+    if (fuzzy) return fuzzy;
+
+    throw new DeviceNotFoundError(presetKey, devices.map(d => d.name));
+  }
+
+  async checkRuntimes(): Promise<{ installed: SimulatorRuntime[]; issues: string[]; suggestions: string[] }> {
+    const runtimes = await this.listRuntimes();
+    const iosRuntimes = runtimes.filter(r => r.platform === 'iOS');
+    const issues: string[] = [];
+    const suggestions: string[] = [];
+
+    if (iosRuntimes.length === 0) {
+      issues.push('No iOS Simulator runtimes found');
+      suggestions.push('Run: xcodebuild -downloadPlatform iOS');
+    }
+
+    return { installed: iosRuntimes, issues, suggestions };
+  }
+
+  async boot(presetOrId: string, options?: { timeout?: number }): Promise<SimulatorDevice> {
+    const device = await this.resolveDevice(presetOrId);
+
+    // Already booted — return immediately
+    if (device.state === 'Booted') {
+      return device;
+    }
+
+    // Boot
+    await this.simctl.exec(['boot', device.udid]);
+
+    // Poll until booted or timeout
+    const timeout = options?.timeout ?? DEFAULT_SIMULATOR_BOOT_TIMEOUT_MS;
+    const start = Date.now();
+    const pollInterval = 1000;
+
+    while (Date.now() - start < timeout) {
+      const current = await this.getDevice(device.udid);
+      if (current?.state === 'Booted') {
+        return current;
+      }
+      await new Promise(r => setTimeout(r, pollInterval));
+    }
+
+    throw new BootTimeoutError(device.udid, device.name, timeout);
+  }
+
+  async shutdown(deviceId: string, options?: { timeout?: number }): Promise<void> {
+    const device = await this.getDevice(deviceId);
+    if (!device || device.state === 'Shutdown') {
+      return; // Already shutdown
+    }
+
+    // Graceful shutdown
+    try {
+      await this.simctl.exec(['shutdown', deviceId]);
+    } catch {
+      // May already be shutting down
+    }
+
+    // Wait for shutdown
+    const timeout = options?.timeout ?? DEFAULT_SIMULATOR_SHUTDOWN_TIMEOUT_MS;
+    const start = Date.now();
+
+    while (Date.now() - start < timeout) {
+      const current = await this.getDevice(deviceId);
+      if (!current || current.state === 'Shutdown') {
+        return;
+      }
+      await new Promise(r => setTimeout(r, 1000));
+    }
+
+    // Retry shutdown
+    try {
+      await this.simctl.exec(['shutdown', deviceId]);
+      await new Promise(r => setTimeout(r, 5000));
+      const current = await this.getDevice(deviceId);
+      if (!current || current.state === 'Shutdown') return;
+    } catch {
+      // Fall through to erase
+    }
+
+    // Nuclear option — erase device (WARNING: deletes all data)
+    console.error(`[SimulatorManager] Force erasing device ${deviceId} after shutdown timeout`);
+    await this.simctl.exec(['erase', deviceId]);
+  }
+
+  async bootPreset(presetKey: string): Promise<SimulatorDevice> {
+    return this.boot(presetKey);
+  }
+
+  async openUrl(deviceId: string, url: string): Promise<void> {
+    // Validate URL
+    try {
+      new URL(url);
+    } catch {
+      throw new Error(`Invalid URL: ${url}`);
+    }
+
+    // Check device is booted
+    const device = await this.getDevice(deviceId);
+    if (!device || device.state !== 'Booted') {
+      throw new DeviceNotBootedError(deviceId);
+    }
+
+    await this.simctl.exec(['openurl', deviceId, url]);
+    // Brief wait for Safari to start processing
+    await new Promise(r => setTimeout(r, 1000));
+  }
+
+  async screenshot(deviceId: string, options?: { format?: 'png' | 'jpeg' }): Promise<Buffer> {
+    const device = await this.getDevice(deviceId);
+    if (!device || device.state !== 'Booted') {
+      throw new DeviceNotBootedError(deviceId);
+    }
+
+    const format = options?.format ?? 'png';
+    const tmpFile = path.join(os.tmpdir(), `opensafari-screenshot-${randomUUID()}.${format}`);
+
+    try {
+      await this.simctl.exec(
+        ['io', deviceId, 'screenshot', `--type=${format}`, tmpFile],
+        { timeout: DEFAULT_SCREENSHOT_TIMEOUT_MS }
+      );
+      const buffer = await fs.readFile(tmpFile);
+      return buffer;
+    } finally {
+      // Cleanup temp file
+      await fs.unlink(tmpFile).catch(() => {});
+    }
+  }
+
+  async screenshotBase64(deviceId: string, options?: { format?: 'png' | 'jpeg' }): Promise<string> {
+    const buffer = await this.screenshot(deviceId, options);
+    return buffer.toString('base64');
+  }
+
+  // Expose simctl for direct use by other methods
+  getSimctl(): SimctlExecutor {
+    return this.simctl;
+  }
+
+  // === Appearance (Dark/Light Mode) ===
+
+  async setAppearance(deviceId: string, mode: 'light' | 'dark'): Promise<void> {
+    const device = await this.getDevice(deviceId);
+    if (!device || device.state !== 'Booted') {
+      throw new DeviceNotBootedError(deviceId);
+    }
+    await this.simctl.exec(['ui', deviceId, 'appearance', mode]);
+  }
+
+  async getAppearance(deviceId: string): Promise<'light' | 'dark'> {
+    const device = await this.getDevice(deviceId);
+    if (!device || device.state !== 'Booted') {
+      throw new DeviceNotBootedError(deviceId);
+    }
+    const output = await this.simctl.exec(['ui', deviceId, 'appearance']);
+    return output.trim().toLowerCase() === 'dark' ? 'dark' : 'light';
+  }
+
+  async toggleAppearance(deviceId: string): Promise<'light' | 'dark'> {
+    const current = await this.getAppearance(deviceId);
+    const next = current === 'light' ? 'dark' : 'light';
+    await this.setAppearance(deviceId, next);
+    return next;
+  }
+
+  // === Rotation ===
+  // Note: simctl has no direct rotate command.
+  // Method A: AppleScript (requires Simulator.app GUI)
+  // Method B: WebKit Protocol viewport override (Epic 1B fallback)
+
+  async rotate(deviceId: string): Promise<void> {
+    const device = await this.getDevice(deviceId);
+    if (!device || device.state !== 'Booted') {
+      throw new DeviceNotBootedError(deviceId);
+    }
+
+    // Try AppleScript rotation via Simulator.app menu
+    try {
+      const { execFile } = require('child_process');
+      const { promisify } = require('util');
+      const execFileAsync = promisify(execFile);
+      await execFileAsync('osascript', [
+        '-e', 'tell application "Simulator" to activate',
+        '-e', 'delay 0.5',
+        '-e', 'tell application "System Events" to tell process "Simulator" to click menu item "Rotate Left" of menu "Device" of menu bar 1',
+      ], { timeout: 10000 });
+    } catch {
+      // AppleScript may fail in headless/CI environments
+      console.error('[SimulatorManager] Rotation via AppleScript failed — use WebKit Protocol viewport override as fallback (Epic 1B)');
+    }
+  }
+
+  // === Device Clone (state persistence alternative) ===
+  // Note: simctl snapshot save/restore does NOT exist.
+  // simctl clone creates a full device copy with a new UDID.
+
+  async cloneDevice(deviceId: string, cloneName: string): Promise<string> {
+    const output = await this.simctl.exec(['clone', deviceId, cloneName]);
+    // simctl clone returns the new device UDID
+    return output.trim();
+  }
+
+  async deleteDevice(deviceId: string): Promise<void> {
+    await this.simctl.exec(['delete', deviceId]);
+  }
+
+  // === Status Bar Override (for deterministic screenshots) ===
+
+  async overrideStatusBar(deviceId: string): Promise<void> {
+    const device = await this.getDevice(deviceId);
+    if (!device || device.state !== 'Booted') {
+      throw new DeviceNotBootedError(deviceId);
+    }
+    await this.simctl.exec([
+      'status_bar', deviceId, 'override',
+      '--time', '9:41',
+      '--batteryLevel', '100',
+      '--cellularBars', '4',
+    ]);
+  }
+}
+
+export class BootTimeoutError extends Error {
+  constructor(
+    public readonly deviceId: string,
+    public readonly deviceName: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`Simulator boot timeout: "${deviceName}" (${deviceId}) did not boot within ${timeoutMs}ms`);
+    this.name = 'BootTimeoutError';
+  }
+}
+
+export class ShutdownTimeoutError extends Error {
+  constructor(
+    public readonly deviceId: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`Simulator shutdown timeout: ${deviceId} did not shutdown within ${timeoutMs}ms`);
+    this.name = 'ShutdownTimeoutError';
+  }
+}
+
+export class DeviceNotFoundError extends Error {
+  constructor(
+    public readonly requested: string,
+    public readonly available: string[],
+  ) {
+    super(`Device not found: "${requested}". Available: ${available.slice(0, 5).join(', ')}${available.length > 5 ? '...' : ''}`);
+    this.name = 'DeviceNotFoundError';
+  }
+}
+
+export class DeviceNotBootedError extends Error {
+  constructor(public readonly deviceId: string) {
+    super(`Device ${deviceId} is not booted. Call boot() first.`);
+    this.name = 'DeviceNotBootedError';
+  }
+}
+
+export class ScreenshotTimeoutError extends Error {
+  constructor(public readonly deviceId: string) {
+    super(`Screenshot capture timed out for device ${deviceId}`);
+    this.name = 'ScreenshotTimeoutError';
+  }
+}

--- a/src/simulator/presets.ts
+++ b/src/simulator/presets.ts
@@ -1,0 +1,17 @@
+import { DevicePreset } from './types';
+
+export const DEVICE_PRESETS: Record<string, DevicePreset> = {
+  'iphone-se': { name: 'iPhone SE (3rd generation)', w: 375, h: 667, dpr: 2 },
+  'iphone-16': { name: 'iPhone 16', w: 393, h: 852, dpr: 3 },
+  'iphone-16-pro-max': { name: 'iPhone 16 Pro Max', w: 440, h: 956, dpr: 3 },
+  'ipad': { name: 'iPad (10th generation)', w: 820, h: 1180, dpr: 2 },
+  'ipad-pro': { name: 'iPad Pro 13-inch (M4)', w: 1032, h: 1376, dpr: 2 },
+};
+
+export function resolvePreset(key: string): DevicePreset {
+  const preset = DEVICE_PRESETS[key];
+  if (!preset) {
+    throw new Error(`Unknown device preset: ${key}. Available: ${Object.keys(DEVICE_PRESETS).join(', ')}`);
+  }
+  return preset;
+}

--- a/src/simulator/simctl.ts
+++ b/src/simulator/simctl.ts
@@ -1,0 +1,42 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export class SimctlExecutor {
+  async exec(args: string[], options?: { timeout?: number }): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync('xcrun', ['simctl', ...args], {
+        timeout: options?.timeout ?? 30000,
+      });
+      return stdout;
+    } catch (err: unknown) {
+      const error = err as Error & { stderr?: string; code?: number };
+      throw new SimctlError(
+        `simctl ${args.join(' ')} failed: ${error.stderr || error.message}`,
+        args,
+        error.code,
+      );
+    }
+  }
+
+  async execJson<T>(args: string[]): Promise<T> {
+    const output = await this.exec([...args, '-j']);
+    try {
+      return JSON.parse(output) as T;
+    } catch {
+      throw new SimctlError(`Failed to parse JSON from simctl ${args.join(' ')}`, args);
+    }
+  }
+}
+
+export class SimctlError extends Error {
+  constructor(
+    message: string,
+    public readonly args: string[],
+    public readonly exitCode?: number,
+  ) {
+    super(message);
+    this.name = 'SimctlError';
+  }
+}

--- a/src/simulator/types.ts
+++ b/src/simulator/types.ts
@@ -1,0 +1,22 @@
+export interface SimulatorDevice {
+  udid: string;
+  name: string;
+  state: 'Booted' | 'Shutdown' | 'Creating' | 'ShuttingDown';
+  isAvailable: boolean;
+  runtime: string;
+  runtimeVersion: string;
+}
+
+export interface SimulatorRuntime {
+  identifier: string;
+  version: string;
+  isAvailable: boolean;
+  platform: string;
+}
+
+export interface DevicePreset {
+  name: string;
+  w: number;
+  h: number;
+  dpr: number;
+}

--- a/src/simulator/xcode-check.ts
+++ b/src/simulator/xcode-check.ts
@@ -1,0 +1,87 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface XcodeCheckResult {
+  installed: boolean;
+  version?: string;
+  simulatorAvailable: boolean;
+  iosRuntimes: string[];
+  issues: string[];
+  suggestions: string[];
+}
+
+export async function checkXcodeInstallation(): Promise<XcodeCheckResult> {
+  const result: XcodeCheckResult = {
+    installed: false,
+    simulatorAvailable: false,
+    iosRuntimes: [],
+    issues: [],
+    suggestions: [],
+  };
+
+  // Check platform
+  if (process.platform !== 'darwin') {
+    result.issues.push('OpenSafari requires macOS (Xcode Simulator is macOS only)');
+    result.suggestions.push('Run on a Mac with Xcode installed');
+    return result;
+  }
+
+  // Check xcrun
+  try {
+    const { stdout } = await execFileAsync('xcrun', ['--version']);
+    result.installed = true;
+  } catch {
+    result.issues.push('xcrun not found — Xcode or Command Line Tools not installed');
+    result.suggestions.push('Install Xcode from the App Store, or run: xcode-select --install');
+    return result;
+  }
+
+  // Check Xcode version
+  try {
+    const { stdout } = await execFileAsync('xcodebuild', ['-version']);
+    const match = stdout.match(/Xcode (\d+\.\d+)/);
+    if (match) {
+      result.version = match[1];
+    }
+  } catch {
+    result.issues.push('xcodebuild not available — Xcode may not be fully installed');
+    result.suggestions.push('Install Xcode from the App Store');
+  }
+
+  // Check simctl
+  try {
+    await execFileAsync('xcrun', ['simctl', 'list', '-j']);
+    result.simulatorAvailable = true;
+  } catch {
+    result.issues.push('Simulator runtime not available');
+    result.suggestions.push('Open Xcode and install iOS Simulator components');
+  }
+
+  // Check iOS runtimes
+  try {
+    const { stdout } = await execFileAsync('xcrun', ['simctl', 'list', 'runtimes', '-j']);
+    const data = JSON.parse(stdout);
+    const runtimes = (data.runtimes ?? []) as Array<{ isAvailable: boolean; version: string; platform: string }>;
+    result.iosRuntimes = runtimes
+      .filter((r) => r.isAvailable && r.platform === 'iOS')
+      .map((r) => `iOS ${r.version}`);
+
+    if (result.iosRuntimes.length === 0) {
+      result.issues.push('No iOS Simulator runtimes installed');
+      result.suggestions.push('Run: xcodebuild -downloadPlatform iOS');
+    }
+  } catch {
+    result.issues.push('Could not list simulator runtimes');
+  }
+
+  // Check Node.js version
+  const [major] = process.version.slice(1).split('.').map(Number);
+  if (major < 18) {
+    result.issues.push(`Node.js ${process.version} detected — requires >= 18`);
+    result.suggestions.push('Upgrade Node.js to v18 or later');
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
Complete SimulatorManager wrapping xcrun simctl for Xcode Simulator lifecycle management.

## Stories Covered
- **1A.1** (#27): SimctlExecutor, device listing, presets, fuzzy matching
- **1A.2** (#28): Boot with timeout, shutdown with graceful→erase escalation
- **1A.3** (#29): openUrl in Safari, screenshot capture (PNG/JPEG, temp file cleanup)
- **1A.4** (#30): Dark/light mode toggle, AppleScript rotation, simctl clone, status bar override
- **1A.5** (#31): Xcode installation check utility

## Changes (6 files)
- `src/simulator/simctl.ts`: SimctlExecutor + SimctlError
- `src/simulator/types.ts`: SimulatorDevice, SimulatorRuntime, DevicePreset
- `src/simulator/presets.ts`: 5 device presets + resolvePreset
- `src/simulator/manager.ts`: SimulatorManager (boot, shutdown, openUrl, screenshot, rotate, appearance, clone, overrideStatusBar)
- `src/simulator/xcode-check.ts`: checkXcodeInstallation
- `src/simulator/index.ts`: Barrel export

## Post-Deployment Success Criteria
- [ ] Can boot simulator programmatically on macOS with Xcode
- [ ] Can open URL in Safari
- [ ] Can capture screenshot as Buffer/base64
- [ ] Can toggle dark/light mode
- [ ] Boot timeout enforced (15s default)
- [ ] `opensafari doctor` validates installation

Resolves #27 #28 #29 #30 #31
🤖 Generated with [Claude Code](https://claude.com/claude-code)