### PR TITLE
fix: register device_boot simulators in zombie cleanup registry

### DIFF
--- a/src/reliability/index.ts
+++ b/src/reliability/index.ts
@@ -5,6 +5,7 @@ export {
   startPeriodicCleanup,
   stopPeriodicCleanup,
   registerManagedDevices,
+  addManagedDevice,
   unregisterManagedDevices,
   getAllManagedDeviceIds,
 } from './zombie-cleanup';

--- a/src/reliability/zombie-cleanup.ts
+++ b/src/reliability/zombie-cleanup.ts
@@ -42,6 +42,33 @@ export function registerManagedDevices(udids: string[]): void {
 }
 
 /**
+ * Add a single device UDID to the current process's registry entry.
+ * Unlike registerManagedDevices() which replaces the entire list, this
+ * appends without overwriting devices already registered by the same process
+ * (e.g. devices managed by SimulatorPool).
+ */
+export function addManagedDevice(udid: string): void {
+  try {
+    const registry = readRegistry();
+    const entry = registry[String(process.pid)];
+    if (entry) {
+      if (!entry.udids.includes(udid)) {
+        entry.udids.push(udid);
+      }
+    } else {
+      registry[String(process.pid)] = {
+        udids: [udid],
+        startedAt: new Date().toISOString(),
+      };
+    }
+    writeRegistry(registry);
+    console.error(`[DeviceRegistry] Added device ${udid} for PID ${process.pid}`);
+  } catch (err) {
+    console.error(`[DeviceRegistry] Failed to add device: ${err}`);
+  }
+}
+
+/**
  * Remove the current process from the shared registry (e.g. on shutdown).
  */
 export function unregisterManagedDevices(): void {
@@ -106,7 +133,12 @@ function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err: unknown) {
+    // EPERM means the process exists but we lack permission to signal it —
+    // treat it as alive. Only ESRCH ("no such process") means truly dead.
+    if (err && typeof err === 'object' && 'code' in err && (err as NodeJS.ErrnoException).code === 'EPERM') {
+      return true;
+    }
     return false;
   }
 }

--- a/src/tools/device-boot.ts
+++ b/src/tools/device-boot.ts
@@ -2,6 +2,7 @@ import { MCPServer, getWebKitClient, setWebKitClient } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { getSharedProxy } from '../simulator/proxy';
 import { WebKitClient } from '../webkit/client';
+import { addManagedDevice } from '../reliability/zombie-cleanup';
 
 export function registerDeviceBootTool(server: MCPServer): void {
   server.registerTool(
@@ -19,6 +20,10 @@ export function registerDeviceBootTool(server: MCPServer): void {
     async (_sessionId: string, params: Record<string, unknown>) => {
       const manager = new SimulatorManager();
       const device = await manager.boot(params.device as string);
+
+      // Register the booted device in the shared zombie cleanup registry so
+      // other MCP sessions' periodic cleanup won't shut it down as an orphan.
+      addManagedDevice(device.udid);
 
       // Auto-start the WebInspector proxy so WebKit debugging is available
       let proxyStatus: { running: boolean; pid: number | null } = { running: false, pid: null };


### PR DESCRIPTION
## Summary

- **`device_boot` now registers booted devices** in the shared zombie cleanup registry via a new `addManagedDevice()` helper, preventing other MCP sessions from shutting them down as orphans
- **`isProcessAlive()` now treats EPERM as "alive"** — on macOS, `process.kill(pid, 0)` throws EPERM for processes we lack permission to signal, but only ESRCH means truly dead
- New `addManagedDevice()` appends a single UDID without overwriting existing pool-managed devices

## Problem

When `device_boot` is called, it uses `SimulatorManager` directly (not `SimulatorPool`), so `registerManagedDevices()` is never called. Other opensafari MCP sessions' periodic zombie cleanup detects the booted simulator as an "orphan" and shuts it down within ~5 seconds.

Additionally, `isProcessAlive()` treated EPERM errors as "process dead", which caused registry entries belonging to processes owned by other users (or system processes like PID 1) to be incorrectly pruned.

## Changes

| File | Change |
|---|---|
| `src/tools/device-boot.ts` | Import and call `addManagedDevice(device.udid)` after boot |
| `src/reliability/zombie-cleanup.ts` | Add `addManagedDevice()` helper that appends without overwriting |
| `src/reliability/zombie-cleanup.ts` | Fix `isProcessAlive()` to return `true` on EPERM |
| `src/reliability/index.ts` | Export new `addManagedDevice` function |

## Test plan

- [x] `npm run build` compiles successfully (both server + cli)
- [x] `npm test` — 156 tests pass, 10 suites
- [ ] Manual: boot a device via `device_boot`, verify it stays alive >30s with other MCP sessions running
- [ ] Manual: verify `/tmp/opensafari-managed-devices.json` contains the booted device UDID

Ref #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)