### PR TITLE
fix: align default WebKit debug port to 9322 to match proxy config

### DIFF
--- a/src/config/global.ts
+++ b/src/config/global.ts
@@ -37,7 +37,7 @@ const defaultConfig: OpenSafariConfig = {
   maxSimulators: 3,
   bootTimeout: 15000,
   idleShutdownTimeout: 300000,
-  webkitDebugPort: 9222,
+  webkitDebugPort: 9322,
   navigationTimeout: 30000,
   screenshotTimeout: 10000,
   evaluateTimeout: 15000,

--- a/src/simulator/pool.ts
+++ b/src/simulator/pool.ts
@@ -50,7 +50,7 @@ export class SimulatorPool extends EventEmitter {
     this.manager = new SimulatorManager();
     this.maxSimulators = options?.max ?? 5;
     this.concurrencyLimit = options?.concurrency ?? 3;
-    this.webkitBasePort = options?.webkitBasePort ?? 9222;
+    this.webkitBasePort = options?.webkitBasePort ?? 9322;
     this.nextPort = this.webkitBasePort;
     this.idleTimeout = DEFAULT_IDLE_SHUTDOWN_TIMEOUT_MS;
     this.memoryWarnMB = DEFAULT_MEMORY_WARN_MB;


### PR DESCRIPTION
## Summary
- Aligns stale port defaults (9222) to 9322 across `config/global.ts` and `simulator/pool.ts`
- The WebInspector proxy already defaults to port 9322 (to coexist with openchrome on 9222), but two config files still referenced the old 9222 default

Ref #148

## Changes
| File | Line | Before | After |
|---|---|---|---|
| `src/config/global.ts` | 40 | `webkitDebugPort: 9222` | `webkitDebugPort: 9322` |
| `src/simulator/pool.ts` | 53 | `webkitBasePort ?? 9222` | `webkitBasePort ?? 9322` |

## Why 9322?
Port 9322 was chosen in `src/simulator/proxy.ts` to avoid conflict with Chrome DevTools / openchrome which uses 9222. These two config files were never updated to match.

## Test plan
- [ ] OpenSafari and openchrome can run simultaneously without port conflict
- [ ] `SimulatorPool` connects to the correct proxy port by default
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)