### PR TITLE
Epic 4B: Publishing & Documentation

### DIFF
--- a/.claude/commands/pr-review-os.md
+++ b/.claude/commands/pr-review-os.md
@@ -1,0 +1,134 @@
+---
+name: pr-review-os
+description: Review PRs in opensafari repo with priority-based issue classification
+---
+
+# OpenSafari PR Review
+
+**Target**: $ARGUMENTS
+
+- No argument → review ALL open PRs (`gh pr list --state open`)
+- PR number → review that PR
+- "latest" → most recent open PR
+
+---
+
+## STEP 1: Gather Context
+
+For EACH PR, run:
+
+```bash
+gh pr view <N> --json title,body,additions,deletions,files,commits,headRefName,baseRefName
+gh pr diff <N>
+```
+
+Read every changed file in full. Do NOT review from the diff alone.
+
+## STEP 2: Find Issues
+
+Check the diff against these 6 areas. For EACH issue found, classify as P0/P1/P2.
+
+| Area | What to Check |
+|------|---------------|
+| **WebKit Protocol** | Correct domain usage (Page for cookies, not Network), `Page.snapshotRect` not `captureScreenshot`, `Runtime.awaitPromise` separate from `evaluate`, `emulateUserGesture: true` on interaction evals |
+| **iOS Safari Compatibility** | `document.createTouch()` not `new Touch()`, `document.createTouchList()` for TouchEvent, no hover-dependent interactions, font-size >= 16px for inputs |
+| **Simulator** | `simctl` commands exist and are correct, no `simctl snapshot save/restore` (doesn't exist), ports per-device (not hardcoded 9222), `simctl status_bar override` for deterministic screenshots |
+| **MCP Protocol** | No `console.log()` in src/ (breaks stdio), `tools/list` response valid, `serverInfo.version` matches package.json, no `oneOf`/`anyOf` in inputSchema properties |
+| **Architecture** | No puppeteer/CDP/Chrome dependencies, `BrowserBackend` interface respected, typed (no `any`), dead code removed |
+| **Reliability** | Error handling (no swallowed promises), resource cleanup (simulators shutdown), timeout enforcement, crash recovery paths tested |
+
+## STEP 3: Classify Each Issue
+
+| Priority | Definition | Merge Gate |
+|----------|-----------|------------|
+| **P0** | **Blocker** — security hole, MCP protocol corruption, wrong WebKit Protocol method, Chrome/puppeteer dependency leaked, silent auth bypass | **Must fix before merge** |
+| **P1** | **Must fix** — simulator crash not handled, resource leak, wrong simctl command, missing error handling, iOS Safari API incompatibility | **Should fix in this PR** |
+| **P2** | **Improve** — code style, docs, minor perf, unlikely edge cases | **Can be follow-up** |
+
+Confidence threshold: only report findings with confidence >= 60/100.
+
+## STEP 4: Write Review
+
+Use this exact format:
+
+```
+## PR #<N>: <title>
+
+### P0 — Blockers (must fix before merge)
+- [ ] **[P0]** Description — `file:line` (Confidence: XX/100)
+  - Impact: ...
+  - Fix: ...
+
+### P1 — Must Fix (should fix in this PR)
+- [ ] **[P1]** Description — `file:line` (Confidence: XX/100)
+  - Fix: ...
+
+### P2 — Improve (can be follow-up)
+- [ ] **[P2]** Description — `file:line`
+  - Suggestion: ...
+
+### Summary
+| Priority | Count |
+|----------|-------|
+| P0 | X |
+| P1 | X |
+| P2 | X |
+
+### Verdict
+- P0 = 0, P1 = 0 → APPROVE
+- P0 = 0, P1 > 0 → REQUEST_CHANGES (fixable)
+- P0 > 0 → BLOCK
+
+### Merge Notes
+- Conflict files with other PRs (if any)
+- Recommended merge order (if multiple PRs)
+```
+
+## STEP 5: Post to GitHub — MANDATORY
+
+Do NOT skip this step. Post the review on EVERY reviewed PR.
+
+**Language Rule**: ALL review comments MUST be written in English.
+
+```bash
+# P0 > 0:
+gh pr review <N> --request-changes --body "<Step 4 output>"
+
+# P0 = 0, P1 > 0:
+gh pr review <N> --request-changes --body "<Step 4 output>"
+
+# P0 = 0, P1 = 0:
+gh pr review <N> --approve --body "<Step 4 output>"
+```
+
+Note: self-PRs cannot be approved via API. Use `--comment` instead of `--approve` for own PRs.
+
+---
+
+## OpenSafari Domain Knowledge
+
+Key files:
+- `src/webkit/client.ts` — WebKitClient: WebKit Remote Debugging Protocol connection, message correlation, heartbeat, reconnection
+- `src/simulator/manager.ts` — SimulatorManager: xcrun simctl wrapper (boot, shutdown, screenshot, appearance, rotation)
+- `src/simulator/pool.ts` — SimulatorPool: multi-device management, idle shutdown, resource monitoring
+- `src/simulator/batch.ts` — BatchExecutor: parallel operations across all simulators
+- `src/session-manager.ts` — Session/worker/connection tracking
+- `src/mcp-server.ts` — MCP tool registration and JSON-RPC handling
+- `src/orchestration/workflow-engine.ts` — Multi-device QA workflow orchestration
+- `src/qa/detectors/*.ts` — 13 iOS QA detectors (auto-zoom, touch targets, safe area, etc.)
+- `src/qa/audit.ts` — QAAudit: runs all detectors, calculates score
+- `src/auth/manager.ts` — AuthManager: cookie export/import for login persistence
+- `src/types/browser-backend.ts` — BrowserBackend interface (26 methods)
+- `src/comparison/cross-viewport.ts` — Cross-viewport capture and comparison
+
+Common P0/P1 patterns specific to OpenSafari:
+1. `Network.setCookie` instead of `Page.setCookie` — wrong WebKit domain (P0)
+2. `Page.captureScreenshot` instead of `Page.snapshotRect` — Chrome CDP method, not WebKit (P0)
+3. `new Touch()` instead of `document.createTouch()` — not supported in iOS Safari (P0)
+4. `simctl snapshot save/restore` — does not exist in any Xcode version (P0)
+5. `console.log()` in src/ — MCP stdio protocol corruption (P0)
+6. Missing `emulateUserGesture: true` on `Runtime.evaluate` for interactions (P1)
+7. `awaitPromise` as parameter to `Runtime.evaluate` — must be separate `Runtime.awaitPromise` command (P1)
+8. Hardcoded port 9222 for multi-simulator — ios-webkit-debug-proxy assigns per-device ports (P1)
+9. `result.data` instead of `result.dataURL` for screenshot — WebKit returns dataURL format (P1)
+10. `result.exceptionDetails` instead of `result.wasThrown` — Chrome CDP field, not WebKit (P1)

--- a/.claude/commands/release-os.md
+++ b/.claude/commands/release-os.md
@@ -1,0 +1,226 @@
+---
+name: release-os
+description: OpenSafari release workflow — triage, review, fix own PRs, merge, and optionally publish
+---
+
+# OpenSafari Release Workflow
+
+$ARGUMENTS
+
+---
+
+## STEP 1: Status Check
+
+Run all of these and report results:
+
+```bash
+git status
+git stash list
+git branch -a
+gh pr list --state open --json number,title,headRefName,baseRefName,additions,deletions,author,files
+npm run build
+npm run lint
+npm test
+```
+
+**Gate**: If build, lint, or tests fail, fix errors first. Do NOT proceed with any failures.
+
+## STEP 2: Classify Open PRs
+
+For each open PR, determine ownership:
+
+| Type | How to Identify | Action |
+|------|----------------|--------|
+| **MY PR** | `author.login` matches repo owner | Review → Fix P0/P1 → Merge |
+| **OTHER's PR** | Different author | Review → Post comment → Do NOT merge |
+
+List all PRs in a table:
+
+```
+| PR # | Title | Author | Type | Files Changed |
+|------|-------|--------|------|---------------|
+```
+
+## STEP 3: Triage Local Changes
+
+Check for uncommitted local work:
+
+```bash
+git status
+git stash list
+git diff --stat
+```
+
+For each local change, classify:
+
+| Change Type | Action |
+|-------------|--------|
+| Source code (`.ts`) changes | Create PR by category (feat/fix/refactor/chore). **All PR titles, descriptions, and commit messages MUST be in English.** |
+| `.claude/` agents/commands | Validate YAML frontmatter, bundle into chore PR |
+| Temp/experiment files | Delete if not needed |
+| Stashed changes | Pop, resolve conflicts, commit or drop |
+
+**Gate**: All local changes committed or discarded. `git status` shows clean working tree.
+
+## STEP 4: Review Each PR
+
+For EACH open PR (both mine and others'), in order:
+
+### 4a. Run `/pr-review-os <N>`
+
+This produces a P0/P1/P2 issue list and verdict.
+
+### 4b. Take action based on ownership + verdict
+
+**MY PR with P0s**:
+1. `git checkout <branch>`
+2. Fix ALL P0 issues
+3. `npm run build` — must pass
+4. Commit and push fixes
+5. Re-run `/pr-review-os <N>` — must have P0 = 0
+6. If P1s remain, fix those too
+7. Repeat until P0 = 0 and P1 = 0
+
+**MY PR, P0 = 0 and P1 = 0**:
+1. Post review to GitHub (use `--comment` for self-PRs)
+
+**OTHER's PR with P0 or P1**:
+1. Post review to GitHub: `gh pr review <N> --request-changes --body "<review>"`
+2. Do NOT fix their code. Do NOT merge. Leave for the author.
+
+**OTHER's PR, clean**:
+1. Post review to GitHub: `gh pr review <N> --approve --body "<review>"`
+2. Still do NOT merge unless user explicitly says to.
+
+**Gate**: Every PR has a posted GitHub review comment before proceeding.
+
+## STEP 5: Pre-merge Checks
+
+Before merging ANY PR, verify ALL of these:
+
+```bash
+npm ci                                                 # must pass (lockfile in sync)
+npm run build                                          # must pass
+npm run lint                                           # must pass (no errors)
+npm test                                               # must pass (ALL test suites green)
+git diff --name-only HEAD | wc -l                      # must be 0 (clean tree)
+```
+
+Also grep for known anti-patterns:
+
+```bash
+# Protocol safety
+grep -r "console\.log(" src/ --include="*.ts"          # must be 0 — MCP stdio breaks
+grep -r "puppeteer\|CDPClient\|CDPSession" src/ --include="*.ts" | grep -v "//"  # must be 0 — no Chrome deps
+grep -r "Network\.setCookie\|Network\.getAllCookies\|Network\.clearBrowserCookies" src/ --include="*.ts"  # must be 0 — use Page domain
+grep -r "captureScreenshot" src/ --include="*.ts"      # must be 0 — use Page.snapshotRect
+grep -r "new Touch(" src/ --include="*.ts"             # must be 0 — use document.createTouch
+grep -r "simctl snapshot save\|simctl snapshot restore" src/ --include="*.ts"  # must be 0 — does not exist
+```
+
+### MCP Protocol Conformance
+
+Verify the MCP server produces spec-compliant responses:
+
+```bash
+# 1. Initialize response must contain ONLY: protocolVersion, capabilities, serverInfo
+INIT_RESPONSE=$(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"conformance-test","version":"1.0.0"}}}' | timeout 10 node dist/cli/index.js serve 2>/dev/null | head -1)
+INIT_KEYS=$(echo "$INIT_RESPONSE" | jq -r '.result | keys | sort | join(",")')
+echo "Initialize result keys: $INIT_KEYS"
+
+# 2. serverInfo.version matches package.json version
+SERVER_VERSION=$(echo "$INIT_RESPONSE" | jq -r '.result.serverInfo.version')
+PACKAGE_VERSION=$(node -p "require('./package.json').version")
+echo "Server version: $SERVER_VERSION, Package version: $PACKAGE_VERSION"
+```
+
+**Gate**: All checks must pass. If any fail, fix before merging.
+
+## STEP 6: Merge (MY PRs only)
+
+For each MY PR:
+
+```bash
+gh pr merge <N> --merge --delete-branch
+git checkout main && git pull origin main
+npm run build                                          # verify after each merge
+npm test                                               # verify tests pass after each merge
+```
+
+Do NOT merge OTHER's PRs unless the user explicitly says to.
+
+## STEP 7: Cleanup
+
+```bash
+git branch --merged main | grep -v 'main' | xargs -r git branch -d
+git branch -a
+gh pr list --state open
+npm run build
+git log --oneline -10
+```
+
+## STEP 8: Publish (only if user requests)
+
+### 8a. Verify CI passes on main
+
+**CRITICAL**: Do NOT publish until CI is green on main.
+
+```bash
+gh run list --branch main --limit 1 --json status,conclusion,databaseId
+```
+
+**Gate**: CI must pass. Do NOT proceed if any job failed.
+
+### 8b. Publish to npm
+
+```bash
+npm version patch   # or minor/major per user request
+git push origin main --tags
+gh release create v$(node -p "require('./package.json').version") --generate-notes
+npm publish
+```
+
+Skip this step entirely unless the user explicitly asks for a version bump or publish.
+
+### 8c. Post-publish: Local Environment Sync
+
+```bash
+# 1. Kill ALL opensafari processes
+pkill -f "opensafari-mcp" || true
+pkill -f "_npx.*opensafari" || true
+sleep 1
+
+# 2. Clear npx cache
+rm -rf ~/.npm/_npx/*/node_modules/opensafari-mcp
+rm -rf ~/.npm/_npx/*/package-lock.json
+
+# 3. Update global npm package
+npm install -g opensafari-mcp@latest
+
+# 4. Verify version consistency
+echo "src:    $(node -p \"require('./package.json').version\")" && \
+echo "dist:   $(node dist/cli/index.js --version 2>/dev/null)" && \
+echo "global: $(npm ls -g opensafari-mcp 2>/dev/null | grep opensafari)" && \
+echo "npm:    $(npm view opensafari-mcp version)"
+```
+
+**Gate**: All versions must match. After verification, restart Claude Code.
+
+---
+
+## Completion Checklist
+
+- [ ] Every open PR has a GitHub review comment posted
+- [ ] All MY PRs: P0 = 0, P1 = 0, merged
+- [ ] All OTHER's PRs: reviewed and commented (NOT merged)
+- [ ] Anti-pattern grep: no console.log, no Chrome/CDP deps, no wrong WebKit methods
+- [ ] MCP Protocol: `initialize` response spec-compliant
+- [ ] MCP Protocol: `serverInfo.version` matches `package.json`
+- [ ] `npm run build` passes on main
+- [ ] `npm test` passes — ALL suites green
+- [ ] `npm run lint` passes — no errors
+- [ ] No unnecessary branches remain
+- [ ] Working tree is clean
+- [ ] (If published) CI green on main before publish
+- [ ] (If published) Global npm package matches published version
+- [ ] (If published) npx cache cleared

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test:ci
+      - run: npm run build
+      - name: Verify dist
+        run: |
+          test -f dist/index.js
+          test -f dist/cli/index.js
+          node dist/cli/index.js --help
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Initial release of OpenSafari MCP server
+- 41+ MCP tools for iOS Safari automation
+- SimulatorManager: boot, shutdown, screenshot, appearance, rotation
+- WebKitClient: navigate, evaluate, screenshot via WebKit Remote Debugging Protocol
+- 13 iOS QA detectors: auto-zoom, touch targets, safe area, keyboard overlap, etc.
+- qa_full_audit with scoring and regression detection
+- Multi-simulator parallel testing with batch operations
+- Cross-viewport visual comparison with Claude Vision format
+- Login persistence via cookie export/import
+- CLI: serve, auth, doctor, devices commands
+- Self-healing: crash recovery, resource monitoring, graceful shutdown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# Claude Code Project Instructions
+
+## Branch Strategy
+
+```
+feature/* → develop → main (release)
+```
+
+- All PRs target `develop` branch
+- Release merges go from `develop` into `main`
+- Tag-based npm publish triggers on `main` (v* tags)
+
+## Build & Test
+
+```bash
+npm install && npm run build && npm test
+```
+
+## Code Quality
+
+- All source code, comments, commit messages, and PR descriptions must be in English
+- Use `console.error()` for logging — `console.log()` writes to stdout which carries MCP JSON-RPC and will corrupt the protocol
+- No `puppeteer-core`, `CDP`, or Chrome dependencies — this project uses WebKit Remote Debugging Protocol
+- Use `Page.getCookies` / `Page.setCookie` / `Page.deleteCookie` (NOT Network domain)
+- Use `Page.snapshotRect` for screenshots (NOT `Page.captureScreenshot`)
+- Use `document.createTouch()` / `document.createTouchList()` (NOT `new Touch()`)
+- Use `Runtime.awaitPromise` as separate command (NOT as parameter to `Runtime.evaluate`)
+- `simctl snapshot save/restore` does NOT exist — use `simctl clone` or WebKit cookie export
+
+## Slash Commands
+
+- `/release-os` — Full release workflow (triage → review → merge → publish)
+- `/pr-review-os` — PR code review with P0/P1/P2 classification
+
+## Key Architecture
+
+```
+OpenSafari = WebKitClient → WebKit Remote Debugging Protocol → Real Safari in Xcode Simulator
+```
+
+No playwright. No middleware. Direct protocol connection via ios-webkit-debug-proxy.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,79 @@
+# OpenSafari API Reference
+
+## MCP Tools
+
+### Core Tools (Tier 1)
+
+#### navigate
+Navigate to a URL in real Safari on iOS Simulator.
+- **Input:** `{ url: string, waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' }`
+- **Output:** `{ url, status, loadTime }`
+
+#### screenshot
+Capture real Safari screen via WebKit Protocol.
+- **Input:** `{ format?: 'png', fullPage?: boolean }`
+- **Output:** Base64 encoded image
+
+#### javascript
+Execute JavaScript in page context via Runtime.evaluate.
+- **Input:** `{ expression: string }`
+- **Output:** Evaluation result
+
+#### read_page
+Extract visible text content from the page.
+- **Input:** `{}`
+- **Output:** Page text
+
+#### click
+Tap element by CSS selector or coordinates.
+- **Input:** `{ selector?: string, x?: number, y?: number }`
+
+#### type
+Type text into input field.
+- **Input:** `{ selector: string, text: string, delay?: number }`
+
+#### scroll
+Scroll page in direction.
+- **Input:** `{ direction: 'up'|'down'|'left'|'right', amount: number }`
+
+#### query_dom
+Query DOM element with details.
+- **Input:** `{ selector: string }`
+- **Output:** `{ tag, text, attributes, boundingBox, computedStyles, isVisible }`
+
+#### cookies
+Get/set/clear Safari cookies (WebKit Page domain).
+- **Input:** `{ action: 'get'|'set'|'clear', cookies?: Cookie[], domain?: string }`
+
+#### device_boot
+Boot a simulator device.
+- **Input:** `{ device: string }` (preset key like 'iphone-16')
+
+#### device_shutdown
+Shutdown a simulator.
+- **Input:** `{ deviceId?: string }`
+
+### Advanced Tools (Tier 2)
+
+inspect, wait_for, long_press, swipe, press, dismiss_keyboard, select_option, device_list, device_rotate, appearance_toggle
+
+### Batch & Orchestration (Tier 3)
+
+batch_navigate, batch_screenshot, batch_execute, cross_viewport_compare, workflow_init, workflow_status, workflow_collect, workflow_collect_partial, workflow_cleanup, worker_update, worker_complete
+
+### QA Detectors (Tier 3)
+
+qa_auto_zoom, qa_touch_targets, qa_hover_only, qa_input_type, qa_safe_area, qa_keyboard_overlap, qa_horizontal_overflow, qa_100vh, qa_fixed_stacking, qa_scroll_lock, qa_dark_mode, qa_orientation, qa_pwa_meta, qa_full_audit
+
+## Claude Code Configuration
+
+```json
+{
+  "mcpServers": {
+    "opensafari": {
+      "command": "opensafari",
+      "args": ["serve"]
+    }
+  }
+}
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,89 @@
+# Getting Started with OpenSafari
+
+## Prerequisites
+
+- **macOS** (Xcode Simulator is macOS only)
+- **Xcode** with iOS Simulator runtime
+- **Node.js** >= 18
+- **ios-webkit-debug-proxy**: `brew install ios-webkit-debug-proxy`
+
+## Installation
+
+```bash
+npm install -g opensafari-mcp
+```
+
+## Verify Installation
+
+```bash
+opensafari doctor
+```
+
+Expected output:
+```
+OpenSafari Doctor
+
+  ✓ macOS
+  ✓ Xcode (v16.0)
+  ✓ Simulator
+  ✓ iOS Runtimes (iOS 18.0)
+  ✓ Node.js >= 18 (v22.0.0)
+```
+
+## Quick Start
+
+### 1. Start the MCP server
+
+```bash
+opensafari serve
+```
+
+### 2. Connect from Claude Code
+
+Add to `~/.claude.json`:
+```json
+{
+  "mcpServers": {
+    "opensafari": {
+      "command": "opensafari",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+### 3. Use in Claude Code
+
+```
+You: Check example.com for mobile issues on iPhone SE
+
+Claude: [Uses navigate, screenshot, qa_full_audit tools]
+        Found 3 issues: auto-zoom on search input, touch target too small...
+```
+
+## Available Device Presets
+
+```bash
+opensafari devices
+```
+
+| Preset | Device | Viewport |
+|--------|--------|----------|
+| iphone-se | iPhone SE (3rd gen) | 375x667 |
+| iphone-16 | iPhone 16 | 393x852 |
+| iphone-16-pro-max | iPhone 16 Pro Max | 440x956 |
+| ipad | iPad (10th gen) | 820x1180 |
+| ipad-pro | iPad Pro 13-inch | 1032x1376 |
+
+## Login Persistence
+
+```bash
+# Save auth after logging in
+opensafari auth save mysite.com
+
+# List saved profiles
+opensafari auth list
+
+# Delete a profile
+opensafari auth delete mysite.com
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,16 @@
+# Troubleshooting
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `opensafari doctor` shows ✗ Xcode | Xcode not installed | Install from App Store |
+| No iOS runtimes | Simulator runtime missing | `xcodebuild -downloadPlatform iOS` |
+| WebKit connection failed | ios-webkit-debug-proxy not running | `brew install ios-webkit-debug-proxy && ios_webkit_debug_proxy` |
+| Simulator won't boot | Device not available | Run `opensafari devices` to see available presets |
+| Auth expired | Cookies expired | Re-run `opensafari auth save <site>` |
+| Screenshot timeout | Page too heavy | Increase timeout or simplify page |
+| Memory warning | Too many simulators | Reduce `--devices` count |
+| Port conflict | Another process on 9222 | Use `--webkit-debug-port` flag |
+| Rotation failed | Simulator.app not open | Rotation requires GUI; use WebKit viewport fallback |
+| Dark mode toggle failed | Device not booted | Boot device first with `device_boot` |


### PR DESCRIPTION
## Summary
npm package publishing, documentation, and release automation.

## Stories: #63 (npm/CI), #65 (Docs/E2E)

## Changes
- `.github/workflows/publish.yml`: Tag-triggered npm publish
- `docs/`: API reference, getting started, troubleshooting
- `CHANGELOG.md`, `CLAUDE.md`
- `.claude/commands/`: release-os, pr-review-os

## Post-Deployment Success Criteria
- [ ] `npm install -g opensafari-mcp` works after publish
- [ ] All 41+ tools documented
- [ ] `/release-os` automates full release workflow
- [ ] `/pr-review-os` catches WebKit-specific issues

Resolves #63 #65
🤖 Generated with [Claude Code](https://claude.com/claude-code)