### PR TITLE
Epic 2C: Cross-Viewport Visual Comparison

### DIFF
--- a/src/comparison/cross-viewport.ts
+++ b/src/comparison/cross-viewport.ts
@@ -1,0 +1,83 @@
+import { SimulatorPool } from '../simulator/pool';
+import { BatchExecutor, BatchResult } from '../simulator/batch';
+import { ScreenshotOptions } from '../types/browser-backend';
+
+export interface ViewportCapture {
+  device: string;
+  viewport: { w: number; h: number };
+  breakpoint: string;
+  screenshot: string;  // base64
+  metadata: PageMetadata | null;
+  error?: string;
+  timing: number;
+}
+
+export interface PageMetadata {
+  title: string;
+  scrollHeight: number;
+  scrollWidth: number;
+  innerWidth: number;
+  innerHeight: number;
+  devicePixelRatio: number;
+  hasHorizontalOverflow: boolean;
+}
+
+export interface CaptureOptions {
+  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle';
+  settleTime?: number;
+  format?: 'png';
+}
+
+export class CrossViewportCapture {
+  constructor(
+    private pool: SimulatorPool,
+    private batch: BatchExecutor,
+  ) {}
+
+  async capture(url: string, options?: CaptureOptions): Promise<ViewportCapture[]> {
+    // Navigate all devices
+    await this.batch.batchNavigate(url, options?.waitUntil ?? 'load');
+
+    // Wait for settle
+    if (options?.settleTime) {
+      await new Promise(r => setTimeout(r, options.settleTime));
+    }
+
+    // Capture screenshots
+    const screenshots = await this.batch.batchScreenshot({ format: options?.format ?? 'png' });
+
+    // Gather metadata
+    const metadata = await this.batch.batchExecute(`
+      (function() {
+        return {
+          title: document.title,
+          scrollHeight: document.documentElement.scrollHeight,
+          scrollWidth: document.documentElement.scrollWidth,
+          innerWidth: window.innerWidth,
+          innerHeight: window.innerHeight,
+          devicePixelRatio: window.devicePixelRatio,
+          hasHorizontalOverflow: document.documentElement.scrollWidth > window.innerWidth
+        };
+      })()
+    `);
+
+    // Combine
+    return screenshots.map((shot, i) => ({
+      device: shot.device,
+      viewport: shot.viewport,
+      breakpoint: this.mapBreakpoint(shot.viewport.w),
+      screenshot: shot.result ?? '',
+      metadata: (metadata[i]?.result as PageMetadata) ?? null,
+      error: shot.error ?? metadata[i]?.error,
+      timing: shot.timing,
+    }));
+  }
+
+  private mapBreakpoint(width: number): string {
+    if (width < 640) return 'sm';
+    if (width < 768) return 'sm';
+    if (width < 1024) return 'md';
+    if (width < 1280) return 'lg';
+    return 'xl';
+  }
+}

--- a/src/comparison/index.ts
+++ b/src/comparison/index.ts
@@ -1,0 +1,3 @@
+export { CrossViewportCapture } from './cross-viewport';
+export type { ViewportCapture, PageMetadata, CaptureOptions } from './cross-viewport';
+export { generateMarkdownReport, formatForClaudeVision } from './report';

--- a/src/comparison/report.ts
+++ b/src/comparison/report.ts
@@ -1,0 +1,75 @@
+import { ViewportCapture } from './cross-viewport';
+
+export function generateMarkdownReport(captures: ViewportCapture[], url: string): string {
+  const lines = [
+    '# Cross-Viewport Comparison Report',
+    '',
+    `**URL:** ${url}`,
+    `**Captured:** ${new Date().toISOString()}`,
+    `**Devices:** ${captures.length}`,
+    '',
+    '## Device Summary',
+    '',
+    '| Device | Viewport | Breakpoint | Overflow | Load Time |',
+    '|--------|----------|------------|----------|-----------|',
+  ];
+
+  for (const cap of captures) {
+    const overflow = cap.metadata?.hasHorizontalOverflow ? 'YES' : 'No';
+    lines.push(
+      `| ${cap.device} | ${cap.viewport.w}x${cap.viewport.h} | ${cap.breakpoint} | ${overflow} | ${cap.timing}ms |`
+    );
+  }
+
+  const issues = captures.filter(c => c.metadata?.hasHorizontalOverflow || c.error);
+  if (issues.length > 0) {
+    lines.push('', '## Issues Found', '');
+    for (const issue of issues) {
+      if (issue.error) lines.push(`- **${issue.device}**: ${issue.error}`);
+      if (issue.metadata?.hasHorizontalOverflow) {
+        lines.push(`- **${issue.device}**: Horizontal overflow (scrollWidth: ${issue.metadata.scrollWidth}px > viewport: ${issue.metadata.innerWidth}px)`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export interface MCPContent {
+  type: 'text' | 'image';
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+export function formatForClaudeVision(captures: ViewportCapture[]): MCPContent[] {
+  const content: MCPContent[] = [];
+
+  // Text summary
+  content.push({
+    type: 'text',
+    text: `Cross-viewport comparison of ${captures.length} devices. Analyze each screenshot for layout consistency, broken elements, overflow, and responsive issues.\n\n` +
+      captures.map(c => `- ${c.device}: ${c.viewport.w}x${c.viewport.h} (Tailwind: ${c.breakpoint})`).join('\n'),
+  });
+
+  // Each screenshot
+  for (const cap of captures) {
+    if (cap.error) {
+      content.push({ type: 'text', text: `[${cap.device} failed: ${cap.error}]` });
+      continue;
+    }
+
+    content.push({
+      type: 'text',
+      text: `--- ${cap.device} (${cap.viewport.w}x${cap.viewport.h}, ${cap.breakpoint}) ---`,
+    });
+
+    content.push({
+      type: 'image',
+      data: cap.screenshot,
+      mimeType: 'image/png',
+    });
+  }
+
+  return content;
+}

--- a/src/tools/cross-viewport-compare.ts
+++ b/src/tools/cross-viewport-compare.ts
@@ -1,0 +1,32 @@
+import { MCPServer } from '../mcp-server.js';
+import { formatForClaudeVision, MCPContent } from '../comparison/report.js';
+
+let capturer: any = null;
+export function setCrossViewportCapture(c: any): void { capturer = c; }
+
+export function registerCrossViewportCompareTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'cross_viewport_compare',
+      description: 'Capture the same page across all active simulators for visual comparison. Returns screenshots with device/viewport/breakpoint metadata.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          url: { type: 'string', description: 'URL to capture on all devices' },
+          waitUntil: { type: 'string', enum: ['load', 'domcontentloaded', 'networkidle'] },
+          settleTime: { type: 'number', description: 'Ms to wait after load for dynamic content' },
+        },
+        required: ['url'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      if (!capturer) return { content: [{ type: 'text' as const, text: 'Error: Cross-viewport capture not initialized' }], isError: true };
+      const captures = await capturer.capture(params.url as string, {
+        waitUntil: params.waitUntil as any,
+        settleTime: params.settleTime as number | undefined,
+      });
+      const content = formatForClaudeVision(captures);
+      return { content: content.map((c: MCPContent) => ({ type: (c.type ?? 'text') as 'text', text: c.text, ...(c.data ? { data: c.data, mimeType: c.mimeType } : {}) })) };
+    },
+  );
+}


### PR DESCRIPTION
CrossViewportCapture + Markdown report + Claude Vision format.\nResolves #55 #56 #57\n🤖 Generated with [Claude Code](https://claude.com/claude-code)