### PR TITLE
feat: add circuit breaker pattern for device reliability

### DIFF
--- a/src/reliability/circuit-breaker.ts
+++ b/src/reliability/circuit-breaker.ts
@@ -1,0 +1,145 @@
+import { EventEmitter } from 'events';
+
+export interface CircuitBreakerOptions {
+  failureThreshold: number;
+  cooldownMs: number;
+  halfOpenMaxAttempts: number;
+}
+
+export type CircuitState = 'closed' | 'open' | 'half-open';
+
+export interface StateChangeEvent {
+  deviceId: string;
+  from: CircuitState;
+  to: CircuitState;
+  error?: Error;
+}
+
+const DEFAULT_OPTIONS: CircuitBreakerOptions = {
+  failureThreshold: 3,
+  cooldownMs: 30000,
+  halfOpenMaxAttempts: 1,
+};
+
+export class CircuitBreaker extends EventEmitter {
+  private state: CircuitState = 'closed';
+  private failureCount = 0;
+  private lastFailureTime = 0;
+  private halfOpenAttempts = 0;
+  private readonly options: CircuitBreakerOptions;
+
+  constructor(
+    private readonly deviceId: string,
+    options?: Partial<CircuitBreakerOptions>,
+  ) {
+    super();
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  getState(): CircuitState { return this.state; }
+  getFailureCount(): number { return this.failureCount; }
+  getDeviceId(): string { return this.deviceId; }
+
+  recordSuccess(): void {
+    if (this.state === 'half-open' || this.state === 'closed') {
+      const prev = this.state;
+      this.state = 'closed';
+      this.failureCount = 0;
+      this.halfOpenAttempts = 0;
+      if (prev !== 'closed') {
+        this.emit('state-change', { deviceId: this.deviceId, from: prev, to: 'closed' } as StateChangeEvent);
+      }
+    }
+  }
+
+  recordFailure(error?: Error): void {
+    this.failureCount++;
+    this.lastFailureTime = Date.now();
+
+    if (this.state === 'half-open') {
+      this.state = 'open';
+      this.halfOpenAttempts = 0;
+      this.emit('state-change', { deviceId: this.deviceId, from: 'half-open', to: 'open', error } as StateChangeEvent);
+      return;
+    }
+
+    if (this.state === 'closed' && this.failureCount >= this.options.failureThreshold) {
+      this.state = 'open';
+      this.emit('state-change', { deviceId: this.deviceId, from: 'closed', to: 'open', error } as StateChangeEvent);
+    }
+  }
+
+  isAvailable(): boolean {
+    if (this.state === 'closed') return true;
+
+    if (this.state === 'open') {
+      if (Date.now() - this.lastFailureTime >= this.options.cooldownMs) {
+        this.state = 'half-open';
+        this.halfOpenAttempts = 1;
+        this.emit('state-change', { deviceId: this.deviceId, from: 'open', to: 'half-open' } as StateChangeEvent);
+        return true;
+      }
+      return false;
+    }
+
+    if (this.halfOpenAttempts < this.options.halfOpenMaxAttempts) {
+      this.halfOpenAttempts++;
+      return true;
+    }
+    return false;
+  }
+
+  reset(): void {
+    const prev = this.state;
+    this.state = 'closed';
+    this.failureCount = 0;
+    this.halfOpenAttempts = 0;
+    this.lastFailureTime = 0;
+    if (prev !== 'closed') {
+      this.emit('state-change', { deviceId: this.deviceId, from: prev, to: 'closed' } as StateChangeEvent);
+    }
+  }
+
+  trip(): void {
+    const prev = this.state;
+    this.state = 'open';
+    this.lastFailureTime = Date.now();
+    if (prev !== 'open') {
+      this.emit('state-change', { deviceId: this.deviceId, from: prev, to: 'open' } as StateChangeEvent);
+    }
+  }
+}
+
+export class CircuitBreakerRegistry {
+  private breakers = new Map<string, CircuitBreaker>();
+  private readonly defaultOptions: Partial<CircuitBreakerOptions>;
+
+  constructor(options?: Partial<CircuitBreakerOptions>) {
+    this.defaultOptions = options ?? {};
+  }
+
+  get(deviceId: string): CircuitBreaker {
+    let cb = this.breakers.get(deviceId);
+    if (!cb) {
+      cb = new CircuitBreaker(deviceId, this.defaultOptions);
+      this.breakers.set(deviceId, cb);
+    }
+    return cb;
+  }
+
+  remove(deviceId: string): void { this.breakers.delete(deviceId); }
+
+  getAvailableDeviceIds(): string[] {
+    return [...this.breakers.entries()].filter(([, cb]) => cb.isAvailable()).map(([id]) => id);
+  }
+
+  getAllStates(): Map<string, CircuitState> {
+    const states = new Map<string, CircuitState>();
+    for (const [id, cb] of this.breakers) { states.set(id, cb.getState()); }
+    return states;
+  }
+
+  resetAll(): void {
+    for (const cb of this.breakers.values()) { cb.reset(); }
+  }
+}

--- a/tests/unit/circuit-breaker.test.ts
+++ b/tests/unit/circuit-breaker.test.ts
@@ -1,0 +1,179 @@
+import { CircuitBreaker, CircuitBreakerRegistry } from '../../src/reliability/circuit-breaker';
+import type { StateChangeEvent } from '../../src/reliability/circuit-breaker';
+
+describe('CircuitBreaker', () => {
+  beforeEach(() => { jest.useFakeTimers(); });
+  afterEach(() => { jest.useRealTimers(); });
+
+  it('starts in closed state', () => {
+    const cb = new CircuitBreaker('device-1');
+    expect(cb.getState()).toBe('closed');
+    expect(cb.getFailureCount()).toBe(0);
+    expect(cb.getDeviceId()).toBe('device-1');
+  });
+
+  it('stays closed on success', () => {
+    const cb = new CircuitBreaker('device-1');
+    cb.recordSuccess();
+    expect(cb.getState()).toBe('closed');
+  });
+
+  it('stays closed below failure threshold', () => {
+    const cb = new CircuitBreaker('device-1', { failureThreshold: 3 });
+    cb.recordFailure(new Error('fail 1'));
+    cb.recordFailure(new Error('fail 2'));
+    expect(cb.getState()).toBe('closed');
+    expect(cb.getFailureCount()).toBe(2);
+    expect(cb.isAvailable()).toBe(true);
+  });
+
+  it('opens after reaching failure threshold', () => {
+    const cb = new CircuitBreaker('device-1', { failureThreshold: 3 });
+    const changes: StateChangeEvent[] = [];
+    cb.on('state-change', (e: StateChangeEvent) => changes.push(e));
+    cb.recordFailure(new Error('1'));
+    cb.recordFailure(new Error('2'));
+    cb.recordFailure(new Error('3'));
+    expect(cb.getState()).toBe('open');
+    expect(cb.isAvailable()).toBe(false);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ from: 'closed', to: 'open' });
+  });
+
+  it('transitions to half-open after cooldown', () => {
+    const cb = new CircuitBreaker('device-1', { failureThreshold: 1, cooldownMs: 5000 });
+    const changes: StateChangeEvent[] = [];
+    cb.on('state-change', (e: StateChangeEvent) => changes.push(e));
+    cb.recordFailure();
+    expect(cb.getState()).toBe('open');
+    expect(cb.isAvailable()).toBe(false);
+    jest.advanceTimersByTime(5000);
+    expect(cb.isAvailable()).toBe(true);
+    expect(cb.getState()).toBe('half-open');
+    expect(changes).toHaveLength(2);
+    expect(changes[1]).toMatchObject({ from: 'open', to: 'half-open' });
+  });
+
+  it('returns to closed on success in half-open', () => {
+    const cb = new CircuitBreaker('device-1', { failureThreshold: 1, cooldownMs: 1000 });
+    cb.recordFailure();
+    jest.advanceTimersByTime(1000);
+    cb.isAvailable();
+    cb.recordSuccess();
+    expect(cb.getState()).toBe('closed');
+    expect(cb.getFailureCount()).toBe(0);
+  });
+
+  it('re-opens on failure in half-open', () => {
+    const cb = new CircuitBreaker('device-1', { failureThreshold: 1, cooldownMs: 1000 });
+    const changes: StateChangeEvent[] = [];
+    cb.on('state-change', (e: StateChangeEvent) => changes.push(e));
+    cb.recordFailure();
+    jest.advanceTimersByTime(1000);
+    cb.isAvailable();
+    cb.recordFailure(new Error('still broken'));
+    expect(cb.getState()).toBe('open');
+    expect(changes[changes.length - 1]).toMatchObject({ from: 'half-open', to: 'open' });
+  });
+
+  it('limits half-open attempts', () => {
+    const cb = new CircuitBreaker('device-1', { failureThreshold: 1, cooldownMs: 1000, halfOpenMaxAttempts: 1 });
+    cb.recordFailure();
+    jest.advanceTimersByTime(1000);
+    expect(cb.isAvailable()).toBe(true);
+    expect(cb.isAvailable()).toBe(false);
+  });
+
+  it('reset() returns to closed from any state', () => {
+    const cb = new CircuitBreaker('device-1', { failureThreshold: 1 });
+    const changes: StateChangeEvent[] = [];
+    cb.on('state-change', (e: StateChangeEvent) => changes.push(e));
+    cb.recordFailure();
+    cb.reset();
+    expect(cb.getState()).toBe('closed');
+    expect(cb.getFailureCount()).toBe(0);
+    expect(cb.isAvailable()).toBe(true);
+    expect(changes[changes.length - 1]).toMatchObject({ from: 'open', to: 'closed' });
+  });
+
+  it('reset() on closed state does not emit', () => {
+    const cb = new CircuitBreaker('device-1');
+    const listener = jest.fn();
+    cb.on('state-change', listener);
+    cb.reset();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('trip() force-opens circuit', () => {
+    const cb = new CircuitBreaker('device-1');
+    const changes: StateChangeEvent[] = [];
+    cb.on('state-change', (e: StateChangeEvent) => changes.push(e));
+    cb.trip();
+    expect(cb.getState()).toBe('open');
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ from: 'closed', to: 'open' });
+  });
+
+  it('trip() on already open circuit does not emit', () => {
+    const cb = new CircuitBreaker('device-1', { failureThreshold: 1 });
+    cb.recordFailure();
+    const listener = jest.fn();
+    cb.on('state-change', listener);
+    cb.trip();
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe('CircuitBreakerRegistry', () => {
+  beforeEach(() => { jest.useFakeTimers(); });
+  afterEach(() => { jest.useRealTimers(); });
+
+  it('creates breakers on demand', () => {
+    const r = new CircuitBreakerRegistry();
+    const cb = r.get('d1');
+    expect(cb).toBeInstanceOf(CircuitBreaker);
+    expect(r.get('d1')).toBe(cb);
+  });
+
+  it('remove() deletes a breaker', () => {
+    const r = new CircuitBreakerRegistry();
+    const cb1 = r.get('d1');
+    r.remove('d1');
+    expect(r.get('d1')).not.toBe(cb1);
+  });
+
+  it('getAvailableDeviceIds() filters out open circuits', () => {
+    const r = new CircuitBreakerRegistry({ failureThreshold: 1 });
+    r.get('d1'); r.get('d2'); r.get('d3');
+    r.get('d2').recordFailure();
+    const avail = r.getAvailableDeviceIds();
+    expect(avail).toContain('d1');
+    expect(avail).not.toContain('d2');
+    expect(avail).toContain('d3');
+  });
+
+  it('getAllStates() returns state map', () => {
+    const r = new CircuitBreakerRegistry({ failureThreshold: 1 });
+    r.get('d1'); r.get('d2').recordFailure();
+    const s = r.getAllStates();
+    expect(s.get('d1')).toBe('closed');
+    expect(s.get('d2')).toBe('open');
+  });
+
+  it('resetAll() resets all breakers', () => {
+    const r = new CircuitBreakerRegistry({ failureThreshold: 1 });
+    r.get('d1').recordFailure(); r.get('d2').recordFailure();
+    r.resetAll();
+    expect(r.get('d1').getState()).toBe('closed');
+    expect(r.get('d2').getState()).toBe('closed');
+  });
+
+  it('passes default options to new breakers', () => {
+    const r = new CircuitBreakerRegistry({ failureThreshold: 2 });
+    const cb = r.get('d1');
+    cb.recordFailure();
+    expect(cb.getState()).toBe('closed');
+    cb.recordFailure();
+    expect(cb.getState()).toBe('open');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `CircuitBreaker` class with closed/open/half-open state machine for per-device health tracking
- Add `CircuitBreakerRegistry` to manage circuit breakers across all pooled devices
- Devices auto-excluded after consecutive failures (default: 3), re-tested after cooldown (default: 30s)
- 18 unit tests covering all state transitions, events, reset, and force-trip

## Closes
Part of #205

## Test plan
- [x] Unit tests for closed → open transition after N failures
- [x] Unit tests for open → half-open after cooldown
- [x] Unit tests for half-open → closed on success
- [x] Unit tests for half-open → open on failure
- [x] Unit tests for trip() force-open and reset()
- [x] Unit tests for CircuitBreakerRegistry (get, remove, filter, resetAll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)