### PR TITLE
refactor: unify device connections through SessionManager

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { registerAllTools } from './tools';
 
 // Core server
 export { MCPServer, getWebKitClient, setWebKitClient } from './mcp-server';
+export { getSessionManager, SessionManager } from './session-manager';
+export type { SimulatorInfo, WorkerInfo } from './session-manager';
 export type { MCPServerOptions } from './mcp-server';
 
 // Tool registration

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -19,25 +19,61 @@ import { createTransport, MCPTransport, TransportMode } from './transports';
 import { TOOL_TIERS, getToolTier } from './config/tool-tiers';
 import { BrowserBackend } from './types/browser-backend';
 import { logAuditEntry } from './security/audit-logger';
+import { getSessionManager } from './session-manager';
 
 // Re-export so callers can use canonical names without knowing the internal alias
 export type { MCPToolDefinition as ToolDefinition, ToolHandler };
 export { TOOL_TIERS, getToolTier };
 
 // ---------------------------------------------------------------------------
-// Global WebKit client accessor — populated during server initialization.
-// Safari tools (Epic 1B/1C) will call getWebKitClient() to obtain the active
-// BrowserBackend instance without creating circular dependencies.
+// Global WebKit client accessor — delegates to SessionManager.
+// All tools call getWebKitClient() to obtain the active BrowserBackend.
+// With SessionManager integration, multiple devices are tracked and the
+// active device connection is returned by default.
 // ---------------------------------------------------------------------------
 
-let webkitClient: BrowserBackend | null = null;
-
-export function getWebKitClient(): BrowserBackend | null {
-  return webkitClient;
+/**
+ * Get the WebKit client for a specific device or the active device.
+ * @param deviceId - Optional device UDID. Falls back to active device.
+ */
+export function getWebKitClient(deviceId?: string): BrowserBackend | null {
+  return getSessionManager().getConnection(deviceId);
 }
 
-export function setWebKitClient(client: BrowserBackend | null): void {
-  webkitClient = client;
+/**
+ * Register a WebKit client for a device and set it as active.
+ * @deprecated Prefer registering via SessionManager directly.
+ * Kept for backward compatibility with device_boot and tests.
+ */
+const LEGACY_DEVICE_ID = '__default__';
+
+export function setWebKitClient(client: BrowserBackend | null, deviceId?: string): void {
+  const sm = getSessionManager();
+  const id = deviceId ?? LEGACY_DEVICE_ID;
+
+  if (client) {
+    // Ensure a simulator entry exists for legacy callers (e.g. tests)
+    if (!sm.getSimulator(id)) {
+      sm.addSimulator(id, {
+        deviceId: id,
+        deviceType: 'legacy',
+        state: 'booted',
+        viewport: { width: 390, height: 844 },
+        bootedAt: Date.now(),
+        lastActivity: Date.now(),
+      });
+    }
+    sm.setConnection(id, client);
+    sm.setActiveDevice(id);
+  } else {
+    // Clear: remove the specified or active device's connection
+    const activeId = sm.getActiveDeviceId();
+    const targetId = deviceId ?? activeId;
+    if (targetId) {
+      sm.removeConnection(targetId);
+      sm.removeSimulator(targetId);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -73,6 +73,19 @@ export class SessionManager extends EventEmitter {
     return this.connections.get(id) ?? null;
   }
 
+  removeConnection(deviceId: string): void {
+    this.connections.delete(deviceId);
+    this.emit('connection:removed', { deviceId });
+  }
+
+  hasConnection(deviceId: string): boolean {
+    return this.connections.has(deviceId);
+  }
+
+  listConnections(): Array<{ deviceId: string; client: BrowserBackend }> {
+    return Array.from(this.connections.entries()).map(([deviceId, client]) => ({ deviceId, client }));
+  }
+
   // Active device
   setActiveDevice(deviceId: string): void {
     if (!this.simulators.has(deviceId)) {

--- a/src/simulator/pool.ts
+++ b/src/simulator/pool.ts
@@ -16,6 +16,7 @@ import {
 } from '../config/defaults';
 import { registerManagedDevices, unregisterManagedDevices } from '../reliability/zombie-cleanup';
 import { CircuitBreakerRegistry } from '../reliability/circuit-breaker';
+import { getSessionManager } from '../session-manager';
 
 const execFileAsync = promisify(execFile);
 
@@ -160,6 +161,23 @@ export class SimulatorPool extends EventEmitter {
     const udids = results.map(r => r.device.udid);
     registerManagedDevices(udids);
 
+    // Sync pool state to SessionManager for unified connection tracking
+    const sm = getSessionManager();
+    for (const pooled of results) {
+      const presetInfo = DEVICE_PRESETS[pooled.preset];
+      sm.addSimulator(pooled.device.udid, {
+        deviceId: pooled.device.udid,
+        deviceType: pooled.device.name,
+        state: 'booted',
+        viewport: { width: presetInfo?.w ?? 390, height: presetInfo?.h ?? 844 },
+        bootedAt: pooled.bootedAt,
+        lastActivity: pooled.lastActivity,
+      });
+      if (pooled.client.isConnected()) {
+        sm.setConnection(pooled.device.udid, pooled.client);
+      }
+    }
+
     return results;
   }
 
@@ -187,6 +205,7 @@ export class SimulatorPool extends EventEmitter {
   async shutdownAll(): Promise<void> {
     this.stopIdleMonitor();
     this.stopResourceMonitor();
+    const sm = getSessionManager();
     await Promise.allSettled(
       this.getAll().map(async (sim) => {
         try {
@@ -195,6 +214,7 @@ export class SimulatorPool extends EventEmitter {
         try {
           await this.manager.shutdown(sim.device.udid);
         } catch { /* best effort */ }
+        sm.removeSimulator(sim.device.udid);
         this.pool.delete(sim.device.udid);
       })
     );
@@ -210,6 +230,7 @@ export class SimulatorPool extends EventEmitter {
     if (!sim) return;
     try { await sim.client.disconnect(); } catch { /* */ }
     try { await this.manager.shutdown(deviceId); } catch { /* */ }
+    getSessionManager().removeSimulator(deviceId);
     this.pool.delete(deviceId);
     this.devicePorts.delete(deviceId);
 

--- a/src/tools/device-boot.ts
+++ b/src/tools/device-boot.ts
@@ -1,8 +1,10 @@
-import { MCPServer, getWebKitClient, setWebKitClient } from '../mcp-server';
+import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { getSharedProxy } from '../simulator/proxy';
 import { WebKitClient } from '../webkit/client';
 import { addManagedDevice } from '../reliability/zombie-cleanup';
+import { getSessionManager } from '../session-manager';
+import { DEVICE_PRESETS } from '../simulator/presets';
 
 export function registerDeviceBootTool(server: MCPServer): void {
   server.registerTool(
@@ -34,10 +36,15 @@ export function registerDeviceBootTool(server: MCPServer): void {
 
         // Open Safari so it registers with WebInspector, then connect WebKitClient
         try {
-          // Disconnect any existing client to avoid leaking WebSocket connections on re-boot
-          const existingClient = getWebKitClient();
-          if (existingClient) {
-            try { await existingClient.disconnect(); } catch { /* best-effort */ }
+          const sm = getSessionManager();
+
+          // Disconnect any existing client for THIS device to avoid leaking WebSocket connections
+          if (sm.hasConnection(device.udid)) {
+            const existingClient = sm.getConnection(device.udid);
+            if (existingClient) {
+              try { await existingClient.disconnect(); } catch { /* best-effort */ }
+            }
+            sm.removeConnection(device.udid);
           }
 
           // Retry openUrl — the simulator may report "Booted" before app
@@ -53,10 +60,23 @@ export function registerDeviceBootTool(server: MCPServer): void {
               await new Promise(r => setTimeout(r, 2000));
             }
           }
+
           // Connect to WebKit with retries — Safari may need time to register with WebInspector
           const client = new WebKitClient({ host: 'localhost', port: proxy.port });
           await client.connect({ retries: 5, retryDelay: 2000 });
-          setWebKitClient(client);
+
+          // Register in SessionManager — tracks connection and sets as active device
+          const preset = Object.entries(DEVICE_PRESETS).find(([, p]) => p.name === device.name);
+          sm.addSimulator(device.udid, {
+            deviceId: device.udid,
+            deviceType: device.name,
+            state: 'booted',
+            viewport: { width: preset?.[1]?.w ?? 390, height: preset?.[1]?.h ?? 844 },
+            bootedAt: Date.now(),
+            lastActivity: Date.now(),
+          });
+          sm.setConnection(device.udid, client);
+          sm.setActiveDevice(device.udid);
         } catch (err) {
           console.error(`[device_boot] WebKit connection failed (proxy running, tools may not work): ${err}`);
         }

--- a/src/tools/device-shutdown.ts
+++ b/src/tools/device-shutdown.ts
@@ -1,6 +1,7 @@
-import { MCPServer, getWebKitClient, setWebKitClient } from '../mcp-server';
+import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { getSharedProxy } from '../simulator/proxy';
+import { getSessionManager } from '../session-manager';
 
 export function registerDeviceShutdownTool(server: MCPServer): void {
   server.registerTool(
@@ -17,27 +18,31 @@ export function registerDeviceShutdownTool(server: MCPServer): void {
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
       const manager = new SimulatorManager();
+      const sm = getSessionManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
       if (!deviceId) {
         return { content: [{ type: 'text' as const, text: 'Error: no booted device found' }], isError: true };
       }
 
-      // Disconnect and clear the WebKitClient before shutting down
-      const client = getWebKitClient();
-      if (client) {
-        try {
-          await client.disconnect();
-        } catch (err) {
-          console.error(`[device_shutdown] WebKit disconnect failed: ${err}`);
+      // Disconnect and remove the WebKitClient via SessionManager
+      if (sm.hasConnection(deviceId)) {
+        const client = sm.getConnection(deviceId);
+        if (client) {
+          try {
+            await client.disconnect();
+          } catch (err) {
+            console.error(`[device_shutdown] WebKit disconnect failed: ${err}`);
+          }
         }
       }
-      setWebKitClient(null);
+      // Remove simulator from SessionManager (also clears connection, updates active device)
+      sm.removeSimulator(deviceId);
 
-      // Stop the WebInspector proxy if we own it
+      // Stop the WebInspector proxy if no more connections remain
       const proxy = getSharedProxy();
       let proxyStopped = false;
-      if (proxy.running) {
+      if (proxy.running && sm.listConnections().length === 0) {
         try {
           await proxy.stop();
           proxyStopped = true;

--- a/tests/unit/session-manager-integration.test.ts
+++ b/tests/unit/session-manager-integration.test.ts
@@ -1,0 +1,219 @@
+/**
+ * SessionManager Integration Tests
+ * Verifies that getWebKitClient/setWebKitClient delegate to SessionManager
+ * and that multi-device connection tracking works correctly.
+ */
+
+import { getWebKitClient, setWebKitClient } from '../../src/mcp-server';
+import { getSessionManager } from '../../src/session-manager';
+import { BrowserBackend } from '../../src/types/browser-backend';
+
+function createMockClient(id: string): BrowserBackend {
+  return {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    isConnected: () => true,
+    navigate: jest.fn(),
+    screenshot: jest.fn(),
+    evaluate: jest.fn(),
+    readPage: jest.fn(),
+    getCookies: jest.fn(),
+    setCookies: jest.fn(),
+    clearCookies: jest.fn(),
+    click: jest.fn(),
+    type: jest.fn(),
+    scroll: jest.fn(),
+    longPress: jest.fn(),
+    swipe: jest.fn(),
+    press: jest.fn(),
+    dismissKeyboard: jest.fn(),
+    selectOption: jest.fn(),
+    querySelector: jest.fn(),
+    querySelectorAll: jest.fn(),
+    inspect: jest.fn(),
+    waitFor: jest.fn(),
+    onConsole: jest.fn(),
+    onRequest: jest.fn(),
+    onResponse: jest.fn(),
+    _id: id, // for identification in tests
+  } as unknown as BrowserBackend;
+}
+
+describe('SessionManager Integration', () => {
+  beforeEach(() => {
+    // Reset SessionManager state
+    const sm = getSessionManager();
+    // Clear all simulators and connections
+    for (const sim of sm.listSimulators()) {
+      sm.removeSimulator(sim.deviceId);
+    }
+  });
+
+  describe('Legacy setWebKitClient/getWebKitClient', () => {
+    it('should store and retrieve client via legacy API', () => {
+      const mock = createMockClient('legacy');
+      setWebKitClient(mock);
+      expect(getWebKitClient()).toBe(mock);
+    });
+
+    it('should clear client when set to null', () => {
+      const mock = createMockClient('legacy');
+      setWebKitClient(mock);
+      expect(getWebKitClient()).toBe(mock);
+      setWebKitClient(null);
+      expect(getWebKitClient()).toBeNull();
+    });
+
+    it('should replace client on repeated set', () => {
+      const mock1 = createMockClient('first');
+      const mock2 = createMockClient('second');
+      setWebKitClient(mock1);
+      expect(getWebKitClient()).toBe(mock1);
+      setWebKitClient(mock2);
+      expect(getWebKitClient()).toBe(mock2);
+    });
+  });
+
+  describe('Multi-device via SessionManager', () => {
+    it('should track multiple device connections', () => {
+      const sm = getSessionManager();
+      const clientA = createMockClient('device-A');
+      const clientB = createMockClient('device-B');
+
+      sm.addSimulator('udid-A', {
+        deviceId: 'udid-A',
+        deviceType: 'iPhone 17',
+        state: 'booted',
+        viewport: { width: 390, height: 844 },
+        bootedAt: Date.now(),
+        lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-A', clientA);
+
+      sm.addSimulator('udid-B', {
+        deviceId: 'udid-B',
+        deviceType: 'iPad Pro',
+        state: 'booted',
+        viewport: { width: 1024, height: 1366 },
+        bootedAt: Date.now(),
+        lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-B', clientB);
+
+      // First registered becomes active
+      expect(getWebKitClient()).toBe(clientA);
+      // Specific device retrieval
+      expect(getWebKitClient('udid-A')).toBe(clientA);
+      expect(getWebKitClient('udid-B')).toBe(clientB);
+    });
+
+    it('should switch active device', () => {
+      const sm = getSessionManager();
+      const clientA = createMockClient('device-A');
+      const clientB = createMockClient('device-B');
+
+      sm.addSimulator('udid-A', {
+        deviceId: 'udid-A', deviceType: 'iPhone 17', state: 'booted',
+        viewport: { width: 390, height: 844 }, bootedAt: Date.now(), lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-A', clientA);
+
+      sm.addSimulator('udid-B', {
+        deviceId: 'udid-B', deviceType: 'iPad Pro', state: 'booted',
+        viewport: { width: 1024, height: 1366 }, bootedAt: Date.now(), lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-B', clientB);
+
+      // Default is first device
+      expect(getWebKitClient()).toBe(clientA);
+
+      // Switch active
+      sm.setActiveDevice('udid-B');
+      expect(getWebKitClient()).toBe(clientB);
+
+      // Specific retrieval still works
+      expect(getWebKitClient('udid-A')).toBe(clientA);
+    });
+
+    it('should fallback to next device when active is removed', () => {
+      const sm = getSessionManager();
+      const clientA = createMockClient('device-A');
+      const clientB = createMockClient('device-B');
+
+      sm.addSimulator('udid-A', {
+        deviceId: 'udid-A', deviceType: 'iPhone 17', state: 'booted',
+        viewport: { width: 390, height: 844 }, bootedAt: Date.now(), lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-A', clientA);
+
+      sm.addSimulator('udid-B', {
+        deviceId: 'udid-B', deviceType: 'iPad Pro', state: 'booted',
+        viewport: { width: 1024, height: 1366 }, bootedAt: Date.now(), lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-B', clientB);
+
+      expect(getWebKitClient()).toBe(clientA);
+
+      // Remove active device → should fallback to udid-B
+      sm.removeSimulator('udid-A');
+      expect(getWebKitClient()).toBe(clientB);
+      expect(sm.getActiveDeviceId()).toBe('udid-B');
+    });
+
+    it('should return null when all devices removed', () => {
+      const sm = getSessionManager();
+      const client = createMockClient('device');
+
+      sm.addSimulator('udid-1', {
+        deviceId: 'udid-1', deviceType: 'iPhone', state: 'booted',
+        viewport: { width: 390, height: 844 }, bootedAt: Date.now(), lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-1', client);
+
+      sm.removeSimulator('udid-1');
+      expect(getWebKitClient()).toBeNull();
+      expect(sm.getActiveDeviceId()).toBeNull();
+    });
+  });
+
+  describe('Connection helpers', () => {
+    it('hasConnection returns correct state', () => {
+      const sm = getSessionManager();
+      const client = createMockClient('test');
+
+      sm.addSimulator('udid-1', {
+        deviceId: 'udid-1', deviceType: 'iPhone', state: 'booted',
+        viewport: { width: 390, height: 844 }, bootedAt: Date.now(), lastActivity: Date.now(),
+      });
+
+      expect(sm.hasConnection('udid-1')).toBe(false);
+      sm.setConnection('udid-1', client);
+      expect(sm.hasConnection('udid-1')).toBe(true);
+      sm.removeConnection('udid-1');
+      expect(sm.hasConnection('udid-1')).toBe(false);
+    });
+
+    it('listConnections returns all active connections', () => {
+      const sm = getSessionManager();
+      const clientA = createMockClient('A');
+      const clientB = createMockClient('B');
+
+      sm.addSimulator('udid-A', {
+        deviceId: 'udid-A', deviceType: 'iPhone', state: 'booted',
+        viewport: { width: 390, height: 844 }, bootedAt: Date.now(), lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-A', clientA);
+
+      sm.addSimulator('udid-B', {
+        deviceId: 'udid-B', deviceType: 'iPad', state: 'booted',
+        viewport: { width: 1024, height: 1366 }, bootedAt: Date.now(), lastActivity: Date.now(),
+      });
+      sm.setConnection('udid-B', clientB);
+
+      const conns = sm.listConnections();
+      expect(conns).toHaveLength(2);
+      expect(conns.find(c => c.deviceId === 'udid-A')?.client).toBe(clientA);
+      expect(conns.find(c => c.deviceId === 'udid-B')?.client).toBe(clientB);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replace global `webkitClient` singleton with `SessionManager` delegation, enabling multi-device connection tracking
- `device_boot` now registers devices in `SessionManager` instead of overwriting a global variable
- `device_shutdown` properly removes from `SessionManager` and auto-switches active device
- `SimulatorPool` syncs boot/shutdown state to `SessionManager`
- All 30+ existing tool files work unchanged (backward compatible `getWebKitClient()` signature)

## Key Changes

| File | Change |
|------|--------|
| `src/mcp-server.ts` | `getWebKitClient()` delegates to `SessionManager.getConnection()` |
| `src/session-manager.ts` | Add `removeConnection()`, `hasConnection()`, `listConnections()` |
| `src/tools/device-boot.ts` | Register device in SessionManager with viewport info |
| `src/tools/device-shutdown.ts` | Remove from SessionManager, conditional proxy stop |
| `src/simulator/pool.ts` | Sync `bootAll()`/`shutdownAll()`/`shutdownOne()` to SessionManager |
| `src/index.ts` | Export `SessionManager` types |

## What This Enables

With this change, OpenSafari can now track multiple device connections simultaneously:
```
device_boot iPhone 17  → SessionManager tracks as active
device_boot iPad Pro   → SessionManager tracks, iPad becomes active
                         iPhone 17 connection preserved (not destroyed!)
getWebKitClient()      → returns iPad Pro (active)
getWebKitClient(iphone_udid) → returns iPhone 17 (specific)
```

Previously, `device_boot` would destroy the existing connection on every call.

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 514 tests pass (505 existing + 9 new)
- [x] Legacy `setWebKitClient(mock)` / `setWebKitClient(null)` pattern works (existing test suites pass)
- [x] New tests verify: multi-device tracking, active device switching, fallback on removal
- [ ] Manual: boot 2 devices → both accessible via `getWebKitClient(udid)`

Closes #304
Part of #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)