### PR TITLE
feat: add network request interception and offline mode (#201)

### DIFF
--- a/src/network-interceptor.ts
+++ b/src/network-interceptor.ts
@@ -1,0 +1,109 @@
+export interface InterceptRule {
+  id: string;
+  urlPattern: string;
+  action: 'block' | 'mock';
+  mockResponse?: {
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  };
+}
+
+export interface InterceptorClient {
+  evaluate<T = unknown>(expression: string): Promise<T>;
+}
+
+let ruleIdCounter = 0;
+
+export function globToRegex(pattern: string): RegExp {
+  let regex = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '*' && pattern[i + 1] === '*') {
+      regex += '.*';
+      i += 2;
+      if (pattern[i] === '/') i++;
+    } else if (ch === '*') {
+      regex += '[^/]*';
+      i++;
+    } else if (ch === '?') {
+      regex += '[^/]';
+      i++;
+    } else if (ch === '.') {
+      regex += '\\.';
+      i++;
+    } else if ('^$+{}[]|()\\'.includes(ch)) {
+      regex += '\\' + ch;
+      i++;
+    } else {
+      regex += ch;
+      i++;
+    }
+  }
+  return new RegExp('^' + regex + '$');
+}
+
+export function matchUrl(url: string, pattern: string): boolean {
+  if (!pattern.includes('*') && !pattern.includes('?')) {
+    return url.includes(pattern);
+  }
+  return globToRegex(pattern).test(url);
+}
+
+export class NetworkInterceptor {
+  private rules: Map<string, InterceptRule> = new Map();
+  private _enabled = false;
+  private _offline = false;
+
+  get enabled(): boolean { return this._enabled; }
+  get offline(): boolean { return this._offline; }
+
+  addRule(rule: Omit<InterceptRule, 'id'>): InterceptRule {
+    const id = 'rule_' + (++ruleIdCounter);
+    const full: InterceptRule = { id, ...rule };
+    this.rules.set(id, full);
+    return full;
+  }
+
+  removeRule(id: string): boolean { return this.rules.delete(id); }
+  listRules(): InterceptRule[] { return [...this.rules.values()]; }
+  clearRules(): void { this.rules.clear(); }
+
+  findMatchingRule(url: string): InterceptRule | undefined {
+    for (const rule of this.rules.values()) {
+      if (matchUrl(url, rule.urlPattern)) return rule;
+    }
+    return undefined;
+  }
+
+  async enable(client: InterceptorClient): Promise<void> {
+    this._enabled = true;
+    await this.inject(client);
+  }
+
+  async disable(client: InterceptorClient): Promise<void> {
+    this._enabled = false;
+    this._offline = false;
+    this.rules.clear();
+    await client.evaluate('(function(){if(window.__osOriginalFetch){window.fetch=window.__osOriginalFetch;delete window.__osOriginalFetch}if(window.__osOriginalXHROpen){XMLHttpRequest.prototype.open=window.__osOriginalXHROpen;delete window.__osOriginalXHROpen}delete window.__osInterceptRules;delete window.__osOfflineMode})()');
+  }
+
+  async setOffline(enabled: boolean, client: InterceptorClient): Promise<void> {
+    this._offline = enabled;
+    if (enabled && !this._enabled) this._enabled = true;
+    await this.inject(client);
+  }
+
+  async syncRules(client: InterceptorClient): Promise<void> {
+    if (!this._enabled) return;
+    await this.inject(client);
+  }
+
+  private async inject(client: InterceptorClient): Promise<void> {
+    const rulesJson = JSON.stringify(this.listRules());
+    const offlineFlag = this._offline ? 'true' : 'false';
+    const script = '(function(){if(!window.__osOriginalFetch){window.__osOriginalFetch=window.fetch.bind(window)}if(!window.__osOriginalXHROpen){window.__osOriginalXHROpen=XMLHttpRequest.prototype.open}window.__osInterceptRules=' + rulesJson + ';window.__osOfflineMode=' + offlineFlag + ';function m(u,p){if(p.indexOf("*")===-1&&p.indexOf("?")===-1)return u.indexOf(p)!==-1;var r="";for(var i=0;i<p.length;i++){var c=p[i];if(c==="*"&&p[i+1]==="*"){r+=".*";i++;if(p[i+1]==="/")i++}else if(c==="*")r+="[^/]*";else if(c==="?")r+="[^/]";else if(c===".")r+="\\\\.";else if("^$+{}[]|()\\\\".indexOf(c)!==-1)r+="\\\\"+c;else r+=c}return new RegExp("^"+r+"$").test(u)}function f(u){var rules=window.__osInterceptRules||[];for(var i=0;i<rules.length;i++)if(m(u,rules[i].urlPattern))return rules[i];return null}window.fetch=function(input,init){var url=(typeof input==="string")?input:(input&&input.url?input.url:"");if(window.__osOfflineMode)return Promise.reject(new TypeError("Failed to fetch"));var rule=f(url);if(rule){if(rule.action==="block")return Promise.reject(new TypeError("Request blocked by OpenSafari"));if(rule.action==="mock"&&rule.mockResponse)return Promise.resolve(new Response(rule.mockResponse.body||"",{status:rule.mockResponse.status||200,headers:new Headers(rule.mockResponse.headers||{})}))}return window.__osOriginalFetch(input,init)};XMLHttpRequest.prototype.open=function(method,url){this.__osUrl=url;this.__osBlocked=false;if(window.__osOfflineMode){this.__osBlocked=true}else{var rule=f(String(url));if(rule){this.__osMatchedRule=rule;if(rule.action==="block")this.__osBlocked=true}}return window.__osOriginalXHROpen.apply(this,arguments)};var origSend=XMLHttpRequest.prototype.send;XMLHttpRequest.prototype.send=function(body){if(this.__osBlocked){Object.defineProperty(this,"status",{get:function(){return 0}});Object.defineProperty(this,"readyState",{get:function(){return 4}});if(typeof this.onerror==="function")this.onerror(new Error("Blocked"));this.dispatchEvent(new Event("error"));return}if(this.__osMatchedRule&&this.__osMatchedRule.action==="mock"){var mk=this.__osMatchedRule.mockResponse||{};var s=this;Object.defineProperty(s,"status",{get:function(){return mk.status||200}});Object.defineProperty(s,"responseText",{get:function(){return mk.body||""}});Object.defineProperty(s,"readyState",{get:function(){return 4}});setTimeout(function(){if(typeof s.onload==="function")s.onload(new Event("load"));s.dispatchEvent(new Event("load"))},0);return}return origSend.apply(this,arguments)}})()';
+    await client.evaluate(script);
+  }
+}

--- a/tests/unit/network-interceptor.test.ts
+++ b/tests/unit/network-interceptor.test.ts
@@ -1,0 +1,129 @@
+import { NetworkInterceptor, matchUrl, globToRegex } from '../../src/network-interceptor';
+
+describe('globToRegex', () => {
+  it('converts simple wildcard', () => {
+    const re = globToRegex('*.js');
+    expect(re.test('app.js')).toBe(true);
+    expect(re.test('path/app.js')).toBe(false);
+  });
+  it('converts double-star wildcard', () => {
+    const re = globToRegex('**/api/*');
+    expect(re.test('https://example.com/api/users')).toBe(true);
+    expect(re.test('https://example.com/other')).toBe(false);
+  });
+  it('escapes dots in domain patterns', () => {
+    const re = globToRegex('*.analytics.com/**');
+    expect(re.test('track.analytics.com/v1/event')).toBe(true);
+    expect(re.test('trackXanalyticsXcom/v1/event')).toBe(false);
+  });
+  it('handles question mark', () => {
+    const re = globToRegex('file?.txt');
+    expect(re.test('file1.txt')).toBe(true);
+    expect(re.test('file12.txt')).toBe(false);
+  });
+});
+
+describe('matchUrl', () => {
+  it('substring match when no wildcards', () => {
+    expect(matchUrl('https://example.com/api/users', '/api/')).toBe(true);
+    expect(matchUrl('https://example.com/home', '/api/')).toBe(false);
+  });
+  it('glob match with wildcards', () => {
+    expect(matchUrl('app.js', '*.js')).toBe(true);
+    expect(matchUrl('https://cdn.example.com/app.js', '**/*.js')).toBe(true);
+  });
+  it('matches analytics blocking pattern', () => {
+    expect(matchUrl('https://track.analytics.com/v1/event', '**analytics.com/**')).toBe(true);
+  });
+  it('matches API mock pattern', () => {
+    expect(matchUrl('https://api.example.com/v1/users', '**/v1/users')).toBe(true);
+    expect(matchUrl('https://api.example.com/v2/users', '**/v1/users')).toBe(false);
+  });
+});
+
+describe('NetworkInterceptor', () => {
+  let interceptor: NetworkInterceptor;
+  beforeEach(() => { interceptor = new NetworkInterceptor(); });
+
+  describe('rule management', () => {
+    it('adds a rule with an id', () => {
+      const rule = interceptor.addRule({ urlPattern: '*.js', action: 'block' });
+      expect(rule.id).toMatch(/^rule_\d+$/);
+    });
+    it('lists all rules', () => {
+      interceptor.addRule({ urlPattern: '*.js', action: 'block' });
+      interceptor.addRule({ urlPattern: '**/api/*', action: 'mock', mockResponse: { status: 200, headers: {}, body: '{}' } });
+      expect(interceptor.listRules()).toHaveLength(2);
+    });
+    it('removes a rule by id', () => {
+      const rule = interceptor.addRule({ urlPattern: '*.css', action: 'block' });
+      expect(interceptor.removeRule(rule.id)).toBe(true);
+      expect(interceptor.listRules()).toHaveLength(0);
+    });
+    it('returns false for non-existent rule', () => {
+      expect(interceptor.removeRule('rule_999999')).toBe(false);
+    });
+    it('clears all rules', () => {
+      interceptor.addRule({ urlPattern: '*.js', action: 'block' });
+      interceptor.clearRules();
+      expect(interceptor.listRules()).toHaveLength(0);
+    });
+  });
+
+  describe('findMatchingRule', () => {
+    it('returns first matching rule', () => {
+      interceptor.addRule({ urlPattern: '*.js', action: 'block' });
+      const mockRule = interceptor.addRule({ urlPattern: '**/api/*', action: 'mock', mockResponse: { status: 404, headers: {}, body: 'Not Found' } });
+      expect(interceptor.findMatchingRule('https://example.com/api/users')?.id).toBe(mockRule.id);
+    });
+    it('returns undefined when no match', () => {
+      interceptor.addRule({ urlPattern: '*.js', action: 'block' });
+      expect(interceptor.findMatchingRule('https://example.com/style.css')).toBeUndefined();
+    });
+  });
+
+  describe('enable/disable', () => {
+    const mockClient = { evaluate: jest.fn().mockResolvedValue(undefined) };
+    it('sets enabled on enable', async () => {
+      await interceptor.enable(mockClient);
+      expect(interceptor.enabled).toBe(true);
+      expect(mockClient.evaluate).toHaveBeenCalled();
+    });
+    it('clears state on disable', async () => {
+      interceptor.addRule({ urlPattern: '*.js', action: 'block' });
+      await interceptor.enable(mockClient);
+      await interceptor.disable(mockClient);
+      expect(interceptor.enabled).toBe(false);
+      expect(interceptor.listRules()).toHaveLength(0);
+    });
+  });
+
+  describe('offline mode', () => {
+    const mockClient = { evaluate: jest.fn().mockResolvedValue(undefined) };
+    it('enables offline and auto-enables interception', async () => {
+      await interceptor.setOffline(true, mockClient);
+      expect(interceptor.offline).toBe(true);
+      expect(interceptor.enabled).toBe(true);
+    });
+    it('disables offline', async () => {
+      await interceptor.setOffline(true, mockClient);
+      await interceptor.setOffline(false, mockClient);
+      expect(interceptor.offline).toBe(false);
+    });
+  });
+
+  describe('syncRules', () => {
+    const mockClient = { evaluate: jest.fn().mockResolvedValue(undefined) };
+    it('re-injects when enabled', async () => {
+      await interceptor.enable(mockClient);
+      mockClient.evaluate.mockClear();
+      await interceptor.syncRules(mockClient);
+      expect(mockClient.evaluate).toHaveBeenCalledTimes(1);
+    });
+    it('skips when disabled', async () => {
+      mockClient.evaluate.mockClear();
+      await interceptor.syncRules(mockClient);
+      expect(mockClient.evaluate).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `network_intercept` tool for blocking URLs and mocking API responses using glob-based URL pattern matching
- Add `network_offline` tool for simulating offline mode (blocks all fetch/XHR)
- Implements via JavaScript injection (overrides fetch + XMLHttpRequest) for reliable cross-WebKit support
- Phase 1 of #201: Network request interception and mocking

## Changes
- `src/network-interceptor.ts` — InterceptorEngine with glob→regex URL matching, rule CRUD, JS injection
- `src/tools/network-intercept.ts` — MCP tool: enable/disable/addRule/removeRule/listRules
- `src/tools/network-offline.ts` — MCP tool: toggle offline simulation
- `src/tools/index.ts` — Register new tools
- `src/config/tool-tiers.ts` — Add Tier 2 entries
- `tests/unit/network-interceptor.test.ts` — 21 unit tests

## Test plan
- [x] 21 unit tests for glob matching, rule CRUD, enable/disable, offline mode
- [x] Full test suite passes (177/177)
- [x] Build succeeds
- [ ] Integration test: block a script → verify it doesn't load (requires simulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)