### PR TITLE
feat: sequential device rotation for low-memory multi-device testing

### DIFF
--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -11,6 +11,7 @@ export interface WorkflowInitOptions {
   authProfile?: string;
   taskDescription?: string;
   workerNames?: string[];
+  mode?: 'concurrent' | 'sequential';
 }
 
 export interface WorkflowInitResult {
@@ -132,23 +133,25 @@ export class SimulatorWorkflowEngine extends EventEmitter {
   }
 
   async initWorkflow(options: WorkflowInitOptions): Promise<WorkflowInitResult> {
+    const mode = options.mode ?? 'concurrent';
     const workflowId = `wf-${Date.now()}`;
 
-    // Boot all devices
+    if (mode === 'sequential') {
+      return this.initSequentialWorkflow(workflowId, options);
+    }
+
+    // ── Concurrent mode (default) ──
     const simulators = await this.pool.bootAll(options.devices);
 
-    // Inject auth
     if (options.authProfile) {
       await this.pool.injectAuth(options.authProfile);
     }
 
-    // Navigate all to URL
     if (options.url) {
       const batch = new BatchExecutor(this.pool);
       await batch.batchNavigate(options.url);
     }
 
-    // Create worker entries
     const workers: WorkerEntry[] = simulators.map((sim, i) => ({
       name: options.workerNames?.[i] ?? `worker-${sim.preset}`,
       deviceId: sim.device.udid,
@@ -157,7 +160,6 @@ export class SimulatorWorkflowEngine extends EventEmitter {
       startedAt: Date.now(),
     }));
 
-    // Save state
     const state: WorkflowState = {
       id: workflowId,
       status: 'running',
@@ -168,7 +170,95 @@ export class SimulatorWorkflowEngine extends EventEmitter {
     this.workflows.set(workflowId, state);
     this.persistWorkflow(state);
 
-    // Generate prompts
+    const prompts = workers.map(w => ({
+      workerName: w.name,
+      prompt: this.generateWorkerPrompt(w, options),
+    }));
+
+    return { workflowId, workers: workers.map(w => ({ name: w.name, device: w.preset })), prompts };
+  }
+
+  /**
+   * Sequential mode: boot one device at a time, run, collect results, shutdown.
+   * Peak RAM = ~2GB regardless of device count.
+   */
+  private async initSequentialWorkflow(
+    workflowId: string,
+    options: WorkflowInitOptions,
+  ): Promise<WorkflowInitResult> {
+    const workers: WorkerEntry[] = options.devices.map((preset, i) => ({
+      name: options.workerNames?.[i] ?? `worker-${preset}`,
+      deviceId: '', // Assigned during sequential execution
+      preset,
+      status: 'pending' as const,
+      startedAt: Date.now(),
+    }));
+
+    const state: WorkflowState = {
+      id: workflowId,
+      status: 'running',
+      workers,
+      startedAt: Date.now(),
+      options,
+    };
+    this.workflows.set(workflowId, state);
+    this.persistWorkflow(state);
+
+    // Run sequentially in background — each device boots, runs, shuts down
+    const sequentialResults = await this.pool.bootSequential(
+      options.devices,
+      async (sim, preset) => {
+        const worker = state.workers.find(w => w.preset === preset);
+        if (worker) {
+          worker.deviceId = sim.device.udid;
+          worker.status = 'active';
+          this.persistWorkflow(state);
+        }
+
+        // Inject auth if configured
+        if (options.authProfile) {
+          try {
+            const authMgr = this.authManager;
+            const profile = await authMgr.loadProfile(options.authProfile!);
+            if (sim.client.isConnected()) {
+              await sim.client.setCookies(profile.cookies);
+            }
+          } catch (err) {
+            console.error(`[Workflow] Auth injection failed for ${preset}: ${err}`);
+          }
+        }
+
+        // Navigate to URL
+        if (options.url && sim.client.isConnected()) {
+          try {
+            await sim.client.navigate({ url: options.url });
+          } catch (err) {
+            console.error(`[Workflow] Navigation failed for ${preset}: ${err}`);
+          }
+        }
+
+        return { device: preset, deviceId: sim.device.udid, ready: true };
+      },
+    );
+
+    // Update worker statuses from sequential results
+    for (const [preset, result] of sequentialResults) {
+      const worker = state.workers.find(w => w.preset === preset);
+      if (!worker) continue;
+      if (result.status === 'completed') {
+        worker.status = 'completed';
+        worker.results = result.result;
+        worker.completedAt = Date.now();
+      } else {
+        worker.status = 'failed';
+        worker.error = result.error;
+        worker.completedAt = Date.now();
+      }
+    }
+
+    this.checkWorkflowCompletion(state);
+    this.persistWorkflow(state);
+
     const prompts = workers.map(w => ({
       workerName: w.name,
       prompt: this.generateWorkerPrompt(w, options),

--- a/src/simulator/pool.ts
+++ b/src/simulator/pool.ts
@@ -181,6 +181,74 @@ export class SimulatorPool extends EventEmitter {
     return results;
   }
 
+  /**
+   * Boot devices sequentially: one at a time, run a task, then shut down.
+   * Peak RAM = 1 simulator (~2GB) regardless of device count.
+   */
+  async bootSequential(
+    presets: string[],
+    runner: (sim: PooledSimulator, preset: string) => Promise<unknown>,
+  ): Promise<Map<string, { status: 'completed' | 'failed'; result?: unknown; error?: string; duration: number }>> {
+    const results = new Map<string, { status: 'completed' | 'failed'; result?: unknown; error?: string; duration: number }>();
+
+    for (const preset of presets) {
+      const start = Date.now();
+      let sim: PooledSimulator | null = null;
+
+      try {
+        await this.checkResources(1);
+        const device = await this.manager.boot(preset);
+        await this.manager.openUrl(device.udid, 'https://example.com');
+
+        const port = this.getPortForDevice(device.udid);
+        const client = new WebKitClient({ host: 'localhost', port });
+
+        try {
+          await client.connect();
+        } catch {
+          console.error(`[SimulatorPool] Sequential: WebKit connection failed for ${preset}`);
+        }
+
+        const presetInfo = DEVICE_PRESETS[preset];
+        sim = {
+          device: { ...device, viewport: { width: presetInfo?.w ?? 390, height: presetInfo?.h ?? 844 } } as any,
+          client,
+          preset,
+          bootedAt: Date.now(),
+          lastActivity: Date.now(),
+        };
+
+        this.pool.set(device.udid, sim);
+        const sm = getSessionManager();
+        sm.addSimulator(device.udid, {
+          deviceId: device.udid,
+          deviceType: device.name,
+          state: 'booted',
+          viewport: { width: presetInfo?.w ?? 390, height: presetInfo?.h ?? 844 },
+          bootedAt: sim.bootedAt,
+          lastActivity: sim.lastActivity,
+        });
+        if (client.isConnected()) {
+          sm.setConnection(device.udid, client);
+        }
+
+        const result = await runner(sim, preset);
+        results.set(preset, { status: 'completed', result, duration: Date.now() - start });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[SimulatorPool] Sequential: ${preset} failed: ${msg}`);
+        results.set(preset, { status: 'failed', error: msg, duration: Date.now() - start });
+      } finally {
+        // Always shut down before moving to next device
+        if (sim) {
+          await this.shutdownOne(sim.device.udid);
+        }
+      }
+    }
+
+    return results;
+  }
+
   getAll(): PooledSimulator[] {
     return Array.from(this.pool.values());
   }

--- a/src/tools/orchestration-tools.ts
+++ b/src/tools/orchestration-tools.ts
@@ -29,6 +29,7 @@ export function registerOrchestrationTools(server: MCPServer): void {
           authProfile: { type: 'string', description: 'Auth profile name to inject' },
           taskDescription: { type: 'string', description: 'Task description for worker prompts' },
           workerNames: { type: 'array', items: { type: 'string' }, description: 'Custom worker names' },
+          mode: { type: 'string', enum: ['concurrent', 'sequential'], description: 'Execution mode: concurrent (all at once, high RAM) or sequential (one at a time, low RAM). Default: concurrent' },
         },
         required: ['devices'],
       },

--- a/tests/unit/sequential-pool.test.ts
+++ b/tests/unit/sequential-pool.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Sequential Device Rotation Tests
+ * Verifies SimulatorPool.bootSequential() for low-memory multi-device testing.
+ */
+
+import { SimulatorPool, PooledSimulator } from '../../src/simulator/pool';
+import { getSessionManager } from '../../src/session-manager';
+
+// Mock SimulatorManager
+jest.mock('../../src/simulator/manager', () => {
+  let bootCount = 0;
+  return {
+    SimulatorManager: jest.fn().mockImplementation(() => ({
+      boot: jest.fn().mockImplementation(async (preset: string) => {
+        bootCount++;
+        return {
+          udid: `udid-${preset}-${bootCount}`,
+          name: `Mock ${preset}`,
+          state: 'Booted',
+          isAvailable: true,
+          runtime: 'iOS-18-0',
+          runtimeVersion: '18.0',
+        };
+      }),
+      shutdown: jest.fn().mockResolvedValue(undefined),
+      openUrl: jest.fn().mockResolvedValue(undefined),
+      getDevice: jest.fn().mockResolvedValue(null),
+    })),
+  };
+});
+
+// Mock WebKitClient
+jest.mock('../../src/webkit/client', () => ({
+  WebKitClient: jest.fn().mockImplementation(() => ({
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+    isConnected: () => true,
+    setCookies: jest.fn().mockResolvedValue(undefined),
+    navigate: jest.fn().mockResolvedValue({ url: '', status: 200, loadTime: 0 }),
+  })),
+}));
+
+// Mock zombie-cleanup
+jest.mock('../../src/reliability/zombie-cleanup', () => ({
+  registerManagedDevices: jest.fn(),
+  unregisterManagedDevices: jest.fn(),
+}));
+
+// Mock os.freemem to always have enough
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  freemem: () => 16 * 1024 * 1024 * 1024, // 16GB
+}));
+
+describe('SimulatorPool.bootSequential', () => {
+  let pool: SimulatorPool;
+
+  beforeEach(() => {
+    pool = new SimulatorPool({ max: 5, concurrency: 3 });
+    // Reset SessionManager
+    const sm = getSessionManager();
+    for (const sim of sm.listSimulators()) {
+      sm.removeSimulator(sim.deviceId);
+    }
+  });
+
+  it('should run each device sequentially and return results', async () => {
+    const executionOrder: string[] = [];
+
+    const results = await pool.bootSequential(
+      ['iphone-17', 'ipad-pro', 'iphone-se'],
+      async (sim, preset) => {
+        executionOrder.push(preset);
+        return { tested: preset, pages: 5 };
+      },
+    );
+
+    expect(results.size).toBe(3);
+    expect(executionOrder).toEqual(['iphone-17', 'ipad-pro', 'iphone-se']);
+
+    const r1 = results.get('iphone-17');
+    expect(r1?.status).toBe('completed');
+    expect(r1?.result).toEqual({ tested: 'iphone-17', pages: 5 });
+
+    const r2 = results.get('ipad-pro');
+    expect(r2?.status).toBe('completed');
+  });
+
+  it('should only have one simulator active at a time', async () => {
+    let maxConcurrent = 0;
+    let currentActive = 0;
+
+    const results = await pool.bootSequential(
+      ['device-a', 'device-b', 'device-c'],
+      async () => {
+        currentActive++;
+        maxConcurrent = Math.max(maxConcurrent, currentActive);
+        // Simulate some work
+        await new Promise(r => setTimeout(r, 10));
+        currentActive--;
+        return 'done';
+      },
+    );
+
+    expect(maxConcurrent).toBe(1);
+    expect(results.size).toBe(3);
+  });
+
+  it('should continue after a device failure', async () => {
+    const results = await pool.bootSequential(
+      ['good-1', 'bad-device', 'good-2'],
+      async (_sim, preset) => {
+        if (preset === 'bad-device') {
+          throw new Error('Simulated failure');
+        }
+        return { ok: true };
+      },
+    );
+
+    expect(results.size).toBe(3);
+    expect(results.get('good-1')?.status).toBe('completed');
+    expect(results.get('bad-device')?.status).toBe('failed');
+    expect(results.get('bad-device')?.error).toContain('Simulated failure');
+    expect(results.get('good-2')?.status).toBe('completed');
+  });
+
+  it('should track duration per device', async () => {
+    const results = await pool.bootSequential(
+      ['fast', 'slow'],
+      async (_sim, preset) => {
+        if (preset === 'slow') {
+          await new Promise(r => setTimeout(r, 50));
+        }
+        return 'done';
+      },
+    );
+
+    const fast = results.get('fast')!;
+    const slow = results.get('slow')!;
+    expect(fast.duration).toBeGreaterThanOrEqual(0);
+    expect(slow.duration).toBeGreaterThan(fast.duration);
+  });
+
+  it('should shut down device after each run', async () => {
+    const results = await pool.bootSequential(
+      ['a', 'b'],
+      async () => 'done',
+    );
+
+    // After sequential completion, pool should be empty
+    expect(pool.size).toBe(0);
+    expect(results.size).toBe(2);
+  });
+
+  it('should handle empty device list', async () => {
+    const results = await pool.bootSequential([], async () => 'done');
+    expect(results.size).toBe(0);
+  });
+
+  it('should handle single device', async () => {
+    const results = await pool.bootSequential(
+      ['solo-device'],
+      async () => ({ result: 42 }),
+    );
+
+    expect(results.size).toBe(1);
+    expect(results.get('solo-device')?.status).toBe('completed');
+    expect(results.get('solo-device')?.result).toEqual({ result: 42 });
+  });
+});
+
+describe('WorkflowEngine sequential mode', () => {
+  it('should accept mode parameter in WorkflowInitOptions', () => {
+    // Type-level test: ensure mode is accepted
+    const options = {
+      devices: ['iphone-17'],
+      mode: 'sequential' as const,
+    };
+    expect(options.mode).toBe('sequential');
+  });
+
+  it('should default to concurrent mode', () => {
+    const options: { devices: string[]; mode?: string } = { devices: ['iphone-17'] };
+    expect(options.mode ?? 'concurrent').toBe('concurrent');
+  });
+});


### PR DESCRIPTION
Reopens #310 (auto-closed when base branch was deleted after #312 merge).

## Summary

- Add `bootSequential()` to SimulatorPool — one device at a time, ~2GB peak RAM
- Workflow engine supports `mode: 'sequential'` in `initWorkflow()`
- `workflow_init` tool accepts `mode` parameter
- All 549 tests pass (9 new)

Closes #306
Part of #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)