### PR TITLE
fix: upgrade zombie cleanup to remove orphans and run periodically (#171)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -17,7 +17,7 @@ import { SimulatorWorkflowEngine } from '../src/orchestration/workflow-engine';
 import { CrossViewportCapture } from '../src/comparison/cross-viewport';
 import { setupGracefulShutdown } from '../src/reliability/graceful-shutdown';
 import { SimulatorCrashWatcher } from '../src/reliability/crash-watcher';
-import { cleanupZombieProcesses } from '../src/reliability/zombie-cleanup';
+import { cleanupZombieProcesses, startPeriodicCleanup } from '../src/reliability/zombie-cleanup';
 import { setBlockedDomains } from '../src/security/domain-guard';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from '../src/watchdog/event-loop-monitor';
 import { SimulatorMonitor } from '../src/watchdog/simulator-monitor';
@@ -79,6 +79,13 @@ program
     cleanupZombieProcesses().then(count => {
       if (count > 0) console.error(`[OpenSafari] Found ${count} orphaned simulator process(es)`);
     }).catch(() => {});
+
+    // Periodic zombie cleanup: compare booted simulators against pool
+    startPeriodicCleanup(() => {
+      const ids = new Set<string>();
+      for (const sim of pool.getAll()) ids.add(sim.device.udid);
+      return ids;
+    });
 
     // Wire domain guard
     if (options.blockedDomains) {

--- a/src/reliability/index.ts
+++ b/src/reliability/index.ts
@@ -1,3 +1,3 @@
 export { SimulatorCrashWatcher } from './crash-watcher';
 export { setupGracefulShutdown } from './graceful-shutdown';
-export { cleanupZombieProcesses } from './zombie-cleanup';
+export { cleanupZombieProcesses, startPeriodicCleanup, stopPeriodicCleanup } from './zombie-cleanup';

--- a/src/reliability/zombie-cleanup.ts
+++ b/src/reliability/zombie-cleanup.ts
@@ -3,18 +3,93 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
-export async function cleanupZombieProcesses(): Promise<number> {
-  let cleaned = 0;
+/**
+ * Find and clean up orphaned simulator processes.
+ * When knownDeviceIds is provided, only shuts down booted simulators
+ * NOT in that set. When omitted (startup), reports orphaned CoreSimulator
+ * processes without killing them (conservative first-run behavior).
+ *
+ * Returns the number of processes cleaned up or detected.
+ */
+export async function cleanupZombieProcesses(knownDeviceIds?: Set<string>): Promise<number> {
+  if (knownDeviceIds) {
+    return cleanupOrphanedSimulators(knownDeviceIds);
+  }
+  return detectOrphanedProcesses();
+}
+
+/**
+ * Startup detection: report orphaned CoreSimulator processes without killing.
+ */
+async function detectOrphanedProcesses(): Promise<number> {
   try {
     const { stdout } = await execFileAsync('pgrep', ['-f', 'CoreSimulator']);
     const pids = stdout.trim().split('\n').filter(Boolean);
-    // Just report — don't kill blindly
     if (pids.length > 0) {
       console.error(`[ZombieCleanup] Found ${pids.length} CoreSimulator processes`);
-      cleaned = pids.length;
+    }
+    return pids.length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Runtime cleanup: shut down booted simulators not managed by our pool.
+ * Uses `simctl shutdown` for safe teardown instead of raw process kills.
+ */
+async function cleanupOrphanedSimulators(knownDeviceIds: Set<string>): Promise<number> {
+  let cleaned = 0;
+  try {
+    const { stdout } = await execFileAsync('xcrun', ['simctl', 'list', 'devices', 'booted', '--json']);
+    const data = JSON.parse(stdout);
+
+    for (const runtime of Object.values(data.devices) as any[]) {
+      for (const device of runtime) {
+        if (device.state === 'Booted' && !knownDeviceIds.has(device.udid)) {
+          try {
+            await execFileAsync('xcrun', ['simctl', 'shutdown', device.udid]);
+            cleaned++;
+            console.error(`[ZombieCleanup] Shut down orphaned simulator: ${device.name} (${device.udid})`);
+          } catch {
+            // May already be shutting down
+          }
+        }
+      }
     }
   } catch {
-    // No CoreSimulator processes
+    // simctl not available or no booted devices
   }
   return cleaned;
+}
+
+let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start periodic zombie cleanup that compares booted simulators against
+ * the pool's known devices and shuts down orphans.
+ */
+export function startPeriodicCleanup(
+  getKnownDeviceIds: () => Set<string>,
+  intervalMs = 60000,
+): void {
+  stopPeriodicCleanup();
+  cleanupInterval = setInterval(async () => {
+    const ids = getKnownDeviceIds();
+    const cleaned = await cleanupZombieProcesses(ids);
+    if (cleaned > 0) {
+      console.error(`[ZombieCleanup] Periodic cleanup removed ${cleaned} orphaned simulator(s)`);
+    }
+  }, intervalMs);
+  cleanupInterval.unref();
+}
+
+/**
+ * Stop periodic zombie cleanup.
+ */
+export function stopPeriodicCleanup(): void {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+  }
 }


### PR DESCRIPTION
## Summary
- Previously `zombie-cleanup.ts` only reported orphaned CoreSimulator processes without removing them, and ran only once at startup
- Runtime cleanup now uses `xcrun simctl shutdown` to safely stop orphaned simulators not managed by the current pool
- Added periodic cleanup (every 60s) that compares booted simulators against the pool's known device IDs
- Startup detection remains conservative (report-only) since the pool is not yet populated
- Added `startPeriodicCleanup()` / `stopPeriodicCleanup()` exports

## Changes
| File | Change |
|------|--------|
| `src/reliability/zombie-cleanup.ts` | Rewritten: runtime orphan removal via simctl + periodic scheduling |
| `src/reliability/index.ts` | Export new functions |
| `cli/index.ts` | Wire `startPeriodicCleanup()` with pool device IDs |

Resolves part of #171 (Zombie Cleanup checklist: 3/3 items)

## Test plan
- [x] `npm run build` succeeds
- [x] Startup detects orphaned CoreSimulator processes
- [x] `startPeriodicCleanup` wired in CLI serve command
- [x] Periodic cleanup uses `simctl shutdown` for safe teardown
- [x] `stopPeriodicCleanup` available for graceful shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)