### PR TITLE
fix: set webpack output library type to commonjs2

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = [
     output: {
       filename: 'index.js',
       path: path.resolve(__dirname, 'dist'),
+      library: { type: 'commonjs2' },
     },
     resolve: {
       extensions: ['.ts', '.js'],


### PR DESCRIPTION
## Summary
- Add `library: { type: 'commonjs2' }` to webpack server output config
- Without this, `dist/index.js` does not export the MCPServer class properly, breaking programmatic imports (e.g. `const { MCPServer } = require('opensafari-mcp')`)

## Test plan
- [x] `npm run build` succeeds
- [x] `node -e "const m = require('./dist/index.js'); console.log(typeof m.MCPServer)"` returns `function`

🤖 Generated with [Claude Code](https://claude.com/claude-code)