### PR TITLE
fix: address P0/P1 issues from code review

### DIFF
--- a/src/orchestration/hybrid-qa.ts
+++ b/src/orchestration/hybrid-qa.ts
@@ -56,7 +56,8 @@ export interface VerifiedIssue {
 
 export interface HybridQAResult {
   id: string;
-  status: 'running' | 'phase-a' | 'phase-b' | 'completed';
+  status: 'running' | 'phase-a' | 'phase-b' | 'completed' | 'error';
+  error?: string;
   phaseA: {
     duration: number;
     scans: PageScanResult[];
@@ -114,7 +115,7 @@ export async function applyViewportEmulation(
       meta.content = 'width=${viewport.width}, initial-scale=1';
 
       // Store original dimensions for detection scripts
-      window.__opensafari_viewport = { width: ${viewport.width}, height: ${viewport.height}, preset: '${viewport.preset}' };
+      window.__opensafari_viewport = { width: ${viewport.width}, height: ${viewport.height}, preset: ${JSON.stringify(viewport.preset)} };
     })()
   `);
 }
@@ -156,6 +157,11 @@ export class HybridQAEngine extends EventEmitter {
 
       if (!sim.client.isConnected()) {
         throw new Error('WebKit connection failed for host simulator');
+      }
+
+      // Inject auth if configured
+      if (options.authProfile) {
+        await this.pool.injectAuth(options.authProfile);
       }
 
       const tabPool = new TabPool(sim.client as WebKitClient, sim.device.udid);
@@ -213,6 +219,8 @@ export class HybridQAEngine extends EventEmitter {
 
     } catch (err) {
       console.error(`[HybridQA] Phase A failed: ${err}`);
+      result.status = 'error';
+      result.error = `Phase A failed: ${err}`;
     }
 
     result.phaseA.duration = Date.now() - phaseAStart;
@@ -253,8 +261,8 @@ export class HybridQAEngine extends EventEmitter {
             await new Promise(r => setTimeout(r, 1000));
 
             // Re-run only the detectors that found issues
-            const detectorNames = pair.issues.map(i => i.detector);
-            const verifyResults = await this.runDetectors(sim.client, detectorNames);
+            const detectorsToVerify = pair.issues.map(i => i.detector);
+            const verifyResults = await this.runDetectors(sim.client, detectorsToVerify);
 
             for (const original of pair.issues) {
               const verified_result = verifyResults.find(v => v.detector === original.detector);

--- a/src/simulator/pool.ts
+++ b/src/simulator/pool.ts
@@ -239,9 +239,14 @@ export class SimulatorPool extends EventEmitter {
         console.error(`[SimulatorPool] Sequential: ${preset} failed: ${msg}`);
         results.set(preset, { status: 'failed', error: msg, duration: Date.now() - start });
       } finally {
-        // Always shut down before moving to next device
+        // Always shut down before moving to next device — wrapped in try/catch
+        // to prevent shutdown failures from aborting the remaining devices
         if (sim) {
-          await this.shutdownOne(sim.device.udid);
+          try {
+            await this.shutdownOne(sim.device.udid);
+          } catch (shutdownErr) {
+            console.error(`[SimulatorPool] Sequential: shutdown failed for ${preset}: ${shutdownErr}`);
+          }
         }
       }
     }

--- a/src/simulator/tab-client.ts
+++ b/src/simulator/tab-client.ts
@@ -17,17 +17,34 @@ import {
 import { WebKitClient } from '../webkit/client';
 
 export class TabClient extends EventEmitter implements BrowserBackend {
+  private _listeners: Array<{ event: string; handler: (...args: any[]) => void }> = [];
+  private _destroyHandler: (event: { targetId: string }) => void;
+
   constructor(
     private client: WebKitClient,
     private targetId: string,
   ) {
     super();
     // Forward inner events scoped to this target
-    this.client.on('target:destroyed', (event: { targetId: string }) => {
+    this._destroyHandler = (event: { targetId: string }) => {
       if (event.targetId === this.targetId) {
         this.emit('disconnect');
       }
-    });
+    };
+    this.client.on('target:destroyed', this._destroyHandler);
+  }
+
+  /**
+   * Remove all listeners registered on the parent WebKitClient.
+   * Must be called when the tab is closed to prevent memory leaks.
+   */
+  destroy(): void {
+    this.client.removeListener('target:destroyed', this._destroyHandler);
+    for (const { event, handler } of this._listeners) {
+      this.client.removeListener(event, handler);
+    }
+    this._listeners = [];
+    this.removeAllListeners();
   }
 
   getTargetId(): string {
@@ -261,21 +278,30 @@ export class TabClient extends EventEmitter implements BrowserBackend {
   // ========== Events ==========
 
   onConsole(handler: (msg: { type: string; text: string }) => void): void {
-    this.client.on('Runtime.consoleAPICalled', (params: any) => {
+    const boundHandler = (params: any, meta?: { targetId?: string }) => {
+      if (meta?.targetId && meta.targetId !== this.targetId) return;
       handler({ type: params.type, text: params.args?.map((a: any) => a.value ?? a.description).join(' ') ?? '' });
-    });
+    };
+    this._listeners.push({ event: 'Runtime.consoleAPICalled', handler: boundHandler });
+    this.client.on('Runtime.consoleAPICalled', boundHandler);
   }
 
   onRequest(handler: (request: { url: string; method: string }) => void): void {
-    this.client.on('Network.requestWillBeSent', (params: any) => {
+    const boundHandler = (params: any, meta?: { targetId?: string }) => {
+      if (meta?.targetId && meta.targetId !== this.targetId) return;
       handler({ url: params.request?.url, method: params.request?.method });
-    });
+    };
+    this._listeners.push({ event: 'Network.requestWillBeSent', handler: boundHandler });
+    this.client.on('Network.requestWillBeSent', boundHandler);
   }
 
   onResponse(handler: (response: { url: string; status: number }) => void): void {
-    this.client.on('Network.responseReceived', (params: any) => {
+    const boundHandler = (params: any, meta?: { targetId?: string }) => {
+      if (meta?.targetId && meta.targetId !== this.targetId) return;
       handler({ url: params.response?.url, status: params.response?.status });
-    });
+    };
+    this._listeners.push({ event: 'Network.responseReceived', handler: boundHandler });
+    this.client.on('Network.responseReceived', boundHandler);
   }
 
   // ========== Private Helpers ==========

--- a/src/simulator/tab-pool.ts
+++ b/src/simulator/tab-pool.ts
@@ -114,14 +114,16 @@ export class TabPool extends EventEmitter {
     const tab = this.tabs.get(targetId);
     if (!tab) return;
 
+    // Remove from map first to prevent double-fire from target:destroyed listener
+    this.tabs.delete(targetId);
+    tab.client.destroy();
+
     try {
-      // Close tab by navigating to about:blank then closing via JavaScript
       await tab.client.evaluate('window.close()');
     } catch {
       // Tab may already be gone
     }
 
-    this.tabs.delete(targetId);
     this.emit('tab:closed', { targetId });
   }
 

--- a/src/webkit/client.ts
+++ b/src/webkit/client.ts
@@ -286,7 +286,9 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
         }
       } else if (innerMsg.method) {
         // Inner event (e.g., Page.loadEventFired, Runtime.consoleAPICalled)
-        this.emit(innerMsg.method, innerMsg.params);
+        // Include targetId so multi-tab consumers can filter by target
+        const sourceTargetId = msg.params.targetId;
+        this.emit(innerMsg.method, innerMsg.params, { targetId: sourceTargetId });
       }
       return;
     }

--- a/tests/unit/hybrid-qa.test.ts
+++ b/tests/unit/hybrid-qa.test.ts
@@ -58,7 +58,7 @@ describe('HybridQAEngine', () => {
       const expr = (client.evaluate as jest.Mock).mock.calls[0][0] as string;
       expect(expr).toContain('width=390');
       expect(expr).toContain('height: 844');
-      expect(expr).toContain("preset: 'iphone-17'");
+      expect(expr).toContain('preset: "iphone-17"');
     });
 
     it('should handle different viewport sizes', async () => {


### PR DESCRIPTION
## Summary

Fixes critical and high-priority issues identified by code reviewers on PRs #308-#314.

### P0 Fixes (Critical)
- **XSS injection** in `applyViewportEmulation` — `viewport.preset` now uses `JSON.stringify()` instead of raw string interpolation
- **Sequential loop abort** — `shutdownOne` in `bootSequential` `finally` block now wrapped in try/catch
- **Cross-tab event leaking** — `dispatchMessageFromTarget` now includes `targetId` in inner event emissions

### P1 Fixes
- **Listener leak** — `TabClient.destroy()` added, called from `TabPool.closeTab()`
- **Event scoping** — `onConsole`/`onRequest`/`onResponse` filter by `targetId`
- **Double-fire** — `TabPool.closeTab()` removes from map before `window.close()`
- **Silent failure** — Phase A sets `status: 'error'` on infrastructure failure
- **Dead parameter** — `authProfile` now actually injected in Phase A
- **Variable shadowing** — `detectorNames` renamed to `detectorsToVerify` in Phase B

## Test plan
- [x] Build passes
- [x] Lint clean (0 errors)
- [x] All 563 tests pass
- [x] Viewport emulation test updated for JSON.stringify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)