### PR TITLE
fix: use explicit querySelector + native setter in type() tool

### DIFF
--- a/src/webkit/client.ts
+++ b/src/webkit/client.ts
@@ -612,24 +612,35 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
   }
 
   async type(selector: string, text: string, options?: { delay?: number }): Promise<void> {
-    // Click to focus
-    await this.click(selector);
+    // Focus the element explicitly — touch-based click() doesn't reliably trigger focus
+    await this.evaluate(`
+      (function() {
+        var el = document.querySelector(${JSON.stringify(selector)});
+        if (el && typeof el.focus === 'function') el.focus();
+      })()
+    `);
 
     if (options?.delay) {
       // Character-by-character mode with delay
       for (const char of text) {
         await this.evaluate(`
           (function() {
-            var el = document.activeElement;
+            var el = document.querySelector(${JSON.stringify(selector)});
             if (!el) return;
             var ev = new KeyboardEvent('keydown', { key: ${JSON.stringify(char)}, bubbles: true });
             el.dispatchEvent(ev);
             el.dispatchEvent(new KeyboardEvent('keypress', { key: ${JSON.stringify(char)}, bubbles: true }));
-            // Append character
-            if (el.value !== undefined) {
+            // Use native setter to avoid cross-context TypeError
+            var proto = el.tagName === 'TEXTAREA'
+              ? window.HTMLTextAreaElement.prototype
+              : window.HTMLInputElement.prototype;
+            var desc = Object.getOwnPropertyDescriptor(proto, 'value');
+            if (desc && desc.set) {
+              desc.set.call(el, el.value + ${JSON.stringify(char)});
+            } else {
               el.value += ${JSON.stringify(char)};
-              el.dispatchEvent(new Event('input', { bubbles: true }));
             }
+            el.dispatchEvent(new Event('input', { bubbles: true }));
             el.dispatchEvent(new KeyboardEvent('keyup', { key: ${JSON.stringify(char)}, bubbles: true }));
           })()
         `);
@@ -639,7 +650,7 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
       // Fast mode: set value directly + dispatch events
       await this.evaluate(`
         (function() {
-          var el = document.activeElement;
+          var el = document.querySelector(${JSON.stringify(selector)});
           if (!el) return;
           // Use native setter for React/Vue compatibility
           var nativeSetter = Object.getOwnPropertyDescriptor(


### PR DESCRIPTION
## Summary
- Fix `type()` method in WebKitClient that fails with `TypeError: The HTMLInputElement.value setter can only be used on instances of HTMLInputElement`
- Replace `document.activeElement` (unreliable after touch-based click) with explicit `document.querySelector(selector)` + `.focus()`
- Apply native `HTMLInputElement`/`HTMLTextAreaElement` prototype setter pattern in both fast and character-by-character delay modes

## Root Cause
The `type()` method called `this.click(selector)` to focus the target element, but the touch-event-based click dispatch doesn't reliably trigger focus on input elements in WebKit's remote evaluation context. Subsequent code used `document.activeElement` which often remained `document.body`, causing the native value setter to throw a TypeError.

Additionally, the delay (character-by-character) mode used `el.value += char` directly instead of the native setter pattern, making it equally vulnerable.

## Changes
- `src/webkit/client.ts`: Rewrite `type()` method (lines 614-662)
  - Use `document.querySelector(selector)` + explicit `.focus()` instead of `document.activeElement`
  - Apply native prototype setter in both fast and delay modes
  - Both `<input>` and `<textarea>` elements handled correctly

## Test plan
- [x] `npm run build` — zero errors
- [x] `npm test` — 20/20 passed
- [ ] Runtime: `type({ selector: '#testinput', text: 'hello' })` sets value correctly
- [ ] Runtime: `type({ selector: '#testinput', text: 'abc', delay: 100 })` types character-by-character

Discovered during #148 runtime verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>