### PR TITLE
feat: multi-tab multiplexing within a single simulator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ export type { WebKitClientOptions, WebKitTarget } from './webkit/client';
 // Simulator
 export { SimulatorManager } from './simulator';
 export { SimulatorPool } from './simulator/pool';
+export { TabPool } from './simulator/tab-pool';
+export type { TabInfo, TabPoolOptions } from './simulator/tab-pool';
+export { TabClient } from './simulator/tab-client';
 export type { PooledSimulator, SimulatorPoolOptions } from './simulator/pool';
 export { WebInspectorProxy, getSharedProxy } from './simulator/proxy';
 export type { ProxyOptions } from './simulator/proxy';

--- a/src/simulator/tab-client.ts
+++ b/src/simulator/tab-client.ts
@@ -1,0 +1,318 @@
+/**
+ * TabClient — Per-tab BrowserBackend wrapper.
+ *
+ * Delegates all operations to the underlying WebKitClient with a pinned targetId,
+ * enabling multiple tabs to be controlled independently through the same WebSocket.
+ */
+
+import { EventEmitter } from 'events';
+import {
+  BrowserBackend,
+  NavigateOptions,
+  NavigateResult,
+  ScreenshotOptions,
+  ElementInfo,
+  Cookie,
+} from '../types/browser-backend';
+import { WebKitClient } from '../webkit/client';
+
+export class TabClient extends EventEmitter implements BrowserBackend {
+  constructor(
+    private client: WebKitClient,
+    private targetId: string,
+  ) {
+    super();
+    // Forward inner events scoped to this target
+    this.client.on('target:destroyed', (event: { targetId: string }) => {
+      if (event.targetId === this.targetId) {
+        this.emit('disconnect');
+      }
+    });
+  }
+
+  getTargetId(): string {
+    return this.targetId;
+  }
+
+  // ========== Lifecycle ==========
+
+  async connect(): Promise<void> {
+    // TabClient reuses the parent WebKitClient's connection — no-op
+    if (!this.client.isConnected()) {
+      throw new Error('Parent WebKitClient is not connected');
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    // TabClient doesn't own the WebSocket — no-op
+    // Tab closure is handled by TabPool
+  }
+
+  isConnected(): boolean {
+    return this.client.isConnected() && this.client.getKnownTargets().has(this.targetId);
+  }
+
+  // ========== Core ==========
+
+  async navigate(options: NavigateOptions): Promise<NavigateResult> {
+    const start = Date.now();
+    await this.send('Page.navigate', { url: options.url });
+    // Wait for load event
+    if (options.waitUntil === 'load' || !options.waitUntil) {
+      await this.waitForEvent('Page.loadEventFired', options.timeout ?? 30000);
+    }
+    return { url: options.url, status: 200, loadTime: Date.now() - start };
+  }
+
+  async screenshot(_options?: ScreenshotOptions): Promise<Buffer> {
+    await this.enableDomain('Page');
+    const result = await this.send<{ dataURL: string }>('Page.snapshotRect', {
+      x: 0, y: 0, width: 0, height: 0, coordinateSystem: 'Viewport',
+    });
+    const base64 = result.dataURL.replace(/^data:image\/png;base64,/, '');
+    return Buffer.from(base64, 'base64');
+  }
+
+  async evaluate<T = unknown>(expression: string): Promise<T> {
+    await this.enableDomain('Runtime');
+    const result = await this.send<{ result: { value: T }; wasThrown?: boolean; exceptionDetails?: any }>(
+      'Runtime.evaluate',
+      { expression, returnByValue: true },
+    );
+    if (result.wasThrown) {
+      throw new Error(`Evaluation failed: ${JSON.stringify(result.exceptionDetails ?? result.result)}`);
+    }
+    return result.result.value;
+  }
+
+  async readPage(): Promise<string> {
+    return this.evaluate<string>('document.documentElement.outerHTML');
+  }
+
+  // ========== Cookies ==========
+
+  async getCookies(domain?: string): Promise<Cookie[]> {
+    await this.enableDomain('Page');
+    const result = await this.send<{ cookies: Cookie[] }>('Page.getCookies');
+    if (domain) {
+      return result.cookies.filter(c => c.domain.includes(domain));
+    }
+    return result.cookies;
+  }
+
+  async setCookies(cookies: Cookie[]): Promise<void> {
+    await this.enableDomain('Page');
+    for (const cookie of cookies) {
+      await this.send('Page.setCookie', cookie as unknown as Record<string, unknown>);
+    }
+  }
+
+  async clearCookies(): Promise<void> {
+    const cookies = await this.getCookies();
+    for (const cookie of cookies) {
+      await this.send('Page.deleteCookie', { cookieName: cookie.name, url: `https://${cookie.domain}${cookie.path}` });
+    }
+  }
+
+  // ========== Interaction ==========
+
+  async click(target: string | { x: number; y: number }): Promise<void> {
+    if (typeof target === 'string') {
+      const el = await this.querySelector(target);
+      if (!el?.boundingBox) throw new Error(`Element not found or not visible: ${target}`);
+      const { x, y, width, height } = el.boundingBox;
+      await this.simulateTouch(x + width / 2, y + height / 2);
+    } else {
+      await this.simulateTouch(target.x, target.y);
+    }
+  }
+
+  async type(selector: string, text: string, options?: { delay?: number }): Promise<void> {
+    await this.click(selector);
+    const delay = options?.delay ?? 50;
+    for (const char of text) {
+      await this.send('Input.dispatchKeyEvent', { type: 'keyDown', text: char });
+      await this.send('Input.dispatchKeyEvent', { type: 'keyUp', text: char });
+      if (delay > 0) await new Promise(r => setTimeout(r, delay));
+    }
+  }
+
+  async scroll(direction: 'up' | 'down' | 'left' | 'right', amount: number): Promise<void> {
+    const deltaX = direction === 'left' ? -amount : direction === 'right' ? amount : 0;
+    const deltaY = direction === 'up' ? -amount : direction === 'down' ? amount : 0;
+    await this.evaluate(`window.scrollBy(${deltaX}, ${deltaY})`);
+  }
+
+  async longPress(selector: string, duration?: number): Promise<void> {
+    const el = await this.querySelector(selector);
+    if (!el?.boundingBox) throw new Error(`Element not found: ${selector}`);
+    const { x, y, width, height } = el.boundingBox;
+    const cx = x + width / 2;
+    const cy = y + height / 2;
+    await this.evaluate(`
+      (function(x, y, dur) {
+        var el = document.elementFromPoint(x, y);
+        if (!el) return;
+        var ts = document.createTouch(window, el, 1, x, y, x, y);
+        var tl = document.createTouchList(ts);
+        el.dispatchEvent(new TouchEvent('touchstart', { touches: tl, changedTouches: tl, bubbles: true }));
+        setTimeout(function() {
+          el.dispatchEvent(new TouchEvent('touchend', { touches: document.createTouchList(), changedTouches: tl, bubbles: true }));
+        }, dur);
+      })(${cx}, ${cy}, ${duration ?? 500})
+    `);
+    await new Promise(r => setTimeout(r, (duration ?? 500) + 100));
+  }
+
+  async swipe(direction: 'up' | 'down' | 'left' | 'right', speed?: number): Promise<void> {
+    const dist = speed ?? 300;
+    const dx = direction === 'left' ? -dist : direction === 'right' ? dist : 0;
+    const dy = direction === 'up' ? -dist : direction === 'down' ? dist : 0;
+    await this.evaluate(`window.scrollBy(${dx}, ${dy})`);
+  }
+
+  async press(key: string): Promise<void> {
+    await this.send('Input.dispatchKeyEvent', { type: 'keyDown', text: key });
+    await this.send('Input.dispatchKeyEvent', { type: 'keyUp', text: key });
+  }
+
+  async dismissKeyboard(): Promise<void> {
+    await this.evaluate('document.activeElement?.blur()');
+  }
+
+  async selectOption(selector: string, value: string): Promise<void> {
+    await this.evaluate(`
+      (function() {
+        var el = document.querySelector(${JSON.stringify(selector)});
+        if (!el) throw new Error('Element not found');
+        el.value = ${JSON.stringify(value)};
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      })()
+    `);
+  }
+
+  // ========== DOM ==========
+
+  async querySelector(selector: string): Promise<ElementInfo | null> {
+    return this.evaluate<ElementInfo | null>(`
+      (function() {
+        var el = document.querySelector(${JSON.stringify(selector)});
+        if (!el) return null;
+        var rect = el.getBoundingClientRect();
+        var cs = window.getComputedStyle(el);
+        return {
+          selector: ${JSON.stringify(selector)},
+          tag: el.tagName.toLowerCase(),
+          text: (el.textContent || '').substring(0, 200),
+          attributes: Object.fromEntries(Array.from(el.attributes).map(function(a) { return [a.name, a.value]; })),
+          boundingBox: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+          isVisible: cs.display !== 'none' && cs.visibility !== 'hidden' && rect.width > 0 && rect.height > 0
+        };
+      })()
+    `);
+  }
+
+  async querySelectorAll(selector: string): Promise<ElementInfo[]> {
+    return this.evaluate<ElementInfo[]>(`
+      Array.from(document.querySelectorAll(${JSON.stringify(selector)})).map(function(el) {
+        var rect = el.getBoundingClientRect();
+        return {
+          selector: ${JSON.stringify(selector)},
+          tag: el.tagName.toLowerCase(),
+          text: (el.textContent || '').substring(0, 200),
+          attributes: Object.fromEntries(Array.from(el.attributes).map(function(a) { return [a.name, a.value]; })),
+          boundingBox: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+          isVisible: window.getComputedStyle(el).display !== 'none' && rect.width > 0 && rect.height > 0
+        };
+      })
+    `);
+  }
+
+  async inspect(selector: string): Promise<Record<string, unknown>> {
+    return this.evaluate<Record<string, unknown>>(`
+      (function() {
+        var el = document.querySelector(${JSON.stringify(selector)});
+        if (!el) return { error: 'Element not found' };
+        var rect = el.getBoundingClientRect();
+        var cs = window.getComputedStyle(el);
+        return {
+          tag: el.tagName.toLowerCase(),
+          id: el.id,
+          className: el.className,
+          text: (el.textContent || '').substring(0, 500),
+          boundingBox: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+          styles: { display: cs.display, position: cs.position, zIndex: cs.zIndex, opacity: cs.opacity },
+        };
+      })()
+    `);
+  }
+
+  async waitFor(selector: string, options?: { visible?: boolean; timeout?: number }): Promise<void> {
+    const timeout = options?.timeout ?? 10000;
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      const el = await this.querySelector(selector);
+      if (el && (!options?.visible || el.isVisible)) return;
+      await new Promise(r => setTimeout(r, 200));
+    }
+    throw new Error(`waitFor: ${selector} not found within ${timeout}ms`);
+  }
+
+  // ========== Events ==========
+
+  onConsole(handler: (msg: { type: string; text: string }) => void): void {
+    this.client.on('Runtime.consoleAPICalled', (params: any) => {
+      handler({ type: params.type, text: params.args?.map((a: any) => a.value ?? a.description).join(' ') ?? '' });
+    });
+  }
+
+  onRequest(handler: (request: { url: string; method: string }) => void): void {
+    this.client.on('Network.requestWillBeSent', (params: any) => {
+      handler({ url: params.request?.url, method: params.request?.method });
+    });
+  }
+
+  onResponse(handler: (response: { url: string; status: number }) => void): void {
+    this.client.on('Network.responseReceived', (params: any) => {
+      handler({ url: params.response?.url, status: params.response?.status });
+    });
+  }
+
+  // ========== Private Helpers ==========
+
+  private async send<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
+    return this.client.sendToTarget<T>(method, params, this.targetId);
+  }
+
+  private async enableDomain(domain: string): Promise<void> {
+    await this.client.enableDomainForTarget(domain, this.targetId);
+  }
+
+  private async simulateTouch(x: number, y: number): Promise<void> {
+    await this.evaluate(`
+      (function(x, y) {
+        var el = document.elementFromPoint(x, y);
+        if (!el) return;
+        var ts = document.createTouch(window, el, 1, x, y, x, y);
+        var tl = document.createTouchList(ts);
+        el.dispatchEvent(new TouchEvent('touchstart', { touches: tl, changedTouches: tl, bubbles: true }));
+        el.dispatchEvent(new TouchEvent('touchend', { touches: document.createTouchList(), changedTouches: tl, bubbles: true }));
+        el.click();
+      })(${x}, ${y})
+    `);
+  }
+
+  private waitForEvent(eventName: string, timeout: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.client.removeListener(eventName, handler);
+        reject(new Error(`Timeout waiting for ${eventName}`));
+      }, timeout);
+      const handler = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      this.client.once(eventName, handler);
+    });
+  }
+}

--- a/src/simulator/tab-pool.ts
+++ b/src/simulator/tab-pool.ts
@@ -1,0 +1,201 @@
+/**
+ * TabPool — Manages multiple Safari tabs within a single simulator.
+ *
+ * Opens tabs via `simctl openurl`, discovers new targets via ios-webkit-debug-proxy's
+ * /json endpoint, and creates TabClient wrappers for independent per-tab control.
+ * This enables lightweight parallelism (~15-50MB per tab vs ~2GB per simulator).
+ */
+
+import { EventEmitter } from 'events';
+import { SimulatorManager } from './manager';
+import { WebKitClient, WebKitTarget } from '../webkit/client';
+import { TabClient } from './tab-client';
+
+export interface TabInfo {
+  targetId: string;
+  url: string;
+  client: TabClient;
+  createdAt: number;
+}
+
+export interface TabPoolOptions {
+  /** Maximum tabs per simulator (default: 10) */
+  maxTabs?: number;
+  /** Time to wait for new target to appear after openurl (default: 5000ms) */
+  targetDiscoveryTimeout?: number;
+}
+
+export class TabPool extends EventEmitter {
+  private tabs: Map<string, TabInfo> = new Map();
+  private manager: SimulatorManager;
+  private maxTabs: number;
+  private discoveryTimeout: number;
+
+  constructor(
+    private client: WebKitClient,
+    private deviceId: string,
+    options?: TabPoolOptions,
+  ) {
+    super();
+    this.manager = new SimulatorManager();
+    this.maxTabs = options?.maxTabs ?? 10;
+    this.discoveryTimeout = options?.targetDiscoveryTimeout ?? 5000;
+
+    // Track target destruction
+    this.client.on('target:destroyed', (event: { targetId: string }) => {
+      if (this.tabs.has(event.targetId)) {
+        this.tabs.delete(event.targetId);
+        this.emit('tab:closed', { targetId: event.targetId });
+      }
+    });
+  }
+
+  /**
+   * Open a new Safari tab by navigating to a URL.
+   * Returns a TabClient for independent control of the new tab.
+   */
+  async openTab(url: string): Promise<TabClient> {
+    if (this.tabs.size >= this.maxTabs) {
+      throw new Error(`Tab limit reached (${this.maxTabs}). Close tabs before opening new ones.`);
+    }
+
+    // Snapshot current targets before opening new tab
+    const beforeTargets = await this.client.listTargets();
+    const beforeIds = new Set(beforeTargets.map(t => t.id));
+
+    // Open URL — creates a new Safari tab
+    await this.manager.openUrl(this.deviceId, url);
+
+    // Wait for new target to appear
+    const newTarget = await this.waitForNewTarget(beforeIds);
+
+    const tabClient = new TabClient(this.client, newTarget.id);
+    this.tabs.set(newTarget.id, {
+      targetId: newTarget.id,
+      url,
+      client: tabClient,
+      createdAt: Date.now(),
+    });
+
+    this.emit('tab:opened', { targetId: newTarget.id, url });
+    return tabClient;
+  }
+
+  /**
+   * Get a TabClient for the current active (first) tab.
+   * Useful when a tab already exists from the initial boot.
+   */
+  async getDefaultTab(): Promise<TabClient> {
+    const targets = await this.client.listTargets();
+    const pageTarget = targets.find(t => t.type === 'page' || !t.type);
+    if (!pageTarget) {
+      throw new Error('No Safari tab found. Is Safari open?');
+    }
+
+    if (this.tabs.has(pageTarget.id)) {
+      return this.tabs.get(pageTarget.id)!.client;
+    }
+
+    const tabClient = new TabClient(this.client, pageTarget.id);
+    this.tabs.set(pageTarget.id, {
+      targetId: pageTarget.id,
+      url: pageTarget.url,
+      client: tabClient,
+      createdAt: Date.now(),
+    });
+
+    return tabClient;
+  }
+
+  /**
+   * Close a specific tab.
+   */
+  async closeTab(targetId: string): Promise<void> {
+    const tab = this.tabs.get(targetId);
+    if (!tab) return;
+
+    try {
+      // Close tab by navigating to about:blank then closing via JavaScript
+      await tab.client.evaluate('window.close()');
+    } catch {
+      // Tab may already be gone
+    }
+
+    this.tabs.delete(targetId);
+    this.emit('tab:closed', { targetId });
+  }
+
+  /**
+   * List all managed tabs.
+   */
+  listTabs(): TabInfo[] {
+    return Array.from(this.tabs.values());
+  }
+
+  /**
+   * Get a specific tab's client.
+   */
+  getTab(targetId: string): TabClient | null {
+    return this.tabs.get(targetId)?.client ?? null;
+  }
+
+  /**
+   * Get count of open tabs.
+   */
+  get size(): number {
+    return this.tabs.size;
+  }
+
+  /**
+   * Close all tabs managed by this pool.
+   */
+  async closeAll(): Promise<void> {
+    const ids = Array.from(this.tabs.keys());
+    for (const id of ids) {
+      await this.closeTab(id);
+    }
+  }
+
+  /**
+   * Discover all existing Safari tabs and wrap them as TabClients.
+   */
+  async discoverExistingTabs(): Promise<TabClient[]> {
+    const targets = await this.client.listTargets();
+    const clients: TabClient[] = [];
+
+    for (const target of targets) {
+      if (this.tabs.has(target.id)) {
+        clients.push(this.tabs.get(target.id)!.client);
+        continue;
+      }
+
+      const tabClient = new TabClient(this.client, target.id);
+      this.tabs.set(target.id, {
+        targetId: target.id,
+        url: target.url,
+        client: tabClient,
+        createdAt: Date.now(),
+      });
+      clients.push(tabClient);
+    }
+
+    return clients;
+  }
+
+  private async waitForNewTarget(beforeIds: Set<string>): Promise<WebKitTarget> {
+    const start = Date.now();
+    const pollInterval = 300;
+
+    while (Date.now() - start < this.discoveryTimeout) {
+      const currentTargets = await this.client.listTargets();
+      const newTarget = currentTargets.find(t => !beforeIds.has(t.id));
+      if (newTarget) return newTarget;
+      await new Promise(r => setTimeout(r, pollInterval));
+    }
+
+    throw new Error(
+      `New tab target not discovered within ${this.discoveryTimeout}ms. ` +
+      'Safari may not have opened the URL.'
+    );
+  }
+}

--- a/src/webkit/client.ts
+++ b/src/webkit/client.ts
@@ -54,6 +54,7 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
 
   // Target-multiplexed protocol state
   private activeTargetId: string | null = null;
+  private knownTargets: Set<string> = new Set();
   private innerMessageId = 0;
   private innerPendingRequests: Map<
     number,
@@ -115,6 +116,7 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
     this.connected = false;
     this.enabledDomains.clear();
     this.activeTargetId = null;
+    this.knownTargets.clear();
     this.targetReady = null;
     this.targetReadyResolve = null;
   }
@@ -133,14 +135,31 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
 
   // ========== Protocol Message Layer ==========
 
+  /**
+   * Send a protocol command to the active target.
+   * For multi-tab, use sendToTarget() with an explicit targetId.
+   */
   async send<T = unknown>(
     method: string,
     params?: Record<string, unknown>,
   ): Promise<T> {
+    return this.sendToTarget<T>(method, params, this.activeTargetId);
+  }
+
+  /**
+   * Send a protocol command to a specific target (tab).
+   * @param targetId - Target to send to. Falls back to activeTargetId if null.
+   */
+  async sendToTarget<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    targetId?: string | null,
+  ): Promise<T> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new ConnectionError('WebSocket not connected');
     }
-    if (!this.activeTargetId) {
+    const resolvedTargetId = targetId ?? this.activeTargetId;
+    if (!resolvedTargetId) {
       throw new ConnectionError(
         'No active target. Is Safari open in the simulator?',
       );
@@ -183,7 +202,7 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
       JSON.stringify({
         id: outerId,
         method: 'Target.sendMessageToTarget',
-        params: { targetId: this.activeTargetId, message: innerMessage },
+        params: { targetId: resolvedTargetId, message: innerMessage },
       }),
     );
 
@@ -202,28 +221,41 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
     if (msg.method === 'Target.targetCreated') {
       const info = msg.params?.targetInfo;
       if (info?.type === 'page') {
-        // Always track the latest page target
-        // If old target still exists, it will be destroyed shortly
-        this.activeTargetId = info.targetId;
+        this.knownTargets.add(info.targetId);
+        this.emit('target:created', { targetId: info.targetId, url: info.url });
+
+        // Set as active target only if none is active yet (single-tab compat)
+        // In multi-tab mode, callers manage targets explicitly via TabPool
+        if (!this.activeTargetId) {
+          this.activeTargetId = info.targetId;
+        }
+
         // Re-enable domains on new target (e.g., after navigation destroys old target)
         const domains = [...this.enabledDomains];
-        this.enabledDomains.clear();
         // Re-enable domains then signal target readiness
         Promise.all(
-          domains.map(domain => this.enableDomain(domain).catch(err => {
-            console.error(`[WebKitClient] Failed to re-enable ${domain} on new target: ${(err as Error).message}`);
-          }))
+          domains.map(domain =>
+            this.sendToTarget(`${domain}.enable`, undefined, info.targetId).catch(err => {
+              console.error(`[WebKitClient] Failed to re-enable ${domain} on new target: ${(err as Error).message}`);
+            })
+          )
         ).then(() => {
           this.targetReadyResolve?.();
         });
-        return;  // Don't call targetReadyResolve here, wait for domains
+        return;
       }
       return;
     }
 
     if (msg.method === 'Target.targetDestroyed') {
-      if (msg.params?.targetId === this.activeTargetId) {
-        this.activeTargetId = null;
+      const destroyedId = msg.params?.targetId;
+      this.knownTargets.delete(destroyedId);
+      this.emit('target:destroyed', { targetId: destroyedId });
+      if (destroyedId === this.activeTargetId) {
+        // Fallback to another known target, or null
+        this.activeTargetId = this.knownTargets.size > 0
+          ? this.knownTargets.values().next().value ?? null
+          : null;
       }
       return;
     }
@@ -291,6 +323,30 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
     }
   }
 
+  /**
+   * Enable a domain on a specific target (tab).
+   */
+  async enableDomainForTarget(domain: string, targetId: string): Promise<void> {
+    await this.sendToTarget(`${domain}.enable`, undefined, targetId);
+  }
+
+  // ========== Multi-Tab Target Management ==========
+
+  getActiveTargetId(): string | null {
+    return this.activeTargetId;
+  }
+
+  setActiveTargetId(targetId: string): void {
+    if (!this.knownTargets.has(targetId)) {
+      throw new ConnectionError(`Target ${targetId} not found in known targets`);
+    }
+    this.activeTargetId = targetId;
+  }
+
+  getKnownTargets(): Set<string> {
+    return new Set(this.knownTargets);
+  }
+
   // ========== Heartbeat ==========
 
   private startHeartbeat(): void {
@@ -326,6 +382,7 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
     }
     this.innerPendingRequests.clear();
     this.activeTargetId = null;
+    this.knownTargets.clear();
 
     this.stopHeartbeat();
 

--- a/tests/unit/multi-tab.test.ts
+++ b/tests/unit/multi-tab.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Multi-Tab Multiplexing Tests
+ * Verifies WebKitClient multi-target support, TabClient, and TabPool.
+ */
+
+import { TabClient } from '../../src/simulator/tab-client';
+import { TabPool } from '../../src/simulator/tab-pool';
+import { WebKitClient } from '../../src/webkit/client';
+import { EventEmitter } from 'events';
+
+// ========== Mock WebKitClient ==========
+
+class MockWebKitClient extends EventEmitter {
+  private _connected = true;
+  private _targets = new Set<string>();
+  private _activeTargetId: string | null = null;
+  private _sentMessages: Array<{ method: string; params?: any; targetId?: string }> = [];
+
+  constructor() {
+    super();
+    this.setMaxListeners(50);
+  }
+
+  isConnected(): boolean { return this._connected; }
+
+  getKnownTargets(): Set<string> { return new Set(this._targets); }
+
+  getActiveTargetId(): string | null { return this._activeTargetId; }
+
+  addTarget(id: string): void {
+    this._targets.add(id);
+    if (!this._activeTargetId) this._activeTargetId = id;
+  }
+
+  removeTarget(id: string): void {
+    this._targets.delete(id);
+    if (this._activeTargetId === id) {
+      this._activeTargetId = this._targets.size > 0
+        ? this._targets.values().next().value ?? null
+        : null;
+    }
+  }
+
+  async sendToTarget<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    targetId?: string | null,
+  ): Promise<T> {
+    const resolvedTarget = targetId ?? this._activeTargetId;
+    this._sentMessages.push({ method, params, targetId: resolvedTarget ?? undefined });
+
+    // Mock responses for common methods
+    if (method === 'Runtime.evaluate') {
+      const expr = params?.expression as string;
+      if (expr === 'document.documentElement.outerHTML') {
+        return { result: { value: '<html></html>' } } as unknown as T;
+      }
+      return { result: { value: `eval-on-${resolvedTarget}` } } as unknown as T;
+    }
+    if (method === 'Page.snapshotRect') {
+      return { dataURL: 'data:image/png;base64,iVBOR' } as unknown as T;
+    }
+    if (method === 'Page.getCookies') {
+      return { cookies: [{ name: 'test', value: '1', domain: '.example.com' }] } as unknown as T;
+    }
+    if (method === 'Page.navigate') {
+      return {} as unknown as T;
+    }
+    if (method.endsWith('.enable')) {
+      return {} as unknown as T;
+    }
+    return {} as unknown as T;
+  }
+
+  async enableDomainForTarget(domain: string, targetId: string): Promise<void> {
+    this._sentMessages.push({ method: `${domain}.enable`, targetId });
+  }
+
+  async listTargets(): Promise<Array<{ id: string; url: string; title: string; webSocketDebuggerUrl: string; type?: string }>> {
+    return Array.from(this._targets).map(id => ({
+      id,
+      url: `https://example.com/${id}`,
+      title: `Tab ${id}`,
+      webSocketDebuggerUrl: `ws://localhost:9222/devtools/page/${id}`,
+      type: 'page',
+    }));
+  }
+
+  getSentMessages() { return this._sentMessages; }
+  clearSentMessages() { this._sentMessages = []; }
+}
+
+// ========== TabClient Tests ==========
+
+describe('TabClient', () => {
+  let mockClient: MockWebKitClient;
+
+  beforeEach(() => {
+    mockClient = new MockWebKitClient();
+    mockClient.addTarget('target-1');
+    mockClient.addTarget('target-2');
+  });
+
+  it('should pin operations to specific target', async () => {
+    const tab1 = new TabClient(mockClient as unknown as WebKitClient, 'target-1');
+    const tab2 = new TabClient(mockClient as unknown as WebKitClient, 'target-2');
+
+    await tab1.evaluate('1+1');
+    await tab2.evaluate('2+2');
+
+    const msgs = mockClient.getSentMessages();
+    const runtimeCalls = msgs.filter(m => m.method === 'Runtime.evaluate');
+    expect(runtimeCalls[0].targetId).toBe('target-1');
+    expect(runtimeCalls[1].targetId).toBe('target-2');
+  });
+
+  it('should return correct targetId', () => {
+    const tab = new TabClient(mockClient as unknown as WebKitClient, 'target-1');
+    expect(tab.getTargetId()).toBe('target-1');
+  });
+
+  it('should report connected when target exists', () => {
+    const tab = new TabClient(mockClient as unknown as WebKitClient, 'target-1');
+    expect(tab.isConnected()).toBe(true);
+  });
+
+  it('should report disconnected when target is removed', () => {
+    const tab = new TabClient(mockClient as unknown as WebKitClient, 'target-1');
+    mockClient.removeTarget('target-1');
+    expect(tab.isConnected()).toBe(false);
+  });
+
+  it('should read page via pinned target', async () => {
+    const tab = new TabClient(mockClient as unknown as WebKitClient, 'target-1');
+    const html = await tab.readPage();
+    expect(html).toBe('<html></html>');
+
+    const msgs = mockClient.getSentMessages();
+    expect(msgs.every(m => m.targetId === 'target-1')).toBe(true);
+  });
+
+  it('should get cookies via pinned target', async () => {
+    const tab = new TabClient(mockClient as unknown as WebKitClient, 'target-1');
+    const cookies = await tab.getCookies();
+    expect(cookies).toHaveLength(1);
+    expect(cookies[0].name).toBe('test');
+  });
+
+  it('should enable domain for specific target', async () => {
+    const tab = new TabClient(mockClient as unknown as WebKitClient, 'target-2');
+    await tab.evaluate('test');
+
+    const msgs = mockClient.getSentMessages();
+    const enableCall = msgs.find(m => m.method === 'Runtime.enable');
+    expect(enableCall?.targetId).toBe('target-2');
+  });
+
+  it('should emit disconnect when target is destroyed', (done) => {
+    const tab = new TabClient(mockClient as unknown as WebKitClient, 'target-1');
+    tab.on('disconnect', () => {
+      done();
+    });
+    mockClient.emit('target:destroyed', { targetId: 'target-1' });
+  });
+
+  it('should not emit disconnect for other targets', () => {
+    const tab = new TabClient(mockClient as unknown as WebKitClient, 'target-1');
+    const handler = jest.fn();
+    tab.on('disconnect', handler);
+    mockClient.emit('target:destroyed', { targetId: 'target-2' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+// ========== TabPool Tests ==========
+
+describe('TabPool', () => {
+  let mockClient: MockWebKitClient;
+
+  beforeEach(() => {
+    mockClient = new MockWebKitClient();
+    mockClient.addTarget('initial-tab');
+  });
+
+  it('should get default tab', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    const tab = await pool.getDefaultTab();
+    expect(tab).toBeInstanceOf(TabClient);
+    expect(tab.getTargetId()).toBe('initial-tab');
+  });
+
+  it('should reuse existing default tab', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    const tab1 = await pool.getDefaultTab();
+    const tab2 = await pool.getDefaultTab();
+    expect(tab1).toBe(tab2);
+  });
+
+  it('should track tab count', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    expect(pool.size).toBe(0);
+    await pool.getDefaultTab();
+    expect(pool.size).toBe(1);
+  });
+
+  it('should list tabs', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    await pool.getDefaultTab();
+    const tabs = pool.listTabs();
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].targetId).toBe('initial-tab');
+  });
+
+  it('should get tab by targetId', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    await pool.getDefaultTab();
+    const tab = pool.getTab('initial-tab');
+    expect(tab).toBeInstanceOf(TabClient);
+    expect(tab?.getTargetId()).toBe('initial-tab');
+  });
+
+  it('should return null for unknown tab', () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    expect(pool.getTab('nonexistent')).toBeNull();
+  });
+
+  it('should discover existing tabs', async () => {
+    mockClient.addTarget('tab-2');
+    mockClient.addTarget('tab-3');
+
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    const clients = await pool.discoverExistingTabs();
+    expect(clients).toHaveLength(3);
+    expect(pool.size).toBe(3);
+  });
+
+  it('should enforce max tabs limit', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid', { maxTabs: 1 });
+    await pool.getDefaultTab();
+
+    await expect(pool.openTab('https://example.com')).rejects.toThrow('Tab limit reached');
+  });
+
+  it('should remove tab on close', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    await pool.getDefaultTab();
+    expect(pool.size).toBe(1);
+
+    await pool.closeTab('initial-tab');
+    expect(pool.size).toBe(0);
+    expect(pool.getTab('initial-tab')).toBeNull();
+  });
+
+  it('should remove tab when target is destroyed externally', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    await pool.getDefaultTab();
+    expect(pool.size).toBe(1);
+
+    mockClient.emit('target:destroyed', { targetId: 'initial-tab' });
+    expect(pool.size).toBe(0);
+  });
+
+  it('should close all tabs', async () => {
+    mockClient.addTarget('tab-2');
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    await pool.discoverExistingTabs();
+    expect(pool.size).toBe(2);
+
+    await pool.closeAll();
+    expect(pool.size).toBe(0);
+  });
+
+  it('should emit events on tab open and close', async () => {
+    const pool = new TabPool(mockClient as unknown as WebKitClient, 'test-udid');
+    const closeHandler = jest.fn();
+    pool.on('tab:closed', closeHandler);
+
+    await pool.getDefaultTab();
+    await pool.closeTab('initial-tab');
+    expect(closeHandler).toHaveBeenCalledWith({ targetId: 'initial-tab' });
+  });
+});
+
+// ========== WebKitClient Multi-Target State Tests ==========
+
+describe('WebKitClient multi-target tracking', () => {
+  // These test the public API contracts without a real WebSocket
+  it('should export sendToTarget method', () => {
+    const client = new WebKitClient({ host: 'localhost', port: 9322 });
+    expect(typeof client.sendToTarget).toBe('function');
+  });
+
+  it('should export target accessor methods', () => {
+    const client = new WebKitClient({ host: 'localhost', port: 9322 });
+    expect(typeof client.getActiveTargetId).toBe('function');
+    expect(typeof client.getKnownTargets).toBe('function');
+    expect(typeof client.setActiveTargetId).toBe('function');
+    expect(typeof client.enableDomainForTarget).toBe('function');
+  });
+
+  it('should return empty known targets initially', () => {
+    const client = new WebKitClient({ host: 'localhost', port: 9322 });
+    expect(client.getKnownTargets().size).toBe(0);
+  });
+
+  it('should return null active target initially', () => {
+    const client = new WebKitClient({ host: 'localhost', port: 9322 });
+    expect(client.getActiveTargetId()).toBeNull();
+  });
+
+  it('should throw when setting unknown target as active', () => {
+    const client = new WebKitClient({ host: 'localhost', port: 9322 });
+    expect(() => client.setActiveTargetId('nonexistent')).toThrow('not found');
+  });
+});


### PR DESCRIPTION
Reopens #309 (auto-closed when base branch was deleted after #308 merge).

## Summary

- Add `TabPool` and `TabClient` for controlling multiple Safari tabs through a single WebSocket connection
- Extend `WebKitClient` with `sendToTarget()` for explicit target routing and multi-target tracking
- Enable lightweight parallelism: ~15-50MB per tab vs ~2GB per simulator
- All 540 tests pass

Closes #305
Part of #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)