### PR TITLE
fix: wait for proxy forwarding readiness before WebKit connection

### DIFF
--- a/src/simulator/proxy.ts
+++ b/src/simulator/proxy.ts
@@ -84,6 +84,7 @@ export class WebInspectorProxy {
         this._running = true;
         this._reusing = true;
         this.registerRefSync();
+        await this.waitForForwarding();
         return;
       }
       throw new Error(
@@ -146,6 +147,7 @@ export class WebInspectorProxy {
     });
 
     await this.waitForReady();
+    await this.waitForForwarding();
   }
 
   /** Stop the proxy process gracefully with SIGKILL fallback. */
@@ -271,6 +273,24 @@ export class WebInspectorProxy {
       await new Promise(r => setTimeout(r, 500));
     }
     throw new Error(`WebInspectorProxy did not become ready within ${timeout}ms`);
+  }
+
+  /**
+   * Poll the first device forwarding port until it returns a valid JSON target list.
+   * ios_webkit_debug_proxy requires ~10s initialization before page forwarding is available.
+   * If the timeout expires we log a warning instead of throwing — Safari may not be open yet.
+   */
+  private async waitForForwarding(timeout = 15000): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      try {
+        const body = await this.httpGet(`http://localhost:${this._port}/json`);
+        if (body.startsWith('[')) return; // Valid JSON array = targets available
+      } catch { /* retry */ }
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    // Don't throw — forwarding may not be available if no Safari is open yet
+    console.error('[WebInspectorProxy] Forwarding port not ready within timeout — Safari may not be open');
   }
 
   private isPortInUse(port: number): Promise<boolean> {

--- a/src/tools/device-boot.ts
+++ b/src/tools/device-boot.ts
@@ -48,20 +48,9 @@ export function registerDeviceBootTool(server: MCPServer): void {
               await new Promise(r => setTimeout(r, 2000));
             }
           }
-          // Retry WebKit connection — Safari may need time to register with WebInspector
+          // Connect to WebKit with retries — Safari may need time to register with WebInspector
           const client = new WebKitClient({ host: 'localhost', port: proxy.port });
-          let connectRetries = 5;
-          while (connectRetries > 0) {
-            await new Promise(r => setTimeout(r, 2000));
-            try {
-              await client.connect();
-              break;
-            } catch (connErr) {
-              connectRetries--;
-              if (connectRetries === 0) throw connErr;
-              console.error(`[device_boot] WebKit connect attempt failed, retrying (${connectRetries} left)...`);
-            }
-          }
+          await client.connect({ retries: 5, retryDelay: 2000 });
           setWebKitClient(client);
         } catch (err) {
           console.error(`[device_boot] WebKit connection failed (proxy running, tools may not work): ${err}`);

--- a/src/webkit/client.ts
+++ b/src/webkit/client.ts
@@ -72,18 +72,34 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
 
   // ========== Lifecycle ==========
 
-  async connect(): Promise<void> {
-    const targets = await this.listTargets();
-    const targetIndex = this.options.targetIndex ?? 0;
+  async connect(options?: { retries?: number; retryDelay?: number }): Promise<void> {
+    const maxRetries = options?.retries ?? 0;
+    const delay = options?.retryDelay ?? 2000;
 
-    if (targets.length === 0) {
-      throw new ConnectionError(
-        'No Safari targets found. Is Safari open in the simulator?',
-      );
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const targets = await this.listTargets();
+        const targetIndex = this.options.targetIndex ?? 0;
+
+        if (targets.length === 0) {
+          throw new ConnectionError(
+            'No Safari targets found. Is Safari open in the simulator?',
+          );
+        }
+
+        const target = targets[Math.min(targetIndex, targets.length - 1)];
+        await this.connectToTarget(target.webSocketDebuggerUrl);
+        return;
+      } catch (err) {
+        lastError = err as Error;
+        if (attempt < maxRetries) {
+          console.error(`[WebKitClient] Connect attempt ${attempt + 1} failed, retrying in ${delay}ms...`);
+          await new Promise(r => setTimeout(r, delay));
+        }
+      }
     }
-
-    const target = targets[Math.min(targetIndex, targets.length - 1)];
-    await this.connectToTarget(target.webSocketDebuggerUrl);
+    throw lastError ?? new Error('WebKit connection failed');
   }
 
   async disconnect(): Promise<void> {


### PR DESCRIPTION
## Summary
- Add `waitForForwarding()` to `WebInspectorProxy` that polls the forwarding port after proxy startup, addressing the ~10s initialization delay in ios_webkit_debug_proxy before page forwarding is available
- Add optional `retries` and `retryDelay` parameters to `WebKitClient.connect()`, encapsulating retry logic within the client itself
- Simplify `device-boot.ts` by replacing the manual retry loop with the new built-in `connect({ retries: 5, retryDelay: 2000 })` call

Closes #190

## Test plan
- [ ] Boot a fresh simulator and verify proxy forwarding becomes available without manual delays
- [ ] Verify `device_boot` tool connects to WebKit successfully on first attempt after proxy readiness
- [ ] Verify reused proxy path also waits for forwarding readiness
- [ ] Confirm `npm run build` compiles without errors
- [ ] Confirm `npm test` passes all 156 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)