### PR TITLE
feat: enhance cross-viewport report with visual diff scores and DOM analysis

### DIFF
--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,0 +1,14 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests/integration'],
+  testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/'],
+  // Transform ESM-only dependencies (pixelmatch is pure ESM)
+  transformIgnorePatterns: ['/node_modules/(?!pixelmatch)'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.jsx?$': ['ts-jest', { tsconfig: { allowJs: true } }],
+  },
+};

--- a/src/comparison/index.ts
+++ b/src/comparison/index.ts
@@ -12,6 +12,7 @@ export type {
   AnnotationResult,
   LegendEntry,
 } from './annotator';
+export type { ReportOptions, MCPContent } from './report';
 export { VisualDiffEngine } from './visual-diff';
 export type { VisualDiffResult, VisualDiffOptions, BoundingBox, PairwiseComparisonMatrix } from './visual-diff';
 export { DOMDiffEngine, DOM_SNAPSHOT_SCRIPT } from './dom-diff';

--- a/src/comparison/report.ts
+++ b/src/comparison/report.ts
@@ -1,6 +1,13 @@
 import { ViewportCapture } from './cross-viewport';
+import { PairwiseComparisonMatrix } from './visual-diff';
+import { DOMDiffResult } from './dom-diff';
 
-export function generateMarkdownReport(captures: ViewportCapture[], url: string): string {
+export interface ReportOptions {
+  visualDiff?: PairwiseComparisonMatrix;
+  domDiffs?: DOMDiffResult[];
+}
+
+export function generateMarkdownReport(captures: ViewportCapture[], url: string, options?: ReportOptions): string {
   const lines = [
     '# Cross-Viewport Comparison Report',
     '',
@@ -21,6 +28,103 @@ export function generateMarkdownReport(captures: ViewportCapture[], url: string)
     );
   }
 
+  // Visual Diff Summary section
+  if (options?.visualDiff) {
+    const matrix = options.visualDiff;
+    const hasFlagged = matrix.flaggedPairs.length > 0;
+    const overallStatus = hasFlagged ? 'FAIL' : 'PASS';
+
+    lines.push('', '## Visual Diff Summary', '');
+    lines.push(`**Overall Result:** ${overallStatus}`);
+    lines.push(`**Similarity Threshold:** ${(matrix.threshold * 100).toFixed(0)}%`);
+    lines.push(`**Pairs Compared:** ${matrix.results.length}`);
+    lines.push(`**Flagged Pairs:** ${matrix.flaggedPairs.length}`);
+
+    if (matrix.results.length > 0) {
+      lines.push('', '### Pairwise Similarity Matrix', '');
+      lines.push('| Device A | Device B | Similarity | Diff % | Status |');
+      lines.push('|----------|----------|------------|--------|--------|');
+
+      for (const result of matrix.results) {
+        const similarity = (result.similarity * 100).toFixed(1);
+        const diffPct = result.diffPercentage.toFixed(1);
+        const status = result.similarity >= matrix.threshold ? 'PASS' : 'FAIL';
+        lines.push(`| ${result.deviceA} | ${result.deviceB} | ${similarity}% | ${diffPct}% | ${status} |`);
+      }
+    }
+
+    if (matrix.flaggedPairs.length > 0) {
+      lines.push('', '### Flagged Pairs', '');
+
+      for (const flagged of matrix.flaggedPairs) {
+        lines.push(`- **${flagged.deviceA}** vs **${flagged.deviceB}**: ${(flagged.similarity * 100).toFixed(1)}% similarity, ${flagged.diffPercentage.toFixed(1)}% pixels differ, ${flagged.diffRegions.length} diff region(s)`);
+      }
+    }
+  }
+
+  // DOM Differences section
+  if (options?.domDiffs && options.domDiffs.length > 0) {
+    const diffsWithIssues = options.domDiffs.filter(d => d.differences.length > 0);
+
+    lines.push('', '## DOM Differences', '');
+    lines.push(`**Pairs Analyzed:** ${options.domDiffs.length}`);
+    lines.push(`**Pairs With Differences:** ${diffsWithIssues.length}`);
+
+    for (const domDiff of options.domDiffs) {
+      if (domDiff.differences.length === 0) continue;
+
+      lines.push('', `### ${domDiff.deviceA} vs ${domDiff.deviceB}`, '');
+      lines.push(domDiff.summary);
+      lines.push('');
+      lines.push('| Type | Selector | Severity | Description |');
+      lines.push('|------|----------|----------|-------------|');
+
+      for (const diff of domDiff.differences) {
+        lines.push(`| ${diff.type} | ${diff.selector} | ${diff.severity} | ${diff.description} |`);
+      }
+    }
+  }
+
+  // Responsive Breakpoint Analysis section
+  if (captures.length > 1) {
+    const breakpointGroups = new Map<string, ViewportCapture[]>();
+    for (const cap of captures) {
+      const group = breakpointGroups.get(cap.breakpoint) ?? [];
+      group.push(cap);
+      breakpointGroups.set(cap.breakpoint, group);
+    }
+
+    if (breakpointGroups.size > 0) {
+      lines.push('', '## Responsive Breakpoint Analysis', '');
+
+      for (const [breakpoint, caps] of breakpointGroups) {
+        const deviceList = caps.map(c => c.device).join(', ');
+        const hasIssues = caps.some(c => c.metadata?.hasHorizontalOverflow || c.error);
+        const statusIcon = hasIssues ? 'Issues detected' : 'OK';
+        lines.push(`- **${breakpoint}** (${caps.length} device(s): ${deviceList}): ${statusIcon}`);
+      }
+
+      // Check for flagged visual diffs within same breakpoint
+      if (options?.visualDiff) {
+        const breakpointIssues: string[] = [];
+        for (const [breakpoint, caps] of breakpointGroups) {
+          const deviceNames = new Set(caps.map(c => c.device));
+          const flaggedInBreakpoint = options.visualDiff.flaggedPairs.filter(
+            fp => deviceNames.has(fp.deviceA) && deviceNames.has(fp.deviceB)
+          );
+          if (flaggedInBreakpoint.length > 0) {
+            breakpointIssues.push(`- **${breakpoint}**: ${flaggedInBreakpoint.length} flagged pair(s) within same breakpoint`);
+          }
+        }
+        if (breakpointIssues.length > 0) {
+          lines.push('', '**Breakpoint Issues:**');
+          lines.push(...breakpointIssues);
+        }
+      }
+    }
+  }
+
+  // Issues section (existing)
   const issues = captures.filter(c => c.metadata?.hasHorizontalOverflow || c.error);
   if (issues.length > 0) {
     lines.push('', '## Issues Found', '');

--- a/tests/integration/cross-device-visual-diff.test.ts
+++ b/tests/integration/cross-device-visual-diff.test.ts
@@ -1,0 +1,396 @@
+import { PNG } from 'pngjs';
+import { VisualDiffEngine } from '../../src/comparison/visual-diff';
+import { DOMDiffEngine, DOMSnapshot, DOMElementSnapshot } from '../../src/comparison/dom-diff';
+import { generateMarkdownReport, ReportOptions } from '../../src/comparison/report';
+import { ViewportCapture, PageMetadata } from '../../src/comparison/cross-viewport';
+
+/** Create a solid-color PNG and return it as base64 */
+function createTestPNG(width: number, height: number, color: { r: number; g: number; b: number }): string {
+  const png = new PNG({ width, height });
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      png.data[idx] = color.r;
+      png.data[idx + 1] = color.g;
+      png.data[idx + 2] = color.b;
+      png.data[idx + 3] = 255;
+    }
+  }
+
+  const buffer = PNG.sync.write(png);
+  return buffer.toString('base64');
+}
+
+/** Create a PNG with a colored region on a white background */
+function createTestPNGWithRegion(
+  width: number,
+  height: number,
+  region: { x: number; y: number; w: number; h: number },
+  regionColor: { r: number; g: number; b: number },
+): string {
+  const png = new PNG({ width, height });
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      const inRegion =
+        x >= region.x && x < region.x + region.w && y >= region.y && y < region.y + region.h;
+
+      if (inRegion) {
+        png.data[idx] = regionColor.r;
+        png.data[idx + 1] = regionColor.g;
+        png.data[idx + 2] = regionColor.b;
+      } else {
+        png.data[idx] = 255;
+        png.data[idx + 1] = 255;
+        png.data[idx + 2] = 255;
+      }
+      png.data[idx + 3] = 255;
+    }
+  }
+
+  const buffer = PNG.sync.write(png);
+  return buffer.toString('base64');
+}
+
+function makeMetadata(overrides: Partial<PageMetadata> = {}): PageMetadata {
+  return {
+    title: 'Test Page',
+    scrollHeight: 844,
+    scrollWidth: 390,
+    innerWidth: 390,
+    innerHeight: 844,
+    devicePixelRatio: 3,
+    hasHorizontalOverflow: false,
+    ...overrides,
+  };
+}
+
+function makeElement(overrides: Partial<DOMElementSnapshot> = {}): DOMElementSnapshot {
+  return {
+    tag: 'div',
+    selector: 'div#main',
+    rect: { x: 0, y: 0, width: 100, height: 50 },
+    visible: true,
+    childCount: 0,
+    ...overrides,
+  };
+}
+
+interface MockDevice {
+  name: string;
+  viewport: { w: number; h: number };
+  breakpoint: string;
+  screenshotImage: string;
+  metadata: PageMetadata;
+  domElements: DOMElementSnapshot[];
+}
+
+/**
+ * Simulate the full cross-device comparison pipeline without real simulators.
+ *
+ * This mimics what CrossViewportCapture + VisualDiffEngine + DOMDiffEngine + report
+ * would do in production, but uses mock data instead of real devices.
+ */
+async function runMockCrossDevicePipeline(
+  url: string,
+  devices: MockDevice[],
+  options: { similarityThreshold?: number } = {},
+) {
+  // Step 1: Simulate CrossViewportCapture.capture() output
+  const captures: ViewportCapture[] = devices.map(d => ({
+    device: d.name,
+    viewport: d.viewport,
+    breakpoint: d.breakpoint,
+    screenshot: d.screenshotImage,
+    metadata: d.metadata,
+    timing: Math.floor(Math.random() * 500) + 100,
+  }));
+
+  // Step 2: Run VisualDiffEngine on screenshots
+  const visualEngine = new VisualDiffEngine();
+  const screenshots = captures.map(c => ({
+    device: c.device,
+    imageBase64: c.screenshot,
+  }));
+  const visualDiff = await visualEngine.compareAll(screenshots, {
+    similarityThreshold: options.similarityThreshold ?? 0.95,
+  });
+
+  // Step 3: Run DOMDiffEngine on DOM snapshots
+  const domEngine = new DOMDiffEngine();
+  const domSnapshots: DOMSnapshot[] = devices.map(d => ({
+    device: d.name,
+    viewport: d.viewport,
+    elements: d.domElements,
+  }));
+  const domDiffs = domEngine.compareAll(domSnapshots);
+
+  // Step 4: Generate enhanced report
+  const reportOptions: ReportOptions = { visualDiff, domDiffs };
+  const report = generateMarkdownReport(captures, url, reportOptions);
+
+  return { captures, visualDiff, domDiffs, report };
+}
+
+describe('Cross-Device Visual Diff Integration', () => {
+  const url = 'https://example.com/test';
+
+  describe('identical pages on different device sizes', () => {
+    it('should produce a valid report with high similarity for same-color screenshots', async () => {
+      const sharedImage = createTestPNG(200, 400, { r: 240, g: 240, b: 240 });
+      const sharedElements = [
+        makeElement({ selector: 'h1#title', rect: { x: 10, y: 10, width: 180, height: 40 } }),
+        makeElement({ selector: 'p.content', rect: { x: 10, y: 60, width: 180, height: 300 } }),
+      ];
+
+      const devices: MockDevice[] = [
+        {
+          name: 'iPhone SE',
+          viewport: { w: 375, h: 667 },
+          breakpoint: 'sm',
+          screenshotImage: sharedImage,
+          metadata: makeMetadata({ innerWidth: 375, innerHeight: 667, scrollWidth: 375 }),
+          domElements: sharedElements,
+        },
+        {
+          name: 'iPhone 15',
+          viewport: { w: 390, h: 844 },
+          breakpoint: 'sm',
+          screenshotImage: sharedImage,
+          metadata: makeMetadata({ innerWidth: 390, innerHeight: 844, scrollWidth: 390 }),
+          domElements: sharedElements,
+        },
+      ];
+
+      const { visualDiff, domDiffs, report } = await runMockCrossDevicePipeline(url, devices);
+
+      // Visual diff: identical images should have similarity = 1
+      expect(visualDiff.results).toHaveLength(1);
+      expect(visualDiff.results[0].similarity).toBe(1);
+      expect(visualDiff.flaggedPairs).toHaveLength(0);
+
+      // DOM diff: identical elements should have 0 differences
+      expect(domDiffs).toHaveLength(1);
+      expect(domDiffs[0].differences).toHaveLength(0);
+
+      // Report structure
+      expect(report).toContain('# Cross-Viewport Comparison Report');
+      expect(report).toContain('## Visual Diff Summary');
+      expect(report).toContain('**Overall Result:** PASS');
+      expect(report).toContain('## DOM Differences');
+      expect(report).toContain('**Pairs With Differences:** 0');
+      expect(report).toContain('## Responsive Breakpoint Analysis');
+    });
+  });
+
+  describe('different pages with visual differences', () => {
+    it('should flag pairs when images differ significantly', async () => {
+      const phoneImage = createTestPNG(200, 400, { r: 255, g: 255, b: 255 });
+      const tabletImage = createTestPNGWithRegion(
+        200,
+        400,
+        { x: 0, y: 0, w: 200, h: 200 },
+        { r: 255, g: 0, b: 0 },
+      );
+
+      const devices: MockDevice[] = [
+        {
+          name: 'iPhone 15',
+          viewport: { w: 390, h: 844 },
+          breakpoint: 'sm',
+          screenshotImage: phoneImage,
+          metadata: makeMetadata(),
+          domElements: [
+            makeElement({ selector: 'h1#title' }),
+            makeElement({ selector: 'nav#menu', visible: true }),
+          ],
+        },
+        {
+          name: 'iPad Air',
+          viewport: { w: 820, h: 1180 },
+          breakpoint: 'md',
+          screenshotImage: tabletImage,
+          metadata: makeMetadata({ innerWidth: 820, innerHeight: 1180, scrollWidth: 820 }),
+          domElements: [
+            makeElement({ selector: 'h1#title' }),
+            makeElement({ selector: 'nav#menu', visible: false }),
+          ],
+        },
+      ];
+
+      const { visualDiff, domDiffs, report } = await runMockCrossDevicePipeline(url, devices);
+
+      // Visual diff: significantly different images should be flagged
+      expect(visualDiff.results).toHaveLength(1);
+      expect(visualDiff.results[0].similarity).toBeLessThan(0.95);
+      expect(visualDiff.flaggedPairs).toHaveLength(1);
+      expect(visualDiff.flaggedPairs[0].diffRegions.length).toBeGreaterThan(0);
+
+      // DOM diff: visibility difference should be detected
+      expect(domDiffs).toHaveLength(1);
+      const visibilityDiff = domDiffs[0].differences.find(d => d.type === 'hidden');
+      expect(visibilityDiff).toBeDefined();
+      expect(visibilityDiff!.selector).toBe('nav#menu');
+
+      // Report should reflect failures
+      expect(report).toContain('**Overall Result:** FAIL');
+      expect(report).toContain('### Flagged Pairs');
+      expect(report).toContain('iPhone 15');
+      expect(report).toContain('iPad Air');
+      expect(report).toContain('## DOM Differences');
+      expect(report).toContain('### iPhone 15 vs iPad Air');
+    });
+  });
+
+  describe('three devices with mixed results', () => {
+    it('should produce 3 pairs and correctly identify flagged ones', async () => {
+      const whiteImage = createTestPNG(100, 200, { r: 255, g: 255, b: 255 });
+      const grayImage = createTestPNG(100, 200, { r: 200, g: 200, b: 200 });
+      const redImage = createTestPNG(100, 200, { r: 255, g: 0, b: 0 });
+
+      const baseElements = [
+        makeElement({ selector: 'header#top', rect: { x: 0, y: 0, width: 100, height: 30 } }),
+        makeElement({ selector: 'main#content', rect: { x: 0, y: 30, width: 100, height: 170 } }),
+      ];
+
+      const devices: MockDevice[] = [
+        {
+          name: 'iPhone SE',
+          viewport: { w: 375, h: 667 },
+          breakpoint: 'sm',
+          screenshotImage: whiteImage,
+          metadata: makeMetadata({ innerWidth: 375, innerHeight: 667, scrollWidth: 375 }),
+          domElements: baseElements,
+        },
+        {
+          name: 'iPhone 15',
+          viewport: { w: 390, h: 844 },
+          breakpoint: 'sm',
+          screenshotImage: grayImage,
+          metadata: makeMetadata({ innerWidth: 390, innerHeight: 844, scrollWidth: 390 }),
+          domElements: baseElements,
+        },
+        {
+          name: 'iPad Air',
+          viewport: { w: 820, h: 1180 },
+          breakpoint: 'md',
+          screenshotImage: redImage,
+          metadata: makeMetadata({ innerWidth: 820, innerHeight: 1180, scrollWidth: 820 }),
+          domElements: [
+            ...baseElements,
+            makeElement({ selector: 'aside#sidebar', rect: { x: 0, y: 0, width: 200, height: 500 } }),
+          ],
+        },
+      ];
+
+      const { visualDiff, domDiffs, report } = await runMockCrossDevicePipeline(url, devices);
+
+      // Should have C(3,2) = 3 pairs
+      expect(visualDiff.results).toHaveLength(3);
+      expect(domDiffs).toHaveLength(3);
+
+      // White vs gray might pass (close colors)
+      // White vs red and gray vs red should definitely fail
+      expect(visualDiff.flaggedPairs.length).toBeGreaterThanOrEqual(1);
+
+      // DOM: iPad has extra aside#sidebar element
+      const ipadDiffs = domDiffs.filter(
+        d => d.deviceA === 'iPad Air' || d.deviceB === 'iPad Air'
+      );
+      const hasMissingSidebar = ipadDiffs.some(
+        d => d.differences.some(diff => diff.selector === 'aside#sidebar' && diff.type === 'missing')
+      );
+      expect(hasMissingSidebar).toBe(true);
+
+      // Report should have all sections
+      expect(report).toContain('**Devices:** 3');
+      expect(report).toContain('**Pairs Compared:** 3');
+      expect(report).toContain('## Visual Diff Summary');
+      expect(report).toContain('## DOM Differences');
+      expect(report).toContain('## Responsive Breakpoint Analysis');
+      expect(report).toContain('**sm**');
+      expect(report).toContain('**md**');
+    });
+  });
+
+  describe('report completeness', () => {
+    it('should include all required report sections in order', async () => {
+      const image = createTestPNG(100, 100, { r: 128, g: 128, b: 128 });
+      const elements = [makeElement({ selector: 'div#app' })];
+
+      const devices: MockDevice[] = [
+        {
+          name: 'Device A',
+          viewport: { w: 375, h: 667 },
+          breakpoint: 'sm',
+          screenshotImage: image,
+          metadata: makeMetadata({ innerWidth: 375, innerHeight: 667, scrollWidth: 375 }),
+          domElements: elements,
+        },
+        {
+          name: 'Device B',
+          viewport: { w: 768, h: 1024 },
+          breakpoint: 'md',
+          screenshotImage: image,
+          metadata: makeMetadata({ innerWidth: 768, innerHeight: 1024, scrollWidth: 768 }),
+          domElements: elements,
+        },
+      ];
+
+      const { report } = await runMockCrossDevicePipeline(url, devices);
+
+      // Verify section order
+      const sections = [
+        '# Cross-Viewport Comparison Report',
+        '## Device Summary',
+        '## Visual Diff Summary',
+        '## DOM Differences',
+        '## Responsive Breakpoint Analysis',
+      ];
+
+      let lastIdx = -1;
+      for (const section of sections) {
+        const idx = report.indexOf(section);
+        expect(idx).toBeGreaterThan(lastIdx);
+        lastIdx = idx;
+      }
+    });
+
+    it('should include device info in the summary table', async () => {
+      const image = createTestPNG(50, 50, { r: 100, g: 100, b: 100 });
+
+      const devices: MockDevice[] = [
+        {
+          name: 'iPhone SE',
+          viewport: { w: 375, h: 667 },
+          breakpoint: 'sm',
+          screenshotImage: image,
+          metadata: makeMetadata({
+            innerWidth: 375,
+            innerHeight: 667,
+            scrollWidth: 500,
+            hasHorizontalOverflow: true,
+          }),
+          domElements: [],
+        },
+        {
+          name: 'iPad Air',
+          viewport: { w: 820, h: 1180 },
+          breakpoint: 'md',
+          screenshotImage: image,
+          metadata: makeMetadata({ innerWidth: 820, innerHeight: 1180, scrollWidth: 820 }),
+          domElements: [],
+        },
+      ];
+
+      const { report } = await runMockCrossDevicePipeline(url, devices);
+
+      expect(report).toContain('| iPhone SE | 375x667 | sm | YES |');
+      expect(report).toContain('| iPad Air | 820x1180 | md | No |');
+      expect(report).toContain('## Issues Found');
+      expect(report).toContain('Horizontal overflow');
+    });
+  });
+});

--- a/tests/unit/enhanced-report.test.ts
+++ b/tests/unit/enhanced-report.test.ts
@@ -1,0 +1,401 @@
+import { generateMarkdownReport } from '../../src/comparison/report';
+import { ViewportCapture } from '../../src/comparison/cross-viewport';
+import { PairwiseComparisonMatrix, VisualDiffResult } from '../../src/comparison/visual-diff';
+import { DOMDiffResult, DOMDifference } from '../../src/comparison/dom-diff';
+
+function makeCapture(overrides: Partial<ViewportCapture> = {}): ViewportCapture {
+  return {
+    device: 'iPhone 15',
+    viewport: { w: 390, h: 844 },
+    breakpoint: 'sm',
+    screenshot: '',
+    metadata: {
+      title: 'Test Page',
+      scrollHeight: 844,
+      scrollWidth: 390,
+      innerWidth: 390,
+      innerHeight: 844,
+      devicePixelRatio: 3,
+      hasHorizontalOverflow: false,
+    },
+    timing: 250,
+    ...overrides,
+  };
+}
+
+function makeVisualDiffResult(overrides: Partial<VisualDiffResult> = {}): VisualDiffResult {
+  return {
+    similarity: 0.98,
+    diffPercentage: 2.0,
+    diffPixelCount: 200,
+    totalPixels: 10000,
+    diffRegions: [],
+    deviceA: 'iPhone 15',
+    deviceB: 'iPad Air',
+    normalizedSize: { width: 390, height: 844 },
+    ...overrides,
+  };
+}
+
+function makeMatrix(overrides: Partial<PairwiseComparisonMatrix> = {}): PairwiseComparisonMatrix {
+  return {
+    devices: ['iPhone 15', 'iPad Air'],
+    results: [makeVisualDiffResult()],
+    flaggedPairs: [],
+    threshold: 0.95,
+    ...overrides,
+  };
+}
+
+function makeDOMDiffResult(overrides: Partial<DOMDiffResult> = {}): DOMDiffResult {
+  return {
+    differences: [],
+    deviceA: 'iPhone 15',
+    deviceB: 'iPad Air',
+    summary: 'Compared iPhone 15 vs iPad Air: 0 differences found (0 high, 0 medium, 0 low) across 5 elements',
+    totalElementsCompared: 5,
+    ...overrides,
+  };
+}
+
+function makeDOMDifference(overrides: Partial<DOMDifference> = {}): DOMDifference {
+  return {
+    type: 'missing',
+    selector: 'nav#sidebar',
+    description: 'Element "nav#sidebar" exists in iPhone 15 but missing in iPad Air',
+    deviceA: { device: 'iPhone 15', value: 'present' },
+    deviceB: { device: 'iPad Air', value: 'missing' },
+    severity: 'high',
+    ...overrides,
+  };
+}
+
+describe('generateMarkdownReport (enhanced)', () => {
+  const url = 'https://example.com';
+
+  describe('backward compatibility', () => {
+    it('should produce expected output without options (same as original)', () => {
+      const captures = [
+        makeCapture({ device: 'iPhone 15', viewport: { w: 390, h: 844 }, breakpoint: 'sm' }),
+        makeCapture({ device: 'iPad Air', viewport: { w: 820, h: 1180 }, breakpoint: 'md' }),
+      ];
+
+      const report = generateMarkdownReport(captures, url);
+
+      expect(report).toContain('# Cross-Viewport Comparison Report');
+      expect(report).toContain(`**URL:** ${url}`);
+      expect(report).toContain('**Devices:** 2');
+      expect(report).toContain('## Device Summary');
+      expect(report).toContain('| iPhone 15 |');
+      expect(report).toContain('| iPad Air |');
+      // Should NOT contain diff sections
+      expect(report).not.toContain('## Visual Diff Summary');
+      expect(report).not.toContain('## DOM Differences');
+    });
+
+    it('should produce same output when options is undefined', () => {
+      const captures = [makeCapture()];
+      const report1 = generateMarkdownReport(captures, url);
+      const report2 = generateMarkdownReport(captures, url, undefined);
+
+      // Both should have the same structure (timestamps may differ)
+      expect(report1).toContain('## Device Summary');
+      expect(report2).toContain('## Device Summary');
+      expect(report1).not.toContain('## Visual Diff Summary');
+      expect(report2).not.toContain('## Visual Diff Summary');
+    });
+
+    it('should produce same output when options is empty object', () => {
+      const captures = [makeCapture()];
+      const report = generateMarkdownReport(captures, url, {});
+
+      expect(report).toContain('## Device Summary');
+      expect(report).not.toContain('## Visual Diff Summary');
+      expect(report).not.toContain('## DOM Differences');
+    });
+  });
+
+  describe('visual diff results', () => {
+    it('should include similarity matrix when visual diff is provided', () => {
+      const captures = [
+        makeCapture({ device: 'iPhone 15' }),
+        makeCapture({ device: 'iPad Air', viewport: { w: 820, h: 1180 }, breakpoint: 'md' }),
+      ];
+
+      const matrix = makeMatrix({
+        results: [makeVisualDiffResult({ similarity: 0.97, diffPercentage: 3.0 })],
+        flaggedPairs: [],
+      });
+
+      const report = generateMarkdownReport(captures, url, { visualDiff: matrix });
+
+      expect(report).toContain('## Visual Diff Summary');
+      expect(report).toContain('**Overall Result:** PASS');
+      expect(report).toContain('**Similarity Threshold:** 95%');
+      expect(report).toContain('**Pairs Compared:** 1');
+      expect(report).toContain('**Flagged Pairs:** 0');
+      expect(report).toContain('### Pairwise Similarity Matrix');
+      expect(report).toContain('| iPhone 15 | iPad Air | 97.0% | 3.0% | PASS |');
+    });
+
+    it('should show FAIL status when flagged pairs exist', () => {
+      const captures = [
+        makeCapture({ device: 'iPhone 15' }),
+        makeCapture({ device: 'iPad Air', viewport: { w: 820, h: 1180 }, breakpoint: 'md' }),
+      ];
+
+      const flaggedResult = makeVisualDiffResult({
+        similarity: 0.80,
+        diffPercentage: 20.0,
+        diffRegions: [{ x: 0, y: 0, width: 100, height: 100 }, { x: 200, y: 200, width: 50, height: 50 }],
+      });
+
+      const matrix = makeMatrix({
+        results: [flaggedResult],
+        flaggedPairs: [flaggedResult],
+      });
+
+      const report = generateMarkdownReport(captures, url, { visualDiff: matrix });
+
+      expect(report).toContain('**Overall Result:** FAIL');
+      expect(report).toContain('**Flagged Pairs:** 1');
+      expect(report).toContain('### Flagged Pairs');
+      expect(report).toContain('80.0% similarity');
+      expect(report).toContain('20.0% pixels differ');
+      expect(report).toContain('2 diff region(s)');
+    });
+
+    it('should show PASS for each pair above threshold', () => {
+      const captures = [
+        makeCapture({ device: 'DeviceA' }),
+        makeCapture({ device: 'DeviceB' }),
+        makeCapture({ device: 'DeviceC' }),
+      ];
+
+      const matrix = makeMatrix({
+        devices: ['DeviceA', 'DeviceB', 'DeviceC'],
+        results: [
+          makeVisualDiffResult({ deviceA: 'DeviceA', deviceB: 'DeviceB', similarity: 0.99, diffPercentage: 1.0 }),
+          makeVisualDiffResult({ deviceA: 'DeviceA', deviceB: 'DeviceC', similarity: 0.96, diffPercentage: 4.0 }),
+          makeVisualDiffResult({ deviceA: 'DeviceB', deviceB: 'DeviceC', similarity: 0.97, diffPercentage: 3.0 }),
+        ],
+        flaggedPairs: [],
+        threshold: 0.95,
+      });
+
+      const report = generateMarkdownReport(captures, url, { visualDiff: matrix });
+
+      expect(report).toContain('**Pairs Compared:** 3');
+      expect(report).toContain('| DeviceA | DeviceB | 99.0% | 1.0% | PASS |');
+      expect(report).toContain('| DeviceA | DeviceC | 96.0% | 4.0% | PASS |');
+      expect(report).toContain('| DeviceB | DeviceC | 97.0% | 3.0% | PASS |');
+      expect(report).not.toContain('### Flagged Pairs');
+    });
+  });
+
+  describe('DOM diff results', () => {
+    it('should include DOM differences table when provided', () => {
+      const captures = [
+        makeCapture({ device: 'iPhone 15' }),
+        makeCapture({ device: 'iPad Air', viewport: { w: 820, h: 1180 }, breakpoint: 'md' }),
+      ];
+
+      const domDiffs = [
+        makeDOMDiffResult({
+          deviceA: 'iPhone 15',
+          deviceB: 'iPad Air',
+          summary: 'Compared iPhone 15 vs iPad Air: 2 differences found (1 high, 1 medium, 0 low) across 10 elements',
+          differences: [
+            makeDOMDifference({
+              type: 'missing',
+              selector: 'nav#sidebar',
+              severity: 'high',
+              description: 'Element "nav#sidebar" exists in iPhone 15 but missing in iPad Air',
+            }),
+            makeDOMDifference({
+              type: 'hidden',
+              selector: 'button#menu',
+              severity: 'medium',
+              description: 'Element "button#menu" visibility differs',
+            }),
+          ],
+        }),
+      ];
+
+      const report = generateMarkdownReport(captures, url, { domDiffs });
+
+      expect(report).toContain('## DOM Differences');
+      expect(report).toContain('**Pairs Analyzed:** 1');
+      expect(report).toContain('**Pairs With Differences:** 1');
+      expect(report).toContain('### iPhone 15 vs iPad Air');
+      expect(report).toContain('| Type | Selector | Severity | Description |');
+      expect(report).toContain('| missing | nav#sidebar | high |');
+      expect(report).toContain('| hidden | button#menu | medium |');
+    });
+
+    it('should skip pairs with no differences', () => {
+      const captures = [
+        makeCapture({ device: 'iPhone 15' }),
+        makeCapture({ device: 'iPad Air', viewport: { w: 820, h: 1180 }, breakpoint: 'md' }),
+      ];
+
+      const domDiffs = [
+        makeDOMDiffResult({ differences: [] }),
+      ];
+
+      const report = generateMarkdownReport(captures, url, { domDiffs });
+
+      expect(report).toContain('## DOM Differences');
+      expect(report).toContain('**Pairs With Differences:** 0');
+      expect(report).not.toContain('### iPhone 15 vs iPad Air');
+    });
+  });
+
+  describe('combined visual and DOM diffs', () => {
+    it('should include both sections when both are provided', () => {
+      const captures = [
+        makeCapture({ device: 'iPhone 15' }),
+        makeCapture({ device: 'iPad Air', viewport: { w: 820, h: 1180 }, breakpoint: 'md' }),
+      ];
+
+      const matrix = makeMatrix();
+      const domDiffs = [
+        makeDOMDiffResult({
+          differences: [makeDOMDifference()],
+          summary: 'Compared iPhone 15 vs iPad Air: 1 differences found',
+        }),
+      ];
+
+      const report = generateMarkdownReport(captures, url, { visualDiff: matrix, domDiffs });
+
+      expect(report).toContain('## Visual Diff Summary');
+      expect(report).toContain('## DOM Differences');
+      // Visual diff should come before DOM diff
+      const visualIdx = report.indexOf('## Visual Diff Summary');
+      const domIdx = report.indexOf('## DOM Differences');
+      expect(visualIdx).toBeLessThan(domIdx);
+    });
+  });
+
+  describe('responsive breakpoint analysis', () => {
+    it('should show breakpoint analysis when multiple devices exist', () => {
+      const captures = [
+        makeCapture({ device: 'iPhone SE', viewport: { w: 375, h: 667 }, breakpoint: 'sm' }),
+        makeCapture({ device: 'iPhone 15', viewport: { w: 390, h: 844 }, breakpoint: 'sm' }),
+        makeCapture({ device: 'iPad Air', viewport: { w: 820, h: 1180 }, breakpoint: 'md' }),
+      ];
+
+      const report = generateMarkdownReport(captures, url);
+
+      expect(report).toContain('## Responsive Breakpoint Analysis');
+      expect(report).toContain('**sm**');
+      expect(report).toContain('2 device(s)');
+      expect(report).toContain('iPhone SE, iPhone 15');
+      expect(report).toContain('**md**');
+      expect(report).toContain('1 device(s)');
+    });
+
+    it('should mark breakpoints with issues', () => {
+      const captures = [
+        makeCapture({
+          device: 'iPhone SE',
+          viewport: { w: 375, h: 667 },
+          breakpoint: 'sm',
+          metadata: {
+            title: 'Test',
+            scrollHeight: 667,
+            scrollWidth: 500,
+            innerWidth: 375,
+            innerHeight: 667,
+            devicePixelRatio: 2,
+            hasHorizontalOverflow: true,
+          },
+        }),
+        makeCapture({ device: 'iPad Air', viewport: { w: 820, h: 1180 }, breakpoint: 'md' }),
+      ];
+
+      const report = generateMarkdownReport(captures, url);
+
+      expect(report).toContain('Issues detected');
+    });
+
+    it('should not show breakpoint analysis for single device', () => {
+      const captures = [makeCapture()];
+
+      const report = generateMarkdownReport(captures, url);
+
+      expect(report).not.toContain('## Responsive Breakpoint Analysis');
+    });
+
+    it('should note flagged pairs within same breakpoint', () => {
+      const captures = [
+        makeCapture({ device: 'iPhone SE', viewport: { w: 375, h: 667 }, breakpoint: 'sm' }),
+        makeCapture({ device: 'iPhone 15', viewport: { w: 390, h: 844 }, breakpoint: 'sm' }),
+      ];
+
+      const flagged = makeVisualDiffResult({
+        deviceA: 'iPhone SE',
+        deviceB: 'iPhone 15',
+        similarity: 0.80,
+        diffPercentage: 20.0,
+      });
+
+      const matrix = makeMatrix({
+        devices: ['iPhone SE', 'iPhone 15'],
+        results: [flagged],
+        flaggedPairs: [flagged],
+        threshold: 0.95,
+      });
+
+      const report = generateMarkdownReport(captures, url, { visualDiff: matrix });
+
+      expect(report).toContain('**Breakpoint Issues:**');
+      expect(report).toContain('**sm**');
+      expect(report).toContain('flagged pair(s) within same breakpoint');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty captures array', () => {
+      const report = generateMarkdownReport([], url);
+
+      expect(report).toContain('**Devices:** 0');
+      expect(report).toContain('## Device Summary');
+    });
+
+    it('should handle empty visual diff results', () => {
+      const captures = [makeCapture(), makeCapture({ device: 'iPad Air' })];
+
+      const matrix = makeMatrix({
+        results: [],
+        flaggedPairs: [],
+      });
+
+      const report = generateMarkdownReport(captures, url, { visualDiff: matrix });
+
+      expect(report).toContain('## Visual Diff Summary');
+      expect(report).toContain('**Pairs Compared:** 0');
+      expect(report).not.toContain('### Pairwise Similarity Matrix');
+    });
+
+    it('should handle empty DOM diffs array', () => {
+      const captures = [makeCapture()];
+
+      const report = generateMarkdownReport(captures, url, { domDiffs: [] });
+
+      // Empty array should not produce the section
+      expect(report).not.toContain('## DOM Differences');
+    });
+
+    it('should handle captures with errors in issues section', () => {
+      const captures = [
+        makeCapture({ device: 'Broken Device', error: 'Connection timeout' }),
+      ];
+
+      const report = generateMarkdownReport(captures, url);
+
+      expect(report).toContain('## Issues Found');
+      expect(report).toContain('**Broken Device**: Connection timeout');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Enhances the cross-viewport comparison report with visual diff and structural DOM analysis (#203):

- **Visual Diff Summary**: Overall PASS/FAIL status, pairwise similarity matrix table, flagged pairs details
- **DOM Differences**: Per-pair table of structural differences (type, selector, severity, description)
- **Responsive Breakpoint Analysis**: Groups devices by breakpoint, flags issues within same breakpoint
- **Backward compatible**: `generateMarkdownReport()` accepts optional `ReportOptions` parameter
- **17 unit tests** for enhanced report + **5 integration tests** for full pipeline (mocked simulators)

Depends on #269

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] All 203 unit tests pass (17 new report tests)
- [x] 5 integration tests pass (full pipeline with mocked devices)
- [ ] Backward compatibility: existing `generateMarkdownReport()` calls work unchanged

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)