### PR TITLE
fix: correct viewport dimensions for 4 device presets

### DIFF
--- a/src/simulator/presets.ts
+++ b/src/simulator/presets.ts
@@ -1,12 +1,12 @@
 import { DevicePreset } from './types';
 
 export const DEVICE_PRESETS: Record<string, DevicePreset> = {
-  'iphone-17e': { name: 'iPhone 17e', w: 375, h: 812, dpr: 3 },
-  'iphone-17': { name: 'iPhone 17', w: 393, h: 852, dpr: 3 },
-  'iphone-air': { name: 'iPhone Air', w: 402, h: 874, dpr: 3 },
+  'iphone-17e': { name: 'iPhone 17e', w: 390, h: 844, dpr: 3 },
+  'iphone-17': { name: 'iPhone 17', w: 402, h: 874, dpr: 3 },
+  'iphone-air': { name: 'iPhone Air', w: 420, h: 912, dpr: 3 },
   'iphone-17-pro': { name: 'iPhone 17 Pro', w: 402, h: 874, dpr: 3 },
   'iphone-17-pro-max': { name: 'iPhone 17 Pro Max', w: 440, h: 956, dpr: 3 },
-  'ipad-air': { name: 'iPad Air 13-inch (M4)', w: 1032, h: 1376, dpr: 2 },
+  'ipad-air': { name: 'iPad Air 13-inch (M4)', w: 1024, h: 1366, dpr: 2 },
   'ipad-pro': { name: 'iPad Pro 13-inch (M5)', w: 1032, h: 1376, dpr: 2 },
 };
 


### PR DESCRIPTION
## Summary

- Fixes incorrect viewport dimensions in 4 of 7 device presets in `src/simulator/presets.ts`
- Values were runtime-measured from actual Xcode 26.4 simulators via WebKit Inspector Protocol (`screen.width`, `screen.height`, `devicePixelRatio`)
- Incorrect dimensions affected screenshot clipping, Tailwind breakpoint mapping, and workflow viewport settings

## Changes

| Preset | Before | After (measured) |
|---|---|---|
| `iphone-17e` | 375×812@3x | **390×844@3x** |
| `iphone-17` | 393×852@3x | **402×874@3x** |
| `iphone-air` | 402×874@3x | **420×912@3x** |
| `ipad-air` | 1032×1376@2x | **1024×1366@2x** |

Three presets were already correct and unchanged: `iphone-17-pro`, `iphone-17-pro-max`, `ipad-pro`.

## Root Cause

Original values were estimates based on display specs (noted in #130). The estimates conflated physical pixel counts with CSS logical pixels or borrowed dimensions from similar older models.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (2/2)
- [x] `npm run lint` — 0 errors
- [x] `opensafari devices` shows corrected dimensions
- [x] No hardcoded old values remain in source (only in stale `.claude/worktrees/`)
- [x] `resolvePreset()` returns updated values for all 7 keys

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)