### PR TITLE
fix: enforce domain guard in navigate tool (#171)

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -1,4 +1,5 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
+import { assertDomainAllowed } from '../security/domain-guard';
 
 export function registerNavigateTool(server: MCPServer): void {
   server.registerTool(
@@ -19,10 +20,12 @@ export function registerNavigateTool(server: MCPServer): void {
       },
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
+      const url = params.url as string;
+      assertDomainAllowed(url);
       const client = getWebKitClient();
       if (!client)
         return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
-      const result = await client.navigate({ url: params.url as string, waitUntil: params.waitUntil as any });
+      const result = await client.navigate({ url, waitUntil: params.waitUntil as any });
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     },
   );


### PR DESCRIPTION
## Summary
- `assertDomainAllowed()` was defined in `domain-guard.ts` but never called in the navigate tool
- Added domain check as a pre-condition in `src/tools/navigate.ts` before attempting navigation
- Blocked domains now return a clear security policy error with the matched pattern

## Verification
Live-tested with `opensafari serve --http --blocked-domains 'evil.com,*.bank.com'`:
- `navigate` to `https://evil.com` → `"Access to domain "evil.com" is blocked by security policy (matched pattern: "evil.com")"`
- `navigate` to `https://www.bank.com` → blocked by wildcard `*.bank.com`
- `navigate` to `https://example.com` → proceeds normally (no block error)

Resolves part of #171 (Domain Guard checklist: blocked domain error item)

## Test plan
- [x] `npm run build` succeeds
- [x] Navigate to blocked exact domain returns security policy error
- [x] Navigate to blocked wildcard domain returns security policy error
- [x] Navigate to non-blocked domain proceeds without block error
- [x] No blocked domains configured → all domains allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)