### PR TITLE
fix: normalize Safari console levels and add error capture fallback

### DIFF
--- a/src/webkit/client.ts
+++ b/src/webkit/client.ts
@@ -1018,13 +1018,16 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
 
 
   onError(handler: (error: { message: string; stack?: string; source?: string; line?: number; column?: number }) => void): void {
-    const seen = new Set<string>();
+    const DEDUP_WINDOW_MS = 500;
+    const seen = new Map<string, number>();
     const dedup = (error: { message: string; stack?: string; source?: string; line?: number; column?: number }) => {
-      const key = error.message;
-      if (seen.has(key)) return;
-      seen.add(key);
+      const key = `${error.message}|${error.source ?? ''}|${error.line ?? ''}`;
+      const now = Date.now();
+      const lastSeen = seen.get(key);
+      if (lastSeen !== undefined && now - lastSeen < DEDUP_WINDOW_MS) return;
+      seen.set(key, now);
       if (seen.size > 200) {
-        const first = seen.values().next().value;
+        const first = seen.keys().next().value;
         if (first !== undefined) seen.delete(first);
       }
       handler(error);


### PR DESCRIPTION
## Summary
- Normalize Safari's `"warning"` console level to `"warn"` in `onConsole()` for consistent level filtering
- Add Console domain fallback in `onError()` to capture JS runtime errors (TypeError, ReferenceError) that Safari routes through `Console.messageAdded` instead of `Runtime.exceptionThrown`
- Deduplicate errors that appear in both channels using a bounded Set

## Context
E2E verification of #260 on real Safari (iOS 26.4) revealed:
1. Safari sends level `"warning"` instead of `"warn"` — `console_log` tool's level filter would miss warnings
2. Safari routes JS errors through Console domain, not Runtime domain — `error_log` tool captured 0 errors

## Test plan
- [x] `npm run build` passes
- [x] All 449 tests pass (36 suites)
- [ ] E2E: `console_log` with `level: "warn"` filter captures Safari warnings
- [ ] E2E: `error_log` captures TypeError/ReferenceError on Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)