### PR TITLE
fix: resolve CI lint error and test timeout

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -19,7 +19,6 @@ import { setupGracefulShutdown } from '../src/reliability/graceful-shutdown';
 import { SimulatorCrashWatcher } from '../src/reliability/crash-watcher';
 import { cleanupZombieProcesses } from '../src/reliability/zombie-cleanup';
 import { setBlockedDomains } from '../src/security/domain-guard';
-import { logAuditEntry } from '../src/security/audit-logger';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from '../src/watchdog/event-loop-monitor';
 import { SimulatorMonitor } from '../src/watchdog/simulator-monitor';
 import { AuthManager } from '../src/auth';

--- a/tests/unit/xcode-check.test.ts
+++ b/tests/unit/xcode-check.test.ts
@@ -43,7 +43,7 @@ describe('checkXcodeInstallation behavioral', () => {
       const result = await checkXcodeInstallation();
       expect(typeof result.devicePortReachable).toBe('boolean');
     }
-  });
+  }, 15000);
 
   it('does not probe device port when proxy is not reachable', async () => {
     if (process.platform !== 'darwin') {
@@ -57,5 +57,5 @@ describe('checkXcodeInstallation behavioral', () => {
         expect(result.devicePort).toBeUndefined();
       }
     }
-  });
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
- Remove unused `logAuditEntry` import from `cli/index.ts` — the call was moved to `mcp-server.ts` in #181, leaving the original import dead. This causes **lint failure on all 7 open PRs**.
- Increase timeout for `xcode-check.test.ts` behavioral tests from 5s to 15s — slow ts-jest compilation on Linux CI runners causes **test timeout on all PRs**.

## Root cause
PR #178 added `import { logAuditEntry }` to `cli/index.ts` but the function was never called there. ESLint `no-unused-vars` rule flags this as an error, failing the lint step. Since all open PRs branch from `develop`, they all inherit this failure.

## Impact
Fixes CI for all 7 open PRs (#181–#187) once merged and branches are rebased.

## Test plan
- [x] `npx eslint 'cli/**/*.ts' --quiet` — zero errors
- [x] `npm run build` — compiles successfully
- [x] `npx jest tests/unit/xcode-check.test.ts` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)