### PR TITLE
fix: add simctl screenshot fallback when Page.snapshotRect fails

### DIFF
--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -1,4 +1,5 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
+import { SimulatorManager } from '../simulator';
 
 export function registerScreenshotTool(server: MCPServer): void {
   server.registerTool(
@@ -18,7 +19,24 @@ export function registerScreenshotTool(server: MCPServer): void {
       const client = getWebKitClient();
       if (!client)
         return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
-      const buffer = await client.screenshot({ format: params.format as 'png' | undefined, fullPage: params.fullPage as boolean | undefined });
+
+      // Try WebKit protocol screenshot first, fall back to simctl
+      let buffer: Buffer;
+      try {
+        buffer = await client.screenshot({
+          format: params.format as 'png' | undefined,
+          fullPage: params.fullPage as boolean | undefined,
+        });
+      } catch {
+        // Fallback: use simctl io screenshot
+        const manager = new SimulatorManager();
+        const booted = await manager.listBooted();
+        if (booted.length === 0) {
+          return { content: [{ type: 'text' as const, text: 'Error: No booted simulator for screenshot fallback' }], isError: true };
+        }
+        buffer = await manager.screenshot(booted[0].udid);
+      }
+
       const base64 = buffer.toString('base64');
       return { content: [{ type: 'image' as const, data: base64, mimeType: 'image/png' }] };
     },


### PR DESCRIPTION
## Summary
- Add `simctl io screenshot` fallback in the screenshot tool when WebKit `Page.snapshotRect` fails
- Ensures screenshots work reliably regardless of WebKit protocol support level

## Root Cause
`Page.snapshotRect` is not available in all WebKit versions served by `ios_webkit_debug_proxy`. When it fails, the screenshot tool previously threw an unrecoverable error: "Screenshot failed — use SimulatorManager.screenshot() as fallback".

`SimulatorManager` already has a working `screenshot(deviceId)` method using `simctl io <deviceId> screenshot`, but it was never wired up as a fallback.

## Changes
- `src/tools/screenshot.ts`:
  - Import `SimulatorManager`
  - Wrap WebKit screenshot in try/catch
  - On failure, fall back to `SimulatorManager.screenshot()` using the first booted device
  - Return clear error if no booted simulator is available for fallback

## Test plan
- [x] `npm run build` — zero errors
- [x] `npm test` — 20/20 passed
- [ ] Runtime: `screenshot()` returns valid base64 PNG via simctl fallback
- [ ] Runtime: screenshot works on devices where `Page.snapshotRect` is not supported

Discovered during #148 runtime verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>