### PR TITLE
fix: add proxy cleanup to device_shutdown tool

### DIFF
--- a/src/tools/device-shutdown.ts
+++ b/src/tools/device-shutdown.ts
@@ -1,5 +1,6 @@
-import { MCPServer } from '../mcp-server';
+import { MCPServer, setWebKitClient } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
+import { getSharedProxy } from '../simulator/proxy';
 
 export function registerDeviceShutdownTool(server: MCPServer): void {
   server.registerTool(
@@ -21,8 +22,29 @@ export function registerDeviceShutdownTool(server: MCPServer): void {
       if (!deviceId) {
         return { content: [{ type: 'text' as const, text: 'Error: no booted device found' }], isError: true };
       }
+
+      // Stop the WebInspector proxy if we own it
+      const proxy = getSharedProxy();
+      let proxyStopped = false;
+      if (proxy.running) {
+        try {
+          await proxy.stop();
+          proxyStopped = true;
+        } catch (err) {
+          console.error(`[device_shutdown] Failed to stop proxy: ${err}`);
+        }
+      }
+
+      // Clear the WebKit client reference
+      setWebKitClient(null);
+
       await manager.shutdown(deviceId);
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ shutdown: true, deviceId }) }] };
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({ shutdown: true, deviceId, proxyStopped }),
+        }],
+      };
     },
   );
 }


### PR DESCRIPTION
## Summary

- Add WebInspector proxy cleanup to `device_shutdown` tool
- Clear WebKit client reference on shutdown to prevent stale connections
- Report `proxyStopped` status in shutdown response

## Problem

`device_shutdown` only stopped the simulator, leaving `ios_webkit_debug_proxy` orphaned. Repeated boot/shutdown cycles caused orphan proxy processes to accumulate.

## Changes

| File | Change |
|------|--------|
| `src/tools/device-shutdown.ts` | Import `getSharedProxy` and `setWebKitClient` |
| `src/tools/device-shutdown.ts` | Call `proxy.stop()` before simulator shutdown |
| `src/tools/device-shutdown.ts` | Clear WebKit client via `setWebKitClient(null)` |
| `src/tools/device-shutdown.ts` | Include `proxyStopped` in response JSON |

## Dependency

Works independently, but when combined with #149 (proxy reuse), `stop()` will correctly skip kill for reused proxies.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (2/2)
- [x] `npm run lint` passes (0 errors, 19 warnings — baseline)
- [ ] `device_shutdown` stops proxy process (no orphan after shutdown)
- [ ] `device_boot` → `device_shutdown` cycle 3x produces zero orphan proxies
- [ ] Response includes `proxyStopped: true` when proxy was running

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)