### PR TITLE
fix: tiered socket resolution with liveness validation

### DIFF
--- a/src/simulator/index.ts
+++ b/src/simulator/index.ts
@@ -10,3 +10,5 @@ export { BatchExecutor } from './batch';
 export type { BatchResult } from './batch';
 export { WebInspectorProxy, getSharedProxy } from './proxy';
 export type { ProxyOptions } from './proxy';
+export { findSocketPath, probeSocket } from './socket-finder';
+export type { FindSocketOptions } from './socket-finder';

--- a/src/simulator/proxy.ts
+++ b/src/simulator/proxy.ts
@@ -1,10 +1,9 @@
 import { spawn, ChildProcess, execFile } from 'child_process';
 import { promisify } from 'util';
-import * as fs from 'fs/promises';
 import { readFileSync, writeFileSync, unlinkSync } from 'fs';
-import * as path from 'path';
 import * as http from 'http';
 import * as net from 'net';
+import { findSocketPath } from './socket-finder';
 
 const execFileAsync = promisify(execFile);
 
@@ -69,24 +68,7 @@ export class WebInspectorProxy {
   }
 
   async findSocketPath(): Promise<string | null> {
-    const searchPaths = ['/private/var/tmp', '/private/tmp'];
-    const candidates: { socketPath: string; mtimeMs: number }[] = [];
-    for (const base of searchPaths) {
-      let dirs: string[];
-      try { dirs = await fs.readdir(base); } catch { continue; }
-      for (const dir of dirs) {
-        if (!dir.startsWith('com.apple.launchd.')) continue;
-        const socketPath = path.join(base, dir, 'com.apple.webinspectord_sim.socket');
-        try {
-          const stat = await fs.stat(socketPath);
-          candidates.push({ socketPath, mtimeMs: stat.mtimeMs });
-        } catch { continue; }
-      }
-    }
-    if (candidates.length === 0) return null;
-    // Return the most recently modified socket to avoid stale entries
-    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
-    return candidates[0].socketPath;
+    return findSocketPath();
   }
 
   /** Start the proxy process. Resolves once the proxy is ready. */

--- a/src/simulator/socket-finder.ts
+++ b/src/simulator/socket-finder.ts
@@ -1,0 +1,140 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as net from 'net';
+
+const execFileAsync = promisify(execFile);
+
+const SOCKET_NAME = 'com.apple.webinspectord_sim.socket';
+const SOCKET_SEARCH_DIRS = ['/private/var/tmp', '/private/tmp'];
+const PROBE_TIMEOUT_MS = 2000;
+
+export interface FindSocketOptions {
+  /** Target a specific simulator by UDID (for multi-simulator support). */
+  targetUdid?: string;
+}
+
+/**
+ * Find the active WebKit Inspector socket using tiered resolution:
+ *
+ *  Tier 1 – `lsof -U`: definitively maps sockets to running `launchd_sim`
+ *           processes. Supports `targetUdid` for multi-simulator selection.
+ *  Tier 2 – mtime-sorted `fs.stat()`: collects all candidate sockets, sorts
+ *           by modification time (newest first), probes each with net.connect.
+ *
+ * Both tiers validate candidates with a `net.connect()` liveness probe before
+ * returning. Returns `null` when no live socket is found.
+ */
+export async function findSocketPath(options?: FindSocketOptions): Promise<string | null> {
+  // Tier 1: lsof -U — definitive process-level match
+  const lsofResult = await findViaLsof(options?.targetUdid);
+  if (lsofResult) return lsofResult;
+
+  // Tier 2: mtime-sorted fallback with liveness probe
+  return findViaMtime();
+}
+
+/**
+ * Probe a Unix socket for liveness. Returns true if a process is listening.
+ * Active sockets connect in ~1ms; stale sockets return ECONNREFUSED in ~1ms.
+ */
+export function probeSocket(socketPath: string): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = net.connect({ path: socketPath });
+    socket.setTimeout(PROBE_TIMEOUT_MS);
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once('error', () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1: lsof -U
+// ---------------------------------------------------------------------------
+
+async function findViaLsof(targetUdid?: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('lsof', ['-U'], { timeout: 5000 });
+    const lines = stdout.split('\n');
+
+    // Collect sockets owned by launchd_sim (truncated to "launchd_s" in lsof output)
+    const candidates: { pid: number; socketPath: string }[] = [];
+    for (const line of lines) {
+      if (!line.startsWith('launchd_s') || !line.includes(SOCKET_NAME)) continue;
+      const parts = line.split(/\s+/);
+      const pid = parseInt(parts[1], 10);
+      const socketPath = parts[parts.length - 1];
+      if (socketPath && !candidates.some(c => c.socketPath === socketPath)) {
+        candidates.push({ pid, socketPath });
+      }
+    }
+
+    if (candidates.length === 0) return null;
+
+    // With targetUdid, match the launchd_sim command line to the simulator UDID
+    if (targetUdid) {
+      for (const { pid, socketPath } of candidates) {
+        try {
+          const { stdout: cmdline } = await execFileAsync('ps', ['-p', String(pid), '-o', 'args=']);
+          if (cmdline.includes(targetUdid)) {
+            if (await probeSocket(socketPath)) return socketPath;
+          }
+        } catch { continue; }
+      }
+      return null;
+    }
+
+    // No targetUdid: return first live socket
+    for (const { socketPath } of candidates) {
+      if (await probeSocket(socketPath)) return socketPath;
+    }
+
+    return null;
+  } catch {
+    // lsof unavailable or failed — fall through to Tier 2
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2: mtime-sorted fs.stat with liveness probe
+// ---------------------------------------------------------------------------
+
+async function findViaMtime(): Promise<string | null> {
+  const candidates: { socketPath: string; mtimeMs: number }[] = [];
+
+  for (const base of SOCKET_SEARCH_DIRS) {
+    let dirs: string[];
+    try { dirs = await fs.readdir(base); } catch { continue; }
+    for (const dir of dirs) {
+      if (!dir.startsWith('com.apple.launchd.')) continue;
+      const socketPath = path.join(base, dir, SOCKET_NAME);
+      try {
+        const stat = await fs.stat(socketPath);
+        candidates.push({ socketPath, mtimeMs: stat.mtimeMs });
+      } catch { continue; }
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  // Sort by mtime descending — newest first
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  // Probe each candidate until one is alive
+  for (const { socketPath } of candidates) {
+    if (await probeSocket(socketPath)) return socketPath;
+  }
+
+  return null;
+}

--- a/src/simulator/xcode-check.ts
+++ b/src/simulator/xcode-check.ts
@@ -1,13 +1,9 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import * as fs from 'fs/promises';
-import * as path from 'path';
 import * as http from 'http';
+import { findSocketPath } from './socket-finder';
 
 const execFileAsync = promisify(execFile);
-
-const SOCKET_NAME = 'com.apple.webinspectord_sim.socket';
-const SOCKET_SEARCH_DIRS = ['/private/var/tmp', '/private/tmp'];
 // Device-list ports serve the "iOS Devices" HTML listing.
 // 9321 = opensafari default, 9221 = traditional ios_webkit_debug_proxy default.
 const PROXY_DEVICE_LIST_PORTS = [9321, 9221];
@@ -140,24 +136,8 @@ export async function checkXcodeInstallation(): Promise<XcodeCheckResult> {
   return result;
 }
 
-/**
- * Scan known directories for the WebKit Inspector simulator socket.
- * Duplicates the logic from proxy connection code to avoid circular imports.
- */
 async function findWebInspectorSocket(): Promise<string | undefined> {
-  for (const base of SOCKET_SEARCH_DIRS) {
-    let dirs: string[];
-    try { dirs = await fs.readdir(base); } catch { continue; }
-    for (const dir of dirs) {
-      if (!dir.startsWith('com.apple.launchd.')) continue;
-      const socketPath = path.join(base, dir, SOCKET_NAME);
-      try {
-        await fs.access(socketPath);
-        return socketPath;
-      } catch { continue; }
-    }
-  }
-  return undefined;
+  return (await findSocketPath()) ?? undefined;
 }
 
 /**

--- a/tests/unit/socket-finder.test.ts
+++ b/tests/unit/socket-finder.test.ts
@@ -1,0 +1,240 @@
+import * as childProcess from 'child_process';
+import * as fsPromises from 'fs/promises';
+import { EventEmitter } from 'events';
+import { findSocketPath, probeSocket } from '../../src/simulator/socket-finder';
+
+// Mock modules
+jest.mock('child_process');
+jest.mock('fs/promises');
+
+// Track which sockets should be treated as alive
+let probeResults: Record<string, boolean> = {};
+
+jest.mock('net', () => ({
+  connect: jest.fn((opts: { path?: string }) => {
+    const socketPath = opts.path ?? '';
+    const alive = probeResults[socketPath] ?? false;
+    const emitter = new EventEmitter();
+    (emitter as unknown as Record<string, unknown>).setTimeout = jest.fn();
+    (emitter as unknown as Record<string, unknown>).destroy = jest.fn();
+    process.nextTick(() => {
+      if (alive) {
+        emitter.emit('connect');
+      } else {
+        emitter.emit('error', new Error('ECONNREFUSED'));
+      }
+    });
+    return emitter;
+  }),
+}));
+
+const execFileMock = childProcess.execFile as unknown as jest.Mock;
+const readdirMock = fsPromises.readdir as jest.Mock;
+const statMock = fsPromises.stat as jest.Mock;
+
+// Helper: stub execFile to invoke the callback (promisified pattern)
+function stubExecFile(results: Record<string, { stdout?: string; error?: Error }>) {
+  execFileMock.mockImplementation((cmd: string, args: string[], opts: unknown, cb?: unknown) => {
+    const callback = typeof opts === 'function' ? opts : cb;
+    const key = `${cmd} ${(Array.isArray(args) ? args : []).join(' ')}`;
+    for (const [pattern, res] of Object.entries(results)) {
+      if (key.includes(pattern)) {
+        if (res.error) {
+          (callback as CallableFunction)(res.error);
+        } else {
+          (callback as CallableFunction)(null, { stdout: res.stdout ?? '' });
+        }
+        return;
+      }
+    }
+    (callback as CallableFunction)(new Error(`no stub for: ${key}`));
+  });
+}
+
+// Helper: stub readdir + stat for mtime tier
+function stubFilesystem(sockets: { dir: string; mtimeMs: number }[]) {
+  readdirMock.mockImplementation(async (base: string) => {
+    if (base === '/private/var/tmp') {
+      return sockets.map(s => s.dir);
+    }
+    throw new Error('ENOENT');
+  });
+  statMock.mockImplementation(async (p: string) => {
+    const match = sockets.find(s => p.includes(s.dir));
+    if (match) return { mtimeMs: match.mtimeMs };
+    throw new Error('ENOENT');
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  probeResults = {};
+});
+
+describe('findSocketPath', () => {
+  describe('Tier 1: lsof -U', () => {
+    it('returns active socket identified by lsof', async () => {
+      const socketPath = '/private/var/tmp/com.apple.launchd.ACTIVE/com.apple.webinspectord_sim.socket';
+      probeResults[socketPath] = true;
+
+      stubExecFile({
+        'lsof -U': {
+          stdout: [
+            'COMMAND    PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME',
+            `launchd_s 1234 user   8u  unix 0xabc      0t0      ${socketPath}`,
+          ].join('\n'),
+        },
+      });
+
+      const result = await findSocketPath();
+      expect(result).toBe(socketPath);
+    });
+
+    it('filters by targetUdid via ps command line', async () => {
+      const socket1 = '/private/var/tmp/com.apple.launchd.SIM1/com.apple.webinspectord_sim.socket';
+      const socket2 = '/private/var/tmp/com.apple.launchd.SIM2/com.apple.webinspectord_sim.socket';
+      probeResults[socket1] = true;
+      probeResults[socket2] = true;
+
+      const targetUdid = 'AAAA-BBBB-CCCC-DDDD';
+
+      stubExecFile({
+        'lsof -U': {
+          stdout: [
+            `launchd_s 1001 user  8u  unix 0xa  0t0  ${socket1}`,
+            `launchd_s 1002 user  8u  unix 0xb  0t0  ${socket2}`,
+          ].join('\n'),
+        },
+        'ps -p 1001': { stdout: `launchd_sim /path/to/OTHER-UDID/data/run/bootstrap.plist` },
+        'ps -p 1002': { stdout: `launchd_sim /path/to/${targetUdid}/data/run/bootstrap.plist` },
+      });
+
+      const result = await findSocketPath({ targetUdid });
+      expect(result).toBe(socket2);
+    });
+
+    it('returns null when targetUdid matches no running simulator', async () => {
+      const socket1 = '/private/var/tmp/com.apple.launchd.SIM1/com.apple.webinspectord_sim.socket';
+      probeResults[socket1] = true;
+
+      stubExecFile({
+        'lsof -U': {
+          stdout: `launchd_s 1001 user  8u  unix 0xa  0t0  ${socket1}\n`,
+        },
+        'ps -p 1001': { stdout: `launchd_sim /path/to/OTHER-UDID/data/run/bootstrap.plist` },
+      });
+
+      // Stub filesystem so Tier 2 fallback also returns null
+      readdirMock.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await findSocketPath({ targetUdid: 'NON-EXISTENT-UDID' });
+      expect(result).toBeNull();
+    });
+
+    it('skips sockets that fail liveness probe', async () => {
+      const stale = '/private/var/tmp/com.apple.launchd.STALE/com.apple.webinspectord_sim.socket';
+      const active = '/private/var/tmp/com.apple.launchd.ACTIVE/com.apple.webinspectord_sim.socket';
+      probeResults[stale] = false;
+      probeResults[active] = true;
+
+      stubExecFile({
+        'lsof -U': {
+          stdout: [
+            `launchd_s 1001 user  8u  unix 0xa  0t0  ${stale}`,
+            `launchd_s 1002 user  8u  unix 0xb  0t0  ${active}`,
+          ].join('\n'),
+        },
+      });
+
+      const result = await findSocketPath();
+      expect(result).toBe(active);
+    });
+  });
+
+  describe('Tier 2: mtime-sorted fallback', () => {
+    it('falls back to mtime when lsof fails', async () => {
+      const activeSocket = '/private/var/tmp/com.apple.launchd.NEWEST/com.apple.webinspectord_sim.socket';
+      probeResults[activeSocket] = true;
+
+      stubExecFile({ 'lsof -U': { error: new Error('command not found') } });
+
+      stubFilesystem([
+        { dir: 'com.apple.launchd.OLDEST', mtimeMs: 1000 },
+        { dir: 'com.apple.launchd.NEWEST', mtimeMs: 9000 },
+        { dir: 'com.apple.launchd.MIDDLE', mtimeMs: 5000 },
+      ]);
+
+      const result = await findSocketPath();
+      expect(result).toBe(activeSocket);
+    });
+
+    it('skips stale sockets and returns next live one', async () => {
+      const stale = '/private/var/tmp/com.apple.launchd.NEWEST/com.apple.webinspectord_sim.socket';
+      const active = '/private/var/tmp/com.apple.launchd.MIDDLE/com.apple.webinspectord_sim.socket';
+      probeResults[stale] = false;
+      probeResults[active] = true;
+
+      stubExecFile({ 'lsof -U': { error: new Error('fail') } });
+      stubFilesystem([
+        { dir: 'com.apple.launchd.OLDEST', mtimeMs: 1000 },
+        { dir: 'com.apple.launchd.NEWEST', mtimeMs: 9000 },
+        { dir: 'com.apple.launchd.MIDDLE', mtimeMs: 5000 },
+      ]);
+
+      const result = await findSocketPath();
+      expect(result).toBe(active);
+    });
+
+    it('returns null when all sockets are stale', async () => {
+      stubExecFile({ 'lsof -U': { error: new Error('fail') } });
+      stubFilesystem([
+        { dir: 'com.apple.launchd.A', mtimeMs: 9000 },
+        { dir: 'com.apple.launchd.B', mtimeMs: 5000 },
+      ]);
+
+      const result = await findSocketPath();
+      expect(result).toBeNull();
+    });
+
+    it('returns null when no socket files exist', async () => {
+      stubExecFile({ 'lsof -U': { error: new Error('fail') } });
+      readdirMock.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await findSocketPath();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Tier 1 → Tier 2 fallback chain', () => {
+    it('uses lsof when available, ignores filesystem', async () => {
+      const lsofSocket = '/private/var/tmp/com.apple.launchd.LSOF/com.apple.webinspectord_sim.socket';
+      probeResults[lsofSocket] = true;
+
+      stubExecFile({
+        'lsof -U': {
+          stdout: `launchd_s 999 user  8u  unix 0xa  0t0  ${lsofSocket}\n`,
+        },
+      });
+
+      stubFilesystem([
+        { dir: 'com.apple.launchd.NEWER_BUT_WRONG', mtimeMs: 99999 },
+      ]);
+
+      const result = await findSocketPath();
+      expect(result).toBe(lsofSocket);
+      expect(readdirMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('probeSocket', () => {
+  it('returns true for alive socket', async () => {
+    probeResults['/tmp/alive.sock'] = true;
+    expect(await probeSocket('/tmp/alive.sock')).toBe(true);
+  });
+
+  it('returns false for dead socket', async () => {
+    probeResults['/tmp/dead.sock'] = false;
+    expect(await probeSocket('/tmp/dead.sock')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #157 — `findSocketPath()` selected stale sockets due to alphabetical `fs.readdir()` ordering when 50+ stale `webinspectord_sim.socket` files accumulate in `/private/var/tmp`.

- **Extract shared `socket-finder.ts`** with tiered resolution:
  - **Tier 1**: `lsof -U` — definitively maps sockets to running `launchd_sim` processes, supports `targetUdid` for multi-simulator selection
  - **Tier 2**: mtime-sorted `fs.stat()` fallback — probes each candidate newest-first
  - Both tiers validate with `net.connect()` liveness probe (2s timeout) before returning
  - Returns `null` when no live socket exists (previously returned stale socket)
- **Deduplicate**: Both `proxy.ts` and `xcode-check.ts` now import from shared module
- **Fix xcode-check.ts**: Was using `fs.access()` without mtime sorting — always returned alphabetically-first (stale) socket

## Verified on real hardware

| Test | Result |
|------|--------|
| Active socket selection (98 stale sockets) | ✅ Correct socket via lsof + mtime |
| Not-alphabetically-first socket | ✅ `JQ00gZjmg9` (active) over `0baGt1OOuU` (stale) |
| Null when no sim booted | ✅ Returns `null` (net.connect rejects all) |
| Performance (100 sockets) | ✅ 6.4ms avg |
| Multi-sim (2 booted) | ✅ Returns valid active socket |
| targetUdid filtering | ✅ Unit tested |
| Proxy → device list → JSON targets | ✅ End-to-end |
| WebKitClient connect | ✅ |
| xcode-check doctor | ✅ Now uses shared finder |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (65/65, 11 new socket-finder tests)
- [x] Tier 1 lsof parsing, targetUdid filtering, stale skip
- [x] Tier 2 mtime fallback, stale skip, null case, no-files case
- [x] Tier 1→2 fallback chain
- [x] probeSocket alive/dead
- [x] Real-device verification with 98–100 stale sockets

🤖 Generated with [Claude Code](https://claude.com/claude-code)