### PR TITLE
fix: replace system-wide pgrep with port-specific proxy reuse

### DIFF
--- a/src/simulator/proxy.ts
+++ b/src/simulator/proxy.ts
@@ -35,6 +35,7 @@ export class WebInspectorProxy {
   private _port: number;
   private _deviceListPort: number;
   private _running = false;
+  private _reusing = false;
 
   constructor(private options: ProxyOptions = {}) {
     const envPort = process.env.OPENSAFARI_PROXY_PORT
@@ -65,12 +66,20 @@ export class WebInspectorProxy {
   async start(): Promise<void> {
     if (this._running) return;
 
-    const existingProxy = await this.isProxyAlreadyRunning();
-    if (existingProxy) {
+    // Check if our device-list port already has a healthy proxy (from another session)
+    const deviceListInUse = await this.isPortInUse(this._deviceListPort);
+    if (deviceListInUse) {
+      const healthy = await this.isProxyHealthy();
+      if (healthy) {
+        console.error(`[WebInspectorProxy] Reusing existing proxy on port ${this._deviceListPort}`);
+        this._running = true;
+        this._reusing = true;
+        return;
+      }
       throw new Error(
-        `Another ios_webkit_debug_proxy process is already running. ` +
-        `Stop it first (pkill ios_webkit_debug_proxy) or use a different port ` +
-        `(e.g. port ${this._port + 100}) via the OPENSAFARI_PROXY_PORT env var.`
+        `Port ${this._deviceListPort} already in use by a non-proxy process. ` +
+        `Use a different port (e.g. OPENSAFARI_PROXY_PORT=${this._port + 100}) ` +
+        `or stop the existing process.`
       );
     }
 
@@ -78,7 +87,7 @@ export class WebInspectorProxy {
     if (portInUse) {
       throw new Error(
         `Port ${this._port} already in use. ` +
-        `Use a different port (e.g. port ${this._port + 100}) via the OPENSAFARI_PROXY_PORT env var ` +
+        `Use a different port (e.g. OPENSAFARI_PROXY_PORT=${this._port + 100}) ` +
         `or stop the existing process.`
       );
     }
@@ -107,6 +116,7 @@ export class WebInspectorProxy {
     });
 
     this._running = true;
+    this._reusing = false;
 
     this.process.stderr?.on('data', (data: Buffer) => {
       console.error(`[WebInspectorProxy] ${data.toString().trim()}`);
@@ -129,6 +139,11 @@ export class WebInspectorProxy {
 
   /** Stop the proxy process gracefully with SIGKILL fallback. */
   async stop(): Promise<void> {
+    if (this._reusing) {
+      this._running = false;
+      this._reusing = false;
+      return;
+    }
     if (!this.process) {
       this._running = false;
       return;
@@ -171,6 +186,11 @@ export class WebInspectorProxy {
     return this.process?.pid ?? null;
   }
 
+  /** Whether this instance is reusing another session's proxy. */
+  get reusing(): boolean {
+    return this._reusing;
+  }
+
   private async waitForReady(timeout = 5000): Promise<void> {
     const start = Date.now();
     while (Date.now() - start < timeout) {
@@ -202,10 +222,10 @@ export class WebInspectorProxy {
     });
   }
 
-  private async isProxyAlreadyRunning(): Promise<boolean> {
+  private async isProxyHealthy(): Promise<boolean> {
     try {
-      await execFileAsync('pgrep', ['-x', 'ios_webkit_debug_proxy']);
-      return true;
+      const body = await this.httpGet(`http://localhost:${this._deviceListPort}`);
+      return body.includes('iOS Devices');
     } catch {
       return false;
     }
@@ -238,9 +258,9 @@ export function getSharedProxy(): WebInspectorProxy {
   return _sharedProxy;
 }
 
-// Ensure the proxy is stopped when the host process exits
+// Ensure the proxy is stopped when the host process exits — only if we own it
 process.on('exit', () => {
-  if (_sharedProxy?.running) {
+  if (_sharedProxy?.running && !_sharedProxy.reusing) {
     // In 'exit' handler only synchronous code runs; send SIGTERM best-effort
     try { _sharedProxy['process']?.kill('SIGTERM'); } catch { /* ignore */ }
   }


### PR DESCRIPTION
## Summary

- Replace `isProxyAlreadyRunning()` (system-wide `pgrep -x`) with port-specific `isProxyHealthy()` check
- Add detect-and-reuse pattern: if device-list port has a healthy proxy, reuse it instead of throwing
- Add `_reusing` flag to track proxy ownership — only self-owned proxies are killed on stop/exit
- Unblocks parallel Claude Code sessions sharing the same simulator

## Problem

`proxy.ts:205-211` used `pgrep -x ios_webkit_debug_proxy` which detected ANY running proxy system-wide. Even with `OPENSAFARI_PROXY_PORT=9500`, `start()` threw if another session's proxy existed on a different port. This made opensafari single-session only.

## Changes

| File | Change |
|------|--------|
| `src/simulator/proxy.ts` | Replace `isProxyAlreadyRunning()` with `isProxyHealthy()` (HTTP health check on device-list port) |
| `src/simulator/proxy.ts` | Add `_reusing` flag + `reusing` getter for ownership tracking |
| `src/simulator/proxy.ts` | `stop()` skips kill when reusing another session's proxy |
| `src/simulator/proxy.ts` | `process.on('exit')` handler only kills self-owned proxies |

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (2/2)
- [x] `npm run lint` passes (0 errors, 19 warnings — same as baseline)
- [x] Runtime: proxy starts on port 9322 without being blocked by other proxy on 9221
- [x] Runtime: second instance reuses proxy (`reusing=true`), does not spawn a new process
- [x] Runtime: reused proxy `stop()` does NOT kill the process; owner `stop()` does
- [ ] Integration: two Claude Code sessions can run opensafari tools simultaneously

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)