### PR TITLE
fix: wire audit logging into tool call pipeline (#171)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -88,6 +88,7 @@ program
 
     // Wire audit logging
     if (options.auditLog) {
+      server.enableAuditLog();
       console.error('[OpenSafari] Audit logging enabled');
     }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,6 +18,7 @@ import {
 import { createTransport, MCPTransport, TransportMode } from './transports';
 import { TOOL_TIERS, getToolTier } from './config/tool-tiers';
 import { BrowserBackend } from './types/browser-backend';
+import { logAuditEntry } from './security/audit-logger';
 
 // Re-export so callers can use canonical names without knowing the internal alias
 export type { MCPToolDefinition as ToolDefinition, ToolHandler };
@@ -64,6 +65,7 @@ export class MCPServer {
   private tools: Map<string, RegisteredTool> = new Map();
   private transport: MCPTransport | null = null;
   private currentTier: number = 1;
+  private auditLogEnabled = false;
 
   // ------------------------------------------------------------------
   // Tool registration
@@ -114,6 +116,10 @@ export class MCPServer {
 
   getTier(): number {
     return this.currentTier;
+  }
+
+  enableAuditLog(): void {
+    this.auditLogEnabled = true;
   }
 
   // ------------------------------------------------------------------
@@ -241,12 +247,18 @@ export class MCPServer {
 
     try {
       const result: MCPResult = await tool.handler(sessionId, args);
+      if (this.auditLogEnabled) {
+        logAuditEntry(name, sessionId, args);
+      }
       return {
         jsonrpc: '2.0',
         id: request.id,
         result,
       };
     } catch (err) {
+      if (this.auditLogEnabled) {
+        logAuditEntry(name, sessionId, args);
+      }
       const message = err instanceof Error ? err.message : String(err);
       return {
         jsonrpc: '2.0',


### PR DESCRIPTION
## Summary
- `logAuditEntry()` was imported in `cli/index.ts` but never called in the tool call pipeline
- Added `enableAuditLog()` method to `MCPServer` and wired `logAuditEntry()` into `handleToolsCall()` for both success and error paths
- Audit log is only written when `--audit-log` CLI flag is set

## Verification
Live-tested with `opensafari serve --http --audit-log`:
- Audit log file created at `~/.opensafari/audit.log`
- Each tool call produces a JSONL entry with: timestamp, tool name, sessionId, args_summary, domain
- Sensitive data (password, cookie, token) is redacted to `[REDACTED]`

Resolves part of #171 (Audit Logging checklist: 3/3 items)

## Test plan
- [x] `npm run build` succeeds
- [x] Start server with `--audit-log`, call tools, verify `~/.opensafari/audit.log` has entries
- [x] Verify sensitive fields are redacted in log entries
- [x] Verify no audit log created when `--audit-log` flag is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)