### PR TITLE
test: add navigate e2e scenarios for real simulator validation

### DIFF
--- a/tests/integration/navigate-scenarios.test.ts
+++ b/tests/integration/navigate-scenarios.test.ts
@@ -79,7 +79,6 @@ describeWithSimulator('Navigate E2E: real-world scenarios (#241)', () => {
   let manager: SimulatorManager;
   let proxy: WebInspectorProxy | null = null;
   let client: WebKitClient;
-  let deviceUdid: string | null = null;
   let available = false;
   let connected = false;
 
@@ -90,7 +89,6 @@ describeWithSimulator('Navigate E2E: real-world scenarios (#241)', () => {
     manager = new SimulatorManager();
     const deviceName = await resolveDeviceName();
     const device = await manager.boot(deviceName, { timeout: BOOT_TIMEOUT });
-    deviceUdid = device.udid;
     registerManagedDevices([device.udid]);
 
     // Open Safari with retries


### PR DESCRIPTION
## Summary
- Add comprehensive integration test `navigate-scenarios.test.ts` covering all acceptance criteria from #241
- Tests real-world navigation scenarios on actual iOS simulator via WebKit Remote Debugging Protocol
- Covers: basic navigation, SPA routing (pushState + hash), redirect chains, error handling, all `waitUntil` strategies
- Zero mocked backends — requires real Xcode simulator

## Scenarios Covered
| Scenario | What it tests |
|----------|--------------|
| Basic URL navigation | Navigate to example.com, verify title/URL/status |
| SPA pushState routing | `history.pushState()` updates URL without reload |
| Hash navigation | `location.hash` changes URL fragment |
| Redirect chains | httpbin.org/redirect/2 resolves to final URL |
| Bad domain error | Non-existent domain returns meaningful error, no crash |
| 404 error page | HTTP 404 does not crash the client |
| waitUntil=load | Waits for readyState=complete |
| waitUntil=domcontentloaded | Resolves at interactive or complete |
| waitUntil=networkidle | Waits for complete + 500ms settle |
| Default waitUntil | Works without explicit strategy |

## Related Issue
Part of #241 (depends on #288 for navigate fix)

## Test plan
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] Unit tests pass (449/449)
- [ ] Integration tests pass on real simulator (`npm run test:integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)