### PR TITLE
chore: add merge conflict resolution to release-os workflow

### DIFF
--- a/.claude/commands/release-os.md
+++ b/.claude/commands/release-os.md
@@ -197,8 +197,6 @@ git rebase "origin/$BASE_BRANCH"
 git push --force-with-lease origin <branch>
 
 # 5. Wait for CI to pass after rebase
-echo "Waiting for CI on rebased branch..."
-sleep 10
 gh pr checks <N> --watch --fail-fast
 
 # 6. Re-verify mergeable status
@@ -211,11 +209,13 @@ echo "PR #<N> after rebase: $MERGE_STATUS"
 ### 6c. Merge the PR
 
 ```bash
+# Resolve base branch BEFORE merge (gh pr view works; after merge the PR is closed)
+BASE_BRANCH=$(gh pr view <N> --json baseRefName --jq '.baseRefName')
+
 # Merge into the base branch (usually develop)
 gh pr merge <N> --merge --delete-branch
 
 # Sync the base branch locally after merge
-BASE_BRANCH=$(gh pr view <N> --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "develop")
 git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"
 
 # Verify build/tests pass on the updated base branch


### PR DESCRIPTION
## Summary
- Add STEP 6 merge conflict detection and rebase-based resolution logic
- Determine optimal merge order (MERGEABLE first, smaller PRs first)
- After each merge, sync base branch and re-check remaining PRs
- Improve STEP 7 branch cleanup to verify no open PR before deleting remote branches
- Add mergeable status column to STEP 2 PR classification table
- Expand completion checklist with conflict resolution verification items

## Test plan
- [ ] Run `/release-os` with a conflicting PR to verify rebase flow works
- [ ] Verify multi-PR merge ordering handles cascading conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)