### PR TITLE
Fix moduleResolution Node16/webpack conflict and lint errors

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3,7 +3,7 @@
 import { Command } from 'commander';
 import { MCPServer, getWebKitClient } from '../src/mcp-server';
 import { registerAllTools } from '../src/tools';
-import { SimulatorManager, DEVICE_PRESETS, checkXcodeInstallation } from '../src/simulator';
+import { DEVICE_PRESETS, checkXcodeInstallation } from '../src/simulator';
 import { AuthManager } from '../src/auth';
 
 const program = new Command()

--- a/src/comparison/cross-viewport.ts
+++ b/src/comparison/cross-viewport.ts
@@ -1,6 +1,5 @@
 import { SimulatorPool } from '../simulator/pool';
-import { BatchExecutor, BatchResult } from '../simulator/batch';
-import { ScreenshotOptions } from '../types/browser-backend';
+import { BatchExecutor } from '../simulator/batch';
 
 export interface ViewportCapture {
   device: string;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -86,9 +86,9 @@ export class MCPServer {
   // Lifecycle
   // ------------------------------------------------------------------
 
-  start(options: MCPServerOptions = {}): void {
+  async start(options: MCPServerOptions = {}): Promise<void> {
     const mode: TransportMode = options.transport ?? 'stdio';
-    this.transport = createTransport(mode, { port: options.port });
+    this.transport = await createTransport(mode, { port: options.port });
 
     this.transport.onMessage((msg) => this.handleMessage(msg));
     this.transport.start();

--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { SimulatorPool, PooledSimulator } from '../simulator/pool';
+import { SimulatorPool } from '../simulator/pool';
 import { BatchExecutor } from '../simulator/batch';
 import { AuthManager } from '../auth/manager';
 import { DEVICE_PRESETS } from '../simulator/presets';

--- a/src/simulator/manager.ts
+++ b/src/simulator/manager.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { SimctlExecutor } from './simctl';
 import { SimulatorDevice, SimulatorRuntime } from './types';
 import { DEVICE_PRESETS } from './presets';
@@ -274,8 +276,6 @@ export class SimulatorManager {
 
     // Try AppleScript rotation via Simulator.app menu
     try {
-      const { execFile } = require('child_process');
-      const { promisify } = require('util');
       const execFileAsync = promisify(execFile);
       await execFileAsync('osascript', [
         '-e', 'tell application "Simulator" to activate',

--- a/src/simulator/pool.ts
+++ b/src/simulator/pool.ts
@@ -1,12 +1,11 @@
 import { EventEmitter } from 'events';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { SimulatorManager, DeviceNotBootedError } from './manager';
-import { SimulatorDevice, DevicePreset } from './types';
+import { SimulatorManager } from './manager';
+import { SimulatorDevice } from './types';
 import { DEVICE_PRESETS } from './presets';
-import { WebKitClient, WebKitClientOptions } from '../webkit/client';
-import { BrowserBackend } from '../types/browser-backend';
-import { AuthManager, AuthProfile } from '../auth/manager';
+import { WebKitClient } from '../webkit/client';
+import { AuthManager } from '../auth/manager';
 import * as os from 'os';
 import {
   DEFAULT_IDLE_CHECK_INTERVAL_MS,

--- a/src/simulator/xcode-check.ts
+++ b/src/simulator/xcode-check.ts
@@ -30,7 +30,7 @@ export async function checkXcodeInstallation(): Promise<XcodeCheckResult> {
 
   // Check xcrun
   try {
-    const { stdout } = await execFileAsync('xcrun', ['--version']);
+    await execFileAsync('xcrun', ['--version']);
     result.installed = true;
   } catch {
     result.issues.push('xcrun not found — Xcode or Command Line Tools not installed');

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -42,14 +42,12 @@ export interface TransportOptions {
 /**
  * Factory: create the appropriate transport based on mode.
  */
-export function createTransport(mode: TransportMode, options?: TransportOptions): MCPTransport {
+export async function createTransport(mode: TransportMode, options?: TransportOptions): Promise<MCPTransport> {
   if (mode === 'http') {
-    // Use require to avoid loading HTTP module when not needed
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { HTTPTransport } = require('./http');
+    // Use dynamic import to avoid loading HTTP module when not needed
+    const { HTTPTransport } = await import('./http');
     return new HTTPTransport(options?.port || 3100);
   }
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { StdioTransport } = require('./stdio');
+  const { StdioTransport } = await import('./stdio');
   return new StdioTransport();
 }

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -18,7 +18,7 @@ export class StdioTransport implements MCPTransport {
 
   send(response: MCPResponse): void {
     // stdout is the MCP JSON-RPC channel in stdio mode
-    console.log(JSON.stringify(response));
+    process.stdout.write(JSON.stringify(response) + '\n');
   }
 
   start(): void {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
## Summary
- Switch `moduleResolution` from `Node16` to `Bundler` in `tsconfig.json` to resolve conflict where tsc requires `.js` extensions but webpack cannot resolve them
- Fix all 15 ESLint errors across 9 files: remove unused imports, convert `require()` to ES imports, replace `console.log` with `process.stdout.write` in stdio transport
- All checks pass: `tsc --noEmit`, `npm run build`, `npm run test`, `npm run lint` (0 errors)

## Files Changed (10)
| File | Change |
|------|--------|
| `tsconfig.json` | `moduleResolution: Node16` → `Bundler`, `module: Node16` → `ES2022` |
| `src/tools/qa-audit.ts` | Revert `.js` extensions in dynamic imports |
| `cli/index.ts` | Remove unused `SimulatorManager` import |
| `src/comparison/cross-viewport.ts` | Remove unused `BatchResult`, `ScreenshotOptions` imports |
| `src/orchestration/workflow-engine.ts` | Remove unused `PooledSimulator` import |
| `src/simulator/pool.ts` | Remove 5 unused imports |
| `src/simulator/xcode-check.ts` | Remove unused `stdout` variable |
| `src/simulator/manager.ts` | Convert `require()` to top-level ES imports |
| `src/transports/index.ts` | Convert `require()` to dynamic `import()`, remove stale eslint-disable |
| `src/transports/stdio.ts` | `console.log` → `process.stdout.write` |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx tsc -p tsconfig.cli.json --noEmit` — 0 errors
- [x] `npm run build` — server + CLI compiled successfully
- [x] `npm run test` — 2 tests passed, 0 failures
- [x] `npm run lint` — 0 errors (19 warnings, all pre-existing `no-explicit-any`)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)