### PR TITLE
feat: add structured JSON report with QAReport schema

### DIFF
--- a/src/qa/index.ts
+++ b/src/qa/index.ts
@@ -5,5 +5,7 @@ export type { AuditReport, AuditSummary } from './audit';
 export { generateAuditMarkdown } from './report-markdown';
 export { generateAuditJUnit } from './report-junit';
 export type { JUnitOptions } from './report-junit';
+export { generateAuditJSON } from './report-json';
+export type { QAReport, QAReportDetector, QAReportDevice, QAReportIssue } from './report-json';
 export { QAHistory } from './history';
 export type { RegressionReport } from './history';

--- a/src/qa/report-json.ts
+++ b/src/qa/report-json.ts
@@ -1,0 +1,97 @@
+import { AuditReport } from './audit';
+import { DetectorResult, DetectorIssue } from './types';
+
+export interface QAReportDevice {
+  name: string;
+  viewport: { width: number; height: number };
+}
+
+export interface QAReportIssue {
+  selector: string;
+  element?: string;
+  problem: string;
+  fix: string;
+}
+
+export interface QAReportDetector {
+  name: string;
+  status: 'pass' | 'fail' | 'error';
+  severity: string;
+  scanned: number;
+  issueCount: number;
+  issues: QAReportIssue[];
+  error?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface QAReport {
+  version: string;
+  timestamp: string;
+  url: string;
+  device: QAReportDevice;
+  duration: number;
+  score: number;
+  detectors: QAReportDetector[];
+  summary: {
+    total: number;
+    pass: number;
+    fail: number;
+    error: number;
+    issues: {
+      critical: number;
+      high: number;
+      medium: number;
+      low: number;
+    };
+  };
+}
+
+function mapIssue(issue: DetectorIssue): QAReportIssue {
+  return {
+    selector: issue.selector,
+    ...(issue.element ? { element: issue.element } : {}),
+    problem: issue.problem,
+    fix: issue.fix,
+  };
+}
+
+function mapDetector(det: DetectorResult): QAReportDetector {
+  const result: QAReportDetector = {
+    name: det.detector,
+    status: det.severity === 'error' ? 'error' : det.passed ? 'pass' : 'fail',
+    severity: det.severity,
+    scanned: det.totalScanned,
+    issueCount: det.issueCount,
+    issues: det.issues.map(mapIssue),
+  };
+  if (det.error) result.error = det.error;
+  if (det.metadata) result.metadata = det.metadata;
+  return result;
+}
+
+export function generateAuditJSON(report: AuditReport): QAReport {
+  return {
+    version: '1.0.0',
+    timestamp: report.timestamp,
+    url: report.url,
+    device: {
+      name: report.device,
+      viewport: { width: report.viewport.w, height: report.viewport.h },
+    },
+    duration: report.duration,
+    score: report.score,
+    detectors: report.detectors.map(mapDetector),
+    summary: {
+      total: report.detectors.length,
+      pass: report.detectors.filter(d => d.passed).length,
+      fail: report.detectors.filter(d => !d.passed && d.severity !== 'error').length,
+      error: report.detectors.filter(d => d.severity === 'error').length,
+      issues: {
+        critical: report.summary.critical,
+        high: report.summary.high,
+        medium: report.summary.medium,
+        low: report.summary.low,
+      },
+    },
+  };
+}

--- a/tests/unit/report-json.test.ts
+++ b/tests/unit/report-json.test.ts
@@ -1,0 +1,168 @@
+import { generateAuditJSON, QAReport } from '../../src/qa/report-json';
+import { AuditReport } from '../../src/qa/audit';
+
+function makeReport(overrides?: Partial<AuditReport>): AuditReport {
+  return {
+    url: 'https://example.com',
+    device: 'iPhone 16 Pro',
+    viewport: { w: 393, h: 852 },
+    timestamp: '2026-03-30T12:00:00.000Z',
+    duration: 2400,
+    score: 85,
+    summary: { totalIssues: 3, critical: 0, high: 2, medium: 1, low: 0, passed: 10, failed: 3, errors: 0 },
+    detectors: [
+      {
+        detector: 'touch-targets',
+        severity: 'high',
+        issues: [
+          { selector: 'button.submit', problem: '32x28px below 44px minimum', fix: 'Increase size' },
+          { selector: 'a.nav-link', problem: '40x20px below 44px minimum', fix: 'Increase size' },
+        ],
+        passed: false,
+        totalScanned: 20,
+        issueCount: 2,
+      },
+      {
+        detector: 'auto-zoom',
+        severity: 'pass',
+        issues: [],
+        passed: true,
+        totalScanned: 5,
+        issueCount: 0,
+      },
+      {
+        detector: 'hover-only',
+        severity: 'medium',
+        issues: [
+          { selector: '.dropdown', element: '<div class="dropdown">', problem: 'Hover-only', fix: 'Add touch' },
+        ],
+        passed: false,
+        totalScanned: 10,
+        issueCount: 1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('generateAuditJSON', () => {
+  let result: QAReport;
+
+  beforeAll(() => {
+    result = generateAuditJSON(makeReport());
+  });
+
+  it('includes schema version', () => {
+    expect(result.version).toBe('1.0.0');
+  });
+
+  it('maps timestamp and url', () => {
+    expect(result.timestamp).toBe('2026-03-30T12:00:00.000Z');
+    expect(result.url).toBe('https://example.com');
+  });
+
+  it('maps device with normalized viewport keys', () => {
+    expect(result.device).toEqual({
+      name: 'iPhone 16 Pro',
+      viewport: { width: 393, height: 852 },
+    });
+  });
+
+  it('preserves score and duration', () => {
+    expect(result.score).toBe(85);
+    expect(result.duration).toBe(2400);
+  });
+
+  it('maps detector status correctly', () => {
+    expect(result.detectors[0].status).toBe('fail');  // touch-targets
+    expect(result.detectors[1].status).toBe('pass');  // auto-zoom
+    expect(result.detectors[2].status).toBe('fail');  // hover-only
+  });
+
+  it('maps detector names', () => {
+    expect(result.detectors.map(d => d.name)).toEqual([
+      'touch-targets', 'auto-zoom', 'hover-only',
+    ]);
+  });
+
+  it('includes issues with correct fields', () => {
+    const touchIssues = result.detectors[0].issues;
+    expect(touchIssues).toHaveLength(2);
+    expect(touchIssues[0]).toEqual({
+      selector: 'button.submit',
+      problem: '32x28px below 44px minimum',
+      fix: 'Increase size',
+    });
+  });
+
+  it('includes element field when present', () => {
+    const hoverIssues = result.detectors[2].issues;
+    expect(hoverIssues[0].element).toBe('<div class="dropdown">');
+  });
+
+  it('omits element field when absent', () => {
+    const touchIssues = result.detectors[0].issues;
+    expect(touchIssues[0]).not.toHaveProperty('element');
+  });
+
+  it('produces correct summary counts', () => {
+    expect(result.summary).toEqual({
+      total: 3,
+      pass: 1,
+      fail: 2,
+      error: 0,
+      issues: { critical: 0, high: 2, medium: 1, low: 0 },
+    });
+  });
+
+  it('handles error severity detectors', () => {
+    const report = makeReport({
+      detectors: [
+        {
+          detector: 'orientation',
+          severity: 'error',
+          issues: [],
+          passed: false,
+          totalScanned: 0,
+          issueCount: 0,
+          error: 'Simulator not available',
+        },
+      ],
+    });
+    const json = generateAuditJSON(report);
+    expect(json.detectors[0].status).toBe('error');
+    expect(json.detectors[0].error).toBe('Simulator not available');
+    expect(json.summary.error).toBe(1);
+  });
+
+  it('includes metadata when present', () => {
+    const report = makeReport({
+      detectors: [
+        {
+          detector: 'touch-targets',
+          severity: 'high',
+          issues: [],
+          passed: false,
+          totalScanned: 5,
+          issueCount: 0,
+          metadata: { threshold: 44 },
+        },
+      ],
+    });
+    const json = generateAuditJSON(report);
+    expect(json.detectors[0].metadata).toEqual({ threshold: 44 });
+  });
+
+  it('handles empty detectors', () => {
+    const json = generateAuditJSON(makeReport({ detectors: [] }));
+    expect(json.detectors).toEqual([]);
+    expect(json.summary.total).toBe(0);
+  });
+
+  it('produces valid JSON when serialized', () => {
+    const serialized = JSON.stringify(result);
+    const parsed = JSON.parse(serialized);
+    expect(parsed.version).toBe('1.0.0');
+    expect(parsed.detectors).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `generateAuditJSON()` in `src/qa/report-json.ts` producing a versioned, structured JSON report
- Defines `QAReport` interface with normalized field names (`width`/`height` instead of `w`/`h`)
- Each detector maps to clear `pass`/`fail`/`error` status with severity, issues, and optional metadata
- 14 unit tests covering all edge cases

## Related Issue
Part of #204

## Test plan
- [x] 14 unit tests passing (`npx jest tests/unit/report-json.test.ts`)
- [x] Build succeeds (`npm run build`)
- [x] Validate JSON output against schema in downstream consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)