### PR TITLE
feat(auth): add domain grouping to AuthProfile (#208)

### DIFF
--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -3,11 +3,17 @@ import * as path from 'path';
 import * as os from 'os';
 import { BrowserBackend, Cookie } from '../types/browser-backend';
 
+export interface DomainGroup {
+  domain: string;
+  cookies: Cookie[];
+}
+
 export interface AuthProfile {
   site: string;
   savedAt: string;
   currentUrl: string;
-  cookies: Cookie[];
+  cookies: Cookie[];           // flat list for backward compat
+  domainGroups?: DomainGroup[]; // cookies organized by domain
   localStorage: Record<string, string>;
   sessionStorage: Record<string, string>;
 }
@@ -60,6 +66,7 @@ export class AuthManager {
       savedAt: new Date().toISOString(),
       currentUrl,
       cookies,
+      domainGroups: this.groupCookiesByDomain(cookies),
       localStorage: localStorage ?? {},
       sessionStorage: sessionStorage ?? {},
     };
@@ -96,7 +103,7 @@ export class AuthManager {
     await client.navigate({ url: data.currentUrl ?? 'https://' + site, waitUntil: 'load' });
   }
 
-  async list(): Promise<Array<{ site: string; savedAt: string; cookieCount: number }>> {
+  async list(): Promise<Array<{ site: string; savedAt: string; cookieCount: number; domains: string[] }>> {
     try {
       const files = await fs.readdir(this.authDir);
       const profiles = [];
@@ -104,7 +111,10 @@ export class AuthManager {
         if (!f.endsWith('.json')) continue;
         try {
           const data = JSON.parse(await fs.readFile(path.join(this.authDir, f), 'utf-8')) as AuthProfile;
-          profiles.push({ site: data.site, savedAt: data.savedAt, cookieCount: data.cookies.length });
+          const domains = data.domainGroups
+            ? data.domainGroups.map(g => g.domain)
+            : [...new Set(data.cookies.map(c => c.domain.startsWith('.') ? c.domain.slice(1) : c.domain))];
+          profiles.push({ site: data.site, savedAt: data.savedAt, cookieCount: data.cookies.length, domains });
         } catch {
           // Skip corrupted files
         }
@@ -143,6 +153,16 @@ export class AuthManager {
   async loadProfile(site: string): Promise<AuthProfile> {
     const filePath = path.join(this.authDir, this.sanitizeSite(site) + '.json');
     return JSON.parse(await fs.readFile(filePath, 'utf-8')) as AuthProfile;
+  }
+
+  private groupCookiesByDomain(cookies: Cookie[]): DomainGroup[] {
+    const groups = new Map<string, Cookie[]>();
+    for (const cookie of cookies) {
+      const domain = cookie.domain.startsWith('.') ? cookie.domain.slice(1) : cookie.domain;
+      if (!groups.has(domain)) groups.set(domain, []);
+      groups.get(domain)!.push(cookie);
+    }
+    return Array.from(groups.entries()).map(([domain, cookies]) => ({ domain, cookies }));
   }
 
   private sanitizeSite(site: string): string {

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -145,6 +145,54 @@ describe('AuthManager: save/list/delete lifecycle', () => {
     expect(sites).toContain('gamma.com');
   });
 
+  test('saved profile includes domainGroups', async () => {
+    await authManager.save(TEST_SITE, mockClient);
+    const profile = await authManager.loadProfile(TEST_SITE);
+
+    expect(profile.domainGroups).toBeDefined();
+    expect(Array.isArray(profile.domainGroups)).toBe(true);
+    expect(profile.domainGroups!.length).toBeGreaterThan(0);
+    expect(profile.domainGroups![0]).toHaveProperty('domain');
+    expect(profile.domainGroups![0]).toHaveProperty('cookies');
+  });
+
+  test('domainGroups correctly groups cookies by domain', async () => {
+    // Create a mock client that returns cookies from multiple domains
+    const multiDomainClient = {
+      ...createMockClient(),
+      getCookies: async () => [
+        { name: 'session', value: 'abc', domain: '.example.com', path: '/', expires: Date.now() / 1000 + 3600, httpOnly: true, secure: true },
+        { name: 'token', value: 'xyz', domain: '.auth0.com', path: '/', expires: Date.now() / 1000 + 3600, httpOnly: true, secure: true },
+        { name: 'pref', value: 'dark', domain: '.example.com', path: '/', expires: Date.now() / 1000 + 3600, httpOnly: false, secure: false },
+      ],
+    } as unknown as BrowserBackend;
+
+    await authManager.save('multi-domain-test.com', multiDomainClient);
+    const profile = await authManager.loadProfile('multi-domain-test.com');
+
+    expect(profile.domainGroups).toBeDefined();
+    expect(profile.domainGroups!.length).toBe(2);
+
+    const exampleGroup = profile.domainGroups!.find(g => g.domain === 'example.com');
+    const auth0Group = profile.domainGroups!.find(g => g.domain === 'auth0.com');
+
+    expect(exampleGroup).toBeDefined();
+    expect(exampleGroup!.cookies.length).toBe(2);
+    expect(auth0Group).toBeDefined();
+    expect(auth0Group!.cookies.length).toBe(1);
+  });
+
+  test('list() returns domains for each profile', async () => {
+    await authManager.save(TEST_SITE, mockClient);
+    const profiles = await authManager.list();
+
+    const profile = profiles.find(p => p.site === TEST_SITE);
+    expect(profile).toBeDefined();
+    expect(profile!.domains).toBeDefined();
+    expect(Array.isArray(profile!.domains)).toBe(true);
+    expect(profile!.domains.length).toBeGreaterThan(0);
+  });
+
   test('checkExpiry detects non-expired cookies', async () => {
     await authManager.save(TEST_SITE, mockClient);
     const expiry = await authManager.checkExpiry(TEST_SITE);


### PR DESCRIPTION
## Summary
- Add `DomainGroup` interface and `domainGroups` field to `AuthProfile` for organizing cookies by domain, supporting SSO/OAuth flows with multi-domain cookies
- Add private `groupCookiesByDomain()` helper that normalizes leading-dot domains and groups cookies into `DomainGroup[]`
- Update `list()` to return a `domains` string array per profile, with backward-compatible fallback for profiles saved without `domainGroups`
- Add 3 integration tests covering domain group creation, multi-domain grouping correctness, and `list()` domains field

## Test plan
- [x] `npm run build` compiles without errors
- [x] All 10 auth integration tests pass (7 existing + 3 new)
- [ ] Verify backward compatibility: restoring a profile saved before this change still works (flat `cookies` array unchanged)

Closes #208 (PR 1 of series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)