### PR TITLE
fix: prevent zombie cleanup from killing other sessions' simulators

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -38,6 +38,7 @@ program
   .option('--all-tools', 'Expose all tool tiers immediately')
   .option('--blocked-domains <domains>', 'Block navigation to these domains')
   .option('--audit-log', 'Enable tool call audit logging')
+  .option('--no-zombie-cleanup', 'Disable periodic zombie simulator cleanup')
   .action(async (options) => {
     const server = new MCPServer();
     registerAllTools(server);
@@ -81,11 +82,13 @@ program
     }).catch(() => {});
 
     // Periodic zombie cleanup: compare booted simulators against pool
-    startPeriodicCleanup(() => {
-      const ids = new Set<string>();
-      for (const sim of pool.getAll()) ids.add(sim.device.udid);
-      return ids;
-    });
+    if (options.zombieCleanup !== false) {
+      startPeriodicCleanup(() => {
+        const ids = new Set<string>();
+        for (const sim of pool.getAll()) ids.add(sim.device.udid);
+        return ids;
+      });
+    }
 
     // Wire domain guard
     if (options.blockedDomains) {

--- a/src/reliability/index.ts
+++ b/src/reliability/index.ts
@@ -1,3 +1,10 @@
 export { SimulatorCrashWatcher } from './crash-watcher';
 export { setupGracefulShutdown } from './graceful-shutdown';
-export { cleanupZombieProcesses, startPeriodicCleanup, stopPeriodicCleanup } from './zombie-cleanup';
+export {
+  cleanupZombieProcesses,
+  startPeriodicCleanup,
+  stopPeriodicCleanup,
+  registerManagedDevices,
+  unregisterManagedDevices,
+  getAllManagedDeviceIds,
+} from './zombie-cleanup';

--- a/src/reliability/zombie-cleanup.ts
+++ b/src/reliability/zombie-cleanup.ts
@@ -1,7 +1,119 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const execFileAsync = promisify(execFile);
+
+/** Path to the shared device registry used for cross-process coordination. */
+const REGISTRY_PATH = '/tmp/opensafari-managed-devices.json';
+
+/**
+ * Shape of the shared device registry file.
+ * Each key is a PID (stringified) that owns a set of simulator UDIDs.
+ */
+export interface DeviceRegistry {
+  [pid: string]: {
+    udids: string[];
+    startedAt: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared device registry helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the current process's managed device UDIDs in the shared registry.
+ * Safe to call multiple times; replaces the entry for the current PID.
+ */
+export function registerManagedDevices(udids: string[]): void {
+  try {
+    const registry = readRegistry();
+    registry[String(process.pid)] = {
+      udids,
+      startedAt: new Date().toISOString(),
+    };
+    writeRegistry(registry);
+    console.error(`[DeviceRegistry] Registered ${udids.length} device(s) for PID ${process.pid}`);
+  } catch (err) {
+    console.error(`[DeviceRegistry] Failed to register devices: ${err}`);
+  }
+}
+
+/**
+ * Remove the current process from the shared registry (e.g. on shutdown).
+ */
+export function unregisterManagedDevices(): void {
+  try {
+    const registry = readRegistry();
+    delete registry[String(process.pid)];
+    writeRegistry(registry);
+    console.error(`[DeviceRegistry] Unregistered PID ${process.pid}`);
+  } catch (err) {
+    console.error(`[DeviceRegistry] Failed to unregister devices: ${err}`);
+  }
+}
+
+/**
+ * Return the set of all device UDIDs currently claimed by any live process.
+ * Stale entries (dead PIDs) are pruned automatically.
+ */
+export function getAllManagedDeviceIds(): Set<string> {
+  const registry = readRegistry();
+  const managed = new Set<string>();
+  const stalePids: string[] = [];
+
+  for (const pidStr of Object.keys(registry)) {
+    const pid = Number(pidStr);
+    if (isProcessAlive(pid)) {
+      for (const udid of registry[pidStr].udids) {
+        managed.add(udid);
+      }
+    } else {
+      stalePids.push(pidStr);
+    }
+  }
+
+  // Prune stale entries
+  if (stalePids.length > 0) {
+    for (const pid of stalePids) {
+      delete registry[pid];
+    }
+    writeRegistry(registry);
+    console.error(`[DeviceRegistry] Pruned ${stalePids.length} stale PID(s)`);
+  }
+
+  return managed;
+}
+
+function readRegistry(): DeviceRegistry {
+  try {
+    const data = fs.readFileSync(REGISTRY_PATH, 'utf-8');
+    return JSON.parse(data) as DeviceRegistry;
+  } catch {
+    return {};
+  }
+}
+
+function writeRegistry(registry: DeviceRegistry): void {
+  const dir = path.dirname(REGISTRY_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2), 'utf-8');
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Zombie cleanup logic
+// ---------------------------------------------------------------------------
 
 /**
  * Find and clean up orphaned simulator processes.
@@ -35,7 +147,8 @@ async function detectOrphanedProcesses(): Promise<number> {
 }
 
 /**
- * Runtime cleanup: shut down booted simulators not managed by our pool.
+ * Runtime cleanup: shut down booted simulators not managed by our pool
+ * AND not managed by any other live process in the shared registry.
  * Uses `simctl shutdown` for safe teardown instead of raw process kills.
  */
 async function cleanupOrphanedSimulators(knownDeviceIds: Set<string>): Promise<number> {
@@ -44,9 +157,13 @@ async function cleanupOrphanedSimulators(knownDeviceIds: Set<string>): Promise<n
     const { stdout } = await execFileAsync('xcrun', ['simctl', 'list', 'devices', 'booted', '--json']);
     const data = JSON.parse(stdout);
 
+    // Merge local pool IDs with cross-process registry IDs
+    const registeredIds = getAllManagedDeviceIds();
+    const protectedIds = new Set([...knownDeviceIds, ...registeredIds]);
+
     for (const runtime of Object.values(data.devices) as any[]) {
       for (const device of runtime) {
-        if (device.state === 'Booted' && !knownDeviceIds.has(device.udid)) {
+        if (device.state === 'Booted' && !protectedIds.has(device.udid)) {
           try {
             await execFileAsync('xcrun', ['simctl', 'shutdown', device.udid]);
             cleaned++;
@@ -64,30 +181,51 @@ async function cleanupOrphanedSimulators(knownDeviceIds: Set<string>): Promise<n
 }
 
 let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+let cleanupGraceTimeout: ReturnType<typeof setTimeout> | null = null;
 
 /**
  * Start periodic zombie cleanup that compares booted simulators against
  * the pool's known devices and shuts down orphans.
+ *
+ * @param graceMs - Delay before the first cleanup run (default 30 000 ms).
+ *   This gives other MCP sessions time to register their devices after boot.
  */
 export function startPeriodicCleanup(
   getKnownDeviceIds: () => Set<string>,
   intervalMs = 60000,
+  graceMs = 30000,
 ): void {
   stopPeriodicCleanup();
-  cleanupInterval = setInterval(async () => {
+
+  const runCleanup = async () => {
     const ids = getKnownDeviceIds();
     const cleaned = await cleanupZombieProcesses(ids);
     if (cleaned > 0) {
       console.error(`[ZombieCleanup] Periodic cleanup removed ${cleaned} orphaned simulator(s)`);
     }
-  }, intervalMs);
-  cleanupInterval.unref();
+  };
+
+  // Delay the first cleanup to allow sibling sessions to register devices
+  cleanupGraceTimeout = setTimeout(() => {
+    cleanupGraceTimeout = null;
+    // Run once immediately after grace period, then on interval
+    runCleanup().catch(() => {});
+    cleanupInterval = setInterval(() => {
+      runCleanup().catch(() => {});
+    }, intervalMs);
+    cleanupInterval.unref();
+  }, graceMs);
+  (cleanupGraceTimeout as any).unref?.();
 }
 
 /**
  * Stop periodic zombie cleanup.
  */
 export function stopPeriodicCleanup(): void {
+  if (cleanupGraceTimeout) {
+    clearTimeout(cleanupGraceTimeout);
+    cleanupGraceTimeout = null;
+  }
   if (cleanupInterval) {
     clearInterval(cleanupInterval);
     cleanupInterval = null;

--- a/src/simulator/pool.ts
+++ b/src/simulator/pool.ts
@@ -14,8 +14,12 @@ import {
   DEFAULT_MEMORY_KILL_MB,
   DEFAULT_RESOURCE_CHECK_INTERVAL_MS,
 } from '../config/defaults';
+import { registerManagedDevices, unregisterManagedDevices } from '../reliability/zombie-cleanup';
 
 const execFileAsync = promisify(execFile);
+
+/** Ensures the process exit handler is registered only once across all pool instances. */
+let exitHandlerRegistered = false;
 
 export interface PooledSimulator {
   device: SimulatorDevice;
@@ -55,6 +59,14 @@ export class SimulatorPool extends EventEmitter {
     this.idleTimeout = DEFAULT_IDLE_SHUTDOWN_TIMEOUT_MS;
     this.memoryWarnMB = DEFAULT_MEMORY_WARN_MB;
     this.memoryKillMB = DEFAULT_MEMORY_KILL_MB;
+
+    // Ensure the shared device registry is cleaned up when the process exits
+    if (!exitHandlerRegistered) {
+      exitHandlerRegistered = true;
+      process.on('exit', () => {
+        unregisterManagedDevices();
+      });
+    }
   }
 
   async checkResources(count: number): Promise<void> {
@@ -113,6 +125,10 @@ export class SimulatorPool extends EventEmitter {
       results.push(...batchResults);
     }
 
+    // Register all booted devices in the shared cross-process registry
+    const udids = results.map(r => r.device.udid);
+    registerManagedDevices(udids);
+
     return results;
   }
 
@@ -153,6 +169,9 @@ export class SimulatorPool extends EventEmitter {
     );
     this.devicePorts.clear();
     this.nextPort = this.webkitBasePort;
+
+    // Remove all devices from the shared cross-process registry
+    unregisterManagedDevices();
   }
 
   async shutdownOne(deviceId: string): Promise<void> {
@@ -162,6 +181,14 @@ export class SimulatorPool extends EventEmitter {
     try { await this.manager.shutdown(deviceId); } catch { /* */ }
     this.pool.delete(deviceId);
     this.devicePorts.delete(deviceId);
+
+    // Update the shared registry with remaining devices
+    const remainingUdids = Array.from(this.pool.keys());
+    if (remainingUdids.length > 0) {
+      registerManagedDevices(remainingUdids);
+    } else {
+      unregisterManagedDevices();
+    }
   }
 
   startIdleMonitor(): void {


### PR DESCRIPTION
## Summary
- Add shared device registry (`/tmp/opensafari-managed-devices.json`) so each MCP process tracks which simulator UDIDs it owns, preventing cross-session orphan kills
- Orphan cleanup now merges local pool IDs with the cross-process registry before deciding what to shut down, with automatic stale-PID pruning
- Add 30-second startup grace period before the first periodic cleanup run, giving sibling sessions time to register their devices
- Add `--no-zombie-cleanup` CLI flag to disable periodic cleanup entirely while keeping startup detection
- Pool integration: `bootAll()` registers devices, `shutdownAll()`/`shutdownOne()` update/unregister, `process.on('exit')` ensures cleanup

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — all 156 tests pass
- [x] No `MaxListenersExceededWarning` in test output
- [ ] Manual: start two `opensafari serve` instances, verify neither kills the other's simulators
- [ ] Manual: kill one instance, verify the other's periodic cleanup prunes the dead PID from the registry
- [ ] Manual: `--no-zombie-cleanup` flag skips periodic cleanup but startup detection still runs

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)