### PR TITLE
feat(auth): add multi-domain cookie capture to auth_save (#208)

### DIFF
--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -13,6 +13,15 @@ export function registerAuthTools(server: MCPServer): void {
         type: 'object' as const,
         properties: {
           site: { type: 'string', description: 'Site domain to save auth for (e.g. "github.com")' },
+          additionalDomains: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Additional domains to capture cookies for (e.g. SSO/OAuth providers like "auth0.com")',
+          },
+          captureAll: {
+            type: 'boolean',
+            description: 'Capture all cookies regardless of domain (recommended for complex SSO/OAuth flows)',
+          },
         },
         required: ['site'],
       },
@@ -23,16 +32,32 @@ export function registerAuthTools(server: MCPServer): void {
         return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
       try {
         const site = params.site as string;
-        const cookies = await client.getCookies();
-        const domainCookies = cookies.filter((c: Cookie) => {
-          const cd = c.domain.startsWith('.') ? c.domain.slice(1) : c.domain;
-          return cd === site || site.endsWith('.' + cd);
-        });
-        if (domainCookies.length === 0) {
+        const additionalDomains = params.additionalDomains as string[] | undefined;
+        const captureAll = params.captureAll as boolean | undefined;
+
+        const allCookies = await client.getCookies();
+
+        let selectedCookies: Cookie[];
+        if (captureAll) {
+          selectedCookies = allCookies;
+        } else {
+          const domains = [site, ...(additionalDomains ?? [])];
+          selectedCookies = allCookies.filter((c: Cookie) => {
+            const cd = c.domain.startsWith('.') ? c.domain.slice(1) : c.domain;
+            return domains.some(d => cd === d || d.endsWith('.' + cd));
+          });
+        }
+
+        if (selectedCookies.length === 0) {
           return { content: [{ type: 'text' as const, text: `Error: No cookies found for domain "${site}"` }], isError: true };
         }
-        const filePath = await authManager.save(site, client, domainCookies);
-        return { content: [{ type: 'text' as const, text: JSON.stringify({ saved: true, site, cookieCount: domainCookies.length, filePath }) }] };
+
+        const filePath = await authManager.save(site, client, selectedCookies);
+        const cookieDomains = [...new Set(selectedCookies.map(c => {
+          const d = c.domain.startsWith('.') ? c.domain.slice(1) : c.domain;
+          return d;
+        }))];
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ saved: true, site, cookieCount: selectedCookies.length, domains: cookieDomains, filePath }) }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };

--- a/tests/unit/auth-tools-verification.test.ts
+++ b/tests/unit/auth-tools-verification.test.ts
@@ -59,6 +59,13 @@ const MOCK_COOKIES: Cookie[] = [
   { name: 'pref', value: 'dark', domain: '.example.com', path: '/', expires: Math.floor(Date.now() / 1000) + 86400, httpOnly: false, secure: false },
 ];
 
+const MULTI_DOMAIN_COOKIES: Cookie[] = [
+  { name: 'session', value: 'abc123', domain: '.example.com', path: '/', expires: Math.floor(Date.now() / 1000) + 86400, httpOnly: true, secure: true, sameSite: 'Lax' },
+  { name: 'pref', value: 'dark', domain: '.example.com', path: '/', expires: Math.floor(Date.now() / 1000) + 86400, httpOnly: false, secure: false },
+  { name: 'auth_token', value: 'sso_token_123', domain: '.auth0.com', path: '/', expires: Math.floor(Date.now() / 1000) + 86400, httpOnly: true, secure: true, sameSite: 'None' },
+  { name: 'goog_session', value: 'goog_abc', domain: '.accounts.google.com', path: '/', expires: Math.floor(Date.now() / 1000) + 86400, httpOnly: true, secure: true, sameSite: 'Lax' },
+];
+
 const MOCK_LOCAL_STORAGE: Record<string, string> = { theme: 'dark', lang: 'en' };
 
 let injectedCookies: Cookie[] = [];
@@ -134,7 +141,7 @@ describe('Auth Tools Verification — Issue #168', () => {
     try { await fs.rm(authDir, { recursive: true }); } catch { /* ok */ }
     // Clean up default auth dir profiles created during test
     const defaultDir = path.join(os.homedir(), '.opensafari', 'auth');
-    for (const f of ['example.com.json']) {
+    for (const f of ['example.com.json', 'multi-sso.com.json']) {
       try { await fs.unlink(path.join(defaultDir, f)); } catch { /* ok */ }
     }
   });
@@ -304,6 +311,61 @@ describe('Auth Tools Verification — Issue #168', () => {
       expect(example.savedAt).toBeDefined();
       // Verify savedAt is a valid ISO date
       expect(new Date(example.savedAt).toISOString()).toBe(example.savedAt);
+    });
+  });
+
+  // ====================================================================
+  // auth_save — multi-domain support (Issue #208)
+  // ====================================================================
+
+  describe('auth_save — multi-domain support', () => {
+    afterAll(async () => {
+      // Clean up multi-domain test profiles
+      const defaultDir = path.join(os.homedir(), '.opensafari', 'auth');
+      for (const f of ['multi-sso.com.json']) {
+        try { await fs.unlink(path.join(defaultDir, f)); } catch { /* ok */ }
+      }
+    });
+
+    test('captureAll=true saves cookies from all domains', async () => {
+      setWebKitClient(createMockBackend(MULTI_DOMAIN_COOKIES));
+      const res = await callTool('auth_save', { site: 'multi-sso.com', captureAll: true });
+      expect(isError(res)).toBe(false);
+      const data = JSON.parse(getResultText(res));
+      expect(data.saved).toBe(true);
+      expect(data.cookieCount).toBe(4);
+      expect(data.domains).toBeDefined();
+      expect(data.domains.length).toBe(3); // example.com, auth0.com, accounts.google.com
+    });
+
+    test('additionalDomains captures cookies from specified extra domains', async () => {
+      setWebKitClient(createMockBackend(MULTI_DOMAIN_COOKIES));
+      const res = await callTool('auth_save', {
+        site: 'example.com',
+        additionalDomains: ['auth0.com'],
+      });
+      expect(isError(res)).toBe(false);
+      const data = JSON.parse(getResultText(res));
+      expect(data.saved).toBe(true);
+      expect(data.cookieCount).toBe(3); // 2 example.com + 1 auth0.com
+      expect(data.domains).toContain('example.com');
+      expect(data.domains).toContain('auth0.com');
+      expect(data.domains).not.toContain('accounts.google.com');
+    });
+
+    test('without new params, backward compatible single-domain behavior', async () => {
+      setWebKitClient(createMockBackend(MULTI_DOMAIN_COOKIES));
+      const res = await callTool('auth_save', { site: 'example.com' });
+      expect(isError(res)).toBe(false);
+      const data = JSON.parse(getResultText(res));
+      expect(data.cookieCount).toBe(2); // only example.com cookies
+    });
+
+    test('captureAll with no cookies still returns error', async () => {
+      setWebKitClient(createMockBackend([]));
+      const res = await callTool('auth_save', { site: 'empty.com', captureAll: true });
+      expect(isError(res)).toBe(true);
+      expect(getResultText(res)).toContain('No cookies found');
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `additionalDomains` (string array) and `captureAll` (boolean) optional parameters to `auth_save` tool to support SSO/OAuth flows that set cookies across multiple domains
- Update cookie filtering logic to match against multiple domains when `additionalDomains` is provided, or skip filtering entirely when `captureAll` is true
- Include a `domains` array in the response showing unique cookie domains captured

## Test plan
- [x] `captureAll=true` captures cookies from all domains (4 cookies across 3 domains)
- [x] `additionalDomains` captures cookies from primary + specified extra domains only
- [x] Backward compatible: omitting new params preserves single-domain behavior
- [x] `captureAll` with empty cookie jar still returns error
- [x] Build compiles without errors
- [x] All 22 tests pass (18 existing + 4 new)

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)