### PR TITLE
feat: integrate screenshot annotator with QA audit system (#212)

### DIFF
--- a/src/qa/audit.ts
+++ b/src/qa/audit.ts
@@ -1,5 +1,4 @@
 import { BrowserBackend } from '../types/browser-backend';
-import { annotateScreenshot, detectorResultToAnnotations, formatLegend, AnnotationIssue } from '../comparison/annotator';
 import { annotateScreenshot, detectorResultToAnnotations, formatLegend } from '../comparison/annotator';
 import type { AnnotationIssue, AnnotationResult } from '../comparison/annotator';
 import { DetectorResult, QAConfig, applyIgnoreRules } from './types';
@@ -152,7 +151,6 @@ export class QAAudit {
       annotatedScreenshot: annotationResult.annotatedImage,
       legend: formatLegend(annotationResult.legend),
     };
-    const annotationResult: AnnotationResult = annotateScreenshot(screenshotBase64, annotations, { safeArea, showLabels: true });
     return { ...report, annotatedScreenshot: annotationResult.annotatedImage, legend: formatLegend(annotationResult.legend) };
   }
 

--- a/src/tools/qa-audit.ts
+++ b/src/tools/qa-audit.ts
@@ -59,7 +59,7 @@ export function registerQAAuditTools(server: MCPServer): void {
             { type: 'text' as const, text: annotated.legend },
             { type: 'image' as const, data: annotated.annotatedScreenshot, mimeType: 'image/png' },
           );
-        } catch (_e) {
+        } catch {
           // Annotation is best-effort; continue with unannotated report
         }
       }

--- a/tests/unit/annotator-integration.test.ts
+++ b/tests/unit/annotator-integration.test.ts
@@ -116,30 +116,6 @@ describe('QA audit annotation integration', () => {
     expect(result.legend[1].severity).toBe('high');
     expect(result.legend[2].severity).toBe('medium');
     expect(result.legend[3].severity).toBe('low');
-      { detector: 'touch_targets', severity: 'high', issues: [
-        { selector: '#btn', problem: '32x28px', fix: 'Increase', boundingBox: { x: 100, y: 200, width: 32, height: 28 } },
-        { selector: '#link', problem: '38x20px', fix: 'Increase', boundingBox: { x: 50, y: 400, width: 38, height: 20 } },
-      ], passed: false, totalScanned: 10, issueCount: 2 },
-      { detector: 'safe_area', severity: 'high', issues: [
-        { selector: '.footer', problem: 'Missing inset', fix: 'Add padding', rect: { x: 0, y: 800, width: 390, height: 44 } },
-      ], passed: false, totalScanned: 5, issueCount: 1 },
-      { detector: 'hover_only', severity: 'medium', issues: [
-        { selector: '.tooltip', problem: 'Hover only', fix: 'Add touch' },
-      ], passed: false, totalScanned: 3, issueCount: 1 },
-      { detector: 'pwa_meta', severity: 'pass', issues: [], passed: true, totalScanned: 8, issueCount: 0 },
-    ];
-    const annotations: AnnotationIssue[] = [];
-    for (const r of detectorResults) {
-      if (r.passed || r.severity === 'pass' || r.severity === 'error') continue;
-      annotations.push(...detectorResultToAnnotations(r.detector, r.severity as 'critical'|'high'|'medium'|'low', r.issues));
-    }
-    expect(annotations).toHaveLength(3);
-    const result = annotateScreenshot(screenshot, annotations, { safeArea: { top: 47, bottom: 34, left: 0, right: 0 } });
-    expect(result.width).toBe(390);
-    expect(result.height).toBe(844);
-    expect(result.legend).toHaveLength(3);
-    const decoded = PNG.sync.read(Buffer.from(result.annotatedImage, 'base64'));
-    expect(decoded.width).toBe(390);
   });
 
   it('handles audit with no issues', () => {


### PR DESCRIPTION
## Summary

- Add `annotateReport()` method to `QAAudit` class that converts detector results to visual annotations
- Add `annotate` boolean option to `qa_full_audit` MCP tool — when enabled, takes a screenshot and returns an annotated PNG with bounding boxes highlighting issues
- Annotated output includes severity-colored boxes, numbered labels, and a markdown legend
- Best-effort: annotation failure does not block the audit report
- 3 integration tests covering detector-to-annotation pipeline

Depends on #233

## Test plan

- [x] Integration tests pass for multi-detector annotation pipeline
- [x] Passing audit produces no annotations (clean screenshot)
- [x] Mixed severity annotations render correctly
- [x] Annotator unit tests still pass (16/16)

Part 2 of #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)