### PR TITLE
docs: document proxy ports, env var, and multi-session usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,40 @@ opensafari doctor
 - **macOS** (Xcode Simulator is macOS only)
 - **Xcode** with iOS Simulator runtime installed
 - **Node.js** >= 18
+- **ios-webkit-debug-proxy** — `brew install ios-webkit-debug-proxy`
+
+---
+
+## WebInspector Proxy Configuration
+
+OpenSafari uses `ios_webkit_debug_proxy` to bridge WebKit Remote Debugging from Xcode Simulator. The proxy is **auto-started** by the `device_boot` tool — no manual setup is needed in most cases.
+
+### Default Ports
+
+| Port | Purpose |
+|------|---------|
+| **9321** | Device list (HTML) — serves the proxy's device listing page |
+| **9322** | Device connection (JSON) — WebKit debugging targets for connected simulators |
+
+Port 9322 is deliberately offset from Chrome DevTools (9222) so OpenSafari and [OpenChrome](https://github.com/shaun0927/openchrome) can run simultaneously.
+
+### Custom Port
+
+Set the `OPENSAFARI_PROXY_PORT` environment variable to use a different device port:
+
+```bash
+# Use port 9500 instead of the default 9322
+OPENSAFARI_PROXY_PORT=9500 opensafari serve
+```
+
+Port resolution order:
+1. Explicit `port` option (programmatic use)
+2. `OPENSAFARI_PROXY_PORT` environment variable
+3. Default: **9322**
+
+### Multi-Session Usage
+
+Multiple Claude Code sessions can share the same proxy. When a session detects a healthy proxy already running on its target port, it reuses it instead of starting a new one. When the owning session exits, only its own proxy is terminated — other sessions' proxies remain unaffected.
 
 ---
 


### PR DESCRIPTION
## Summary

- Document default proxy ports (9321 device list, 9322 device connection)
- Document `OPENSAFARI_PROXY_PORT` env var with example and resolution order
- Document multi-session proxy reuse behavior
- Add `ios-webkit-debug-proxy` to Requirements section

## Problem

Default port 9322 and `OPENSAFARI_PROXY_PORT` env var were only documented in code JSDoc comments (`proxy.ts:11-16, 25-31`). Users had no way to discover port configuration or multi-session behavior without reading source code.

## Changes

| File | Change |
|------|--------|
| `README.md` | Add "WebInspector Proxy Configuration" section with ports, env var, multi-session docs |
| `README.md` | Add `ios-webkit-debug-proxy` to Requirements list |

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (2/2)
- [x] README renders correctly in markdown preview

Refs #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)