### PR TITLE
fix: repair test:integration script and integration test type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "node dist/index.js",
     "test": "jest --config jest.config.js",
     "test:unit": "jest --config jest.config.js",
-    "test:integration": "jest --roots tests/integration --testTimeout 120000",
+    "test:integration": "jest --roots tests/integration --testPathIgnorePatterns '/node_modules/' --testTimeout 120000",
     "test:ci": "jest --config jest.ci.config.js",
     "test:coverage": "jest --coverage",
     "lint": "eslint 'src/**/*.ts' 'cli/**/*.ts' 'tests/**/*.ts'",

--- a/tests/integration/webkit-connection.test.ts
+++ b/tests/integration/webkit-connection.test.ts
@@ -91,15 +91,14 @@ describe('WebKit Connection Integration', () => {
     expect(text).toContain('Example Domain');
   });
 
-  test('screenshot returns valid base64 PNG', async () => {
+  test('screenshot returns valid PNG buffer', async () => {
     const data = await client.screenshot();
     expect(data.length).toBeGreaterThan(100);
-    // Verify PNG magic bytes in decoded base64
-    const buf = Buffer.from(data, 'base64');
-    expect(buf[0]).toBe(0x89); // PNG signature
-    expect(buf[1]).toBe(0x50); // 'P'
-    expect(buf[2]).toBe(0x4E); // 'N'
-    expect(buf[3]).toBe(0x47); // 'G'
+    // Verify PNG magic bytes
+    expect(data[0]).toBe(0x89); // PNG signature
+    expect(data[1]).toBe(0x50); // 'P'
+    expect(data[2]).toBe(0x4E); // 'N'
+    expect(data[3]).toBe(0x47); // 'G'
   }, 15_000);
 
   test('querySelector returns element info', async () => {


### PR DESCRIPTION
## Summary
- Fix `test:integration` script: `testPathIgnorePatterns` in `jest.config.js` excluded `/tests/integration/`, causing the script to find 0 tests. Override with `--testPathIgnorePatterns '/node_modules/'`
- Fix TypeScript error in integration test: `Buffer.from(data, 'base64')` fails because `screenshot()` returns `Buffer`, not a base64 string. Use the buffer directly for PNG magic byte verification

Closes #172 (partial — Tier 2 integration tests now runnable)

## Test plan
- [x] `npm run test:integration` finds and runs `tests/integration/webkit-connection.test.ts` (12/12 pass)
- [x] `npm run test:unit` still excludes integration tests (116/116 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)