### PR TITLE
fix: error_log captures Safari JS errors via Console domain fallback

### DIFF
--- a/src/tools/error-log.ts
+++ b/src/tools/error-log.ts
@@ -40,13 +40,16 @@ export function registerErrorLogTool(server: MCPServer): void {
 
       if (action === 'start') {
         if (attachedClient !== client) {
-          const recentMessages = new Set<string>();
+          const DEDUP_WINDOW_MS = 500;
+          const recentMessages = new Map<string, number>();
           const pushError = (entry: ErrorEntry) => {
-            const key = entry.message;
-            if (recentMessages.has(key)) return;
-            recentMessages.add(key);
+            const key = `${entry.message}|${entry.source ?? ''}|${entry.line ?? ''}`;
+            const now = Date.now();
+            const lastSeen = recentMessages.get(key);
+            if (lastSeen !== undefined && now - lastSeen < DEDUP_WINDOW_MS) return;
+            recentMessages.set(key, now);
             if (recentMessages.size > 200) {
-              const first = recentMessages.values().next().value;
+              const first = recentMessages.keys().next().value;
               if (first !== undefined) recentMessages.delete(first);
             }
             for (const c of collectors.values()) {


### PR DESCRIPTION
## Summary
- Add Console domain fallback in `error_log` tool to capture JS runtime errors on Safari
- Safari/WebKit routes TypeError, ReferenceError, etc. through `Console.messageAdded` (error level) instead of `Runtime.exceptionThrown`
- Message-based deduplication prevents double-counting when both channels fire
- Only captures messages matching JS error patterns (not general `console.error()` calls)

## Context
E2E verification of #260 showed `error_log` captured 0 errors on real Safari while `console_log` captured them as error-level messages. This is the tool-level fix complementing the WebKitClient fix in #301.

## Test plan
- [x] `npm run build` passes
- [x] All 449 tests pass (36 suites)
- [ ] E2E: `error_log` captures TypeError/ReferenceError on Safari
- [ ] E2E: No duplicate entries when both Runtime and Console channels fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)