### PR TITLE
Fix: Update device presets for Xcode 26.4 (iPhone 17 series)

### DIFF
--- a/src/simulator/presets.ts
+++ b/src/simulator/presets.ts
@@ -1,11 +1,13 @@
 import { DevicePreset } from './types';
 
 export const DEVICE_PRESETS: Record<string, DevicePreset> = {
-  'iphone-se': { name: 'iPhone SE (3rd generation)', w: 375, h: 667, dpr: 2 },
-  'iphone-16': { name: 'iPhone 16', w: 393, h: 852, dpr: 3 },
-  'iphone-16-pro-max': { name: 'iPhone 16 Pro Max', w: 440, h: 956, dpr: 3 },
-  'ipad': { name: 'iPad (10th generation)', w: 820, h: 1180, dpr: 2 },
-  'ipad-pro': { name: 'iPad Pro 13-inch (M4)', w: 1032, h: 1376, dpr: 2 },
+  'iphone-17e': { name: 'iPhone 17e', w: 375, h: 812, dpr: 3 },
+  'iphone-17': { name: 'iPhone 17', w: 393, h: 852, dpr: 3 },
+  'iphone-air': { name: 'iPhone Air', w: 402, h: 874, dpr: 3 },
+  'iphone-17-pro': { name: 'iPhone 17 Pro', w: 402, h: 874, dpr: 3 },
+  'iphone-17-pro-max': { name: 'iPhone 17 Pro Max', w: 440, h: 956, dpr: 3 },
+  'ipad-air': { name: 'iPad Air 13-inch (M4)', w: 1032, h: 1376, dpr: 2 },
+  'ipad-pro': { name: 'iPad Pro 13-inch (M5)', w: 1032, h: 1376, dpr: 2 },
 };
 
 export function resolvePreset(key: string): DevicePreset {


### PR DESCRIPTION
## Summary
- Replace outdated iPhone SE/16 presets with iPhone 17 series
- Add iPhone Air preset (new device category)
- Update iPad presets to current models (M4/M5)
- All preset names verified against xcrun simctl device list

## Test plan
- [ ] All presets resolve to actual simulator devices
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] `npm run test` passes
- [ ] `npm run lint` passes (0 errors)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)