### PR TITLE
fix: proxy port conflict detection, env var support, and documentation

### DIFF
--- a/src/simulator/proxy.ts
+++ b/src/simulator/proxy.ts
@@ -153,9 +153,14 @@ export class WebInspectorProxy {
   private isPortInUse(port: number): Promise<boolean> {
     return new Promise(resolve => {
       const socket = net.connect({ port, host: '127.0.0.1' });
+      socket.setTimeout(2000);
       socket.once('connect', () => {
         socket.destroy();
         resolve(true);
+      });
+      socket.once('timeout', () => {
+        socket.destroy();
+        resolve(false);
       });
       socket.once('error', () => {
         socket.destroy();


### PR DESCRIPTION
## Summary
- Fix port conflict detection bug where a second `WebInspectorProxy` instance could start without error on an already-used port — now uses `net.connect()` (connect-test) instead of `net.createServer()` (bind-test) and also checks for running `ios_webkit_debug_proxy` processes via `pgrep`
- Add `OPENSAFARI_PROXY_PORT` environment variable support (resolution order: explicit option > env var > default 9322)
- Add JSDoc documenting default port (9322, chosen to avoid conflict with openchrome on 9222)

Closes partially #129 (Port Conflict Avoidance section)

## Test plan
- [ ] Start proxy, then attempt second instance on same port — should throw with helpful error message
- [ ] Set `OPENSAFARI_PROXY_PORT=9400` and verify proxy starts on port 9400
- [ ] `npm run build` succeeds
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>