### PR TITLE
fix: prevent duplicate preset results from being overwritten (#318)

### DIFF
--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -207,8 +207,8 @@ export class SimulatorWorkflowEngine extends EventEmitter {
     // Run sequentially in background — each device boots, runs, shuts down
     const sequentialResults = await this.pool.bootSequential(
       options.devices,
-      async (sim, preset) => {
-        const worker = state.workers.find(w => w.preset === preset);
+      async (sim, preset, index) => {
+        const worker = state.workers[index];
         if (worker) {
           worker.deviceId = sim.device.udid;
           worker.status = 'active';
@@ -241,9 +241,10 @@ export class SimulatorWorkflowEngine extends EventEmitter {
       },
     );
 
-    // Update worker statuses from sequential results
-    for (const [preset, result] of sequentialResults) {
-      const worker = state.workers.find(w => w.preset === preset);
+    // Update worker statuses from sequential results (index-based to handle duplicate presets)
+    for (let i = 0; i < sequentialResults.length; i++) {
+      const result = sequentialResults[i];
+      const worker = state.workers[i];
       if (!worker) continue;
       if (result.status === 'completed') {
         worker.status = 'completed';

--- a/src/simulator/pool.ts
+++ b/src/simulator/pool.ts
@@ -187,11 +187,12 @@ export class SimulatorPool extends EventEmitter {
    */
   async bootSequential(
     presets: string[],
-    runner: (sim: PooledSimulator, preset: string) => Promise<unknown>,
-  ): Promise<Map<string, { status: 'completed' | 'failed'; result?: unknown; error?: string; duration: number }>> {
-    const results = new Map<string, { status: 'completed' | 'failed'; result?: unknown; error?: string; duration: number }>();
+    runner: (sim: PooledSimulator, preset: string, index: number) => Promise<unknown>,
+  ): Promise<Array<{ preset: string; status: 'completed' | 'failed'; result?: unknown; error?: string; duration: number }>> {
+    const results: Array<{ preset: string; status: 'completed' | 'failed'; result?: unknown; error?: string; duration: number }> = [];
 
-    for (const preset of presets) {
+    for (let i = 0; i < presets.length; i++) {
+      const preset = presets[i];
       const start = Date.now();
       let sim: PooledSimulator | null = null;
 
@@ -232,12 +233,12 @@ export class SimulatorPool extends EventEmitter {
           sm.setConnection(device.udid, client);
         }
 
-        const result = await runner(sim, preset);
-        results.set(preset, { status: 'completed', result, duration: Date.now() - start });
+        const result = await runner(sim, preset, i);
+        results.push({ preset, status: 'completed', result, duration: Date.now() - start });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`[SimulatorPool] Sequential: ${preset} failed: ${msg}`);
-        results.set(preset, { status: 'failed', error: msg, duration: Date.now() - start });
+        results.push({ preset, status: 'failed', error: msg, duration: Date.now() - start });
       } finally {
         // Always shut down before moving to next device — wrapped in try/catch
         // to prevent shutdown failures from aborting the remaining devices

--- a/tests/unit/sequential-pool.test.ts
+++ b/tests/unit/sequential-pool.test.ts
@@ -75,14 +75,14 @@ describe('SimulatorPool.bootSequential', () => {
       },
     );
 
-    expect(results.size).toBe(3);
+    expect(results.length).toBe(3);
     expect(executionOrder).toEqual(['iphone-17', 'ipad-pro', 'iphone-se']);
 
-    const r1 = results.get('iphone-17');
+    const r1 = results.find(r => r.preset === 'iphone-17');
     expect(r1?.status).toBe('completed');
     expect(r1?.result).toEqual({ tested: 'iphone-17', pages: 5 });
 
-    const r2 = results.get('ipad-pro');
+    const r2 = results.find(r => r.preset === 'ipad-pro');
     expect(r2?.status).toBe('completed');
   });
 
@@ -103,7 +103,7 @@ describe('SimulatorPool.bootSequential', () => {
     );
 
     expect(maxConcurrent).toBe(1);
-    expect(results.size).toBe(3);
+    expect(results.length).toBe(3);
   });
 
   it('should continue after a device failure', async () => {
@@ -117,11 +117,11 @@ describe('SimulatorPool.bootSequential', () => {
       },
     );
 
-    expect(results.size).toBe(3);
-    expect(results.get('good-1')?.status).toBe('completed');
-    expect(results.get('bad-device')?.status).toBe('failed');
-    expect(results.get('bad-device')?.error).toContain('Simulated failure');
-    expect(results.get('good-2')?.status).toBe('completed');
+    expect(results.length).toBe(3);
+    expect(results.find(r => r.preset === 'good-1')?.status).toBe('completed');
+    expect(results.find(r => r.preset === 'bad-device')?.status).toBe('failed');
+    expect(results.find(r => r.preset === 'bad-device')?.error).toContain('Simulated failure');
+    expect(results.find(r => r.preset === 'good-2')?.status).toBe('completed');
   });
 
   it('should track duration per device', async () => {
@@ -135,8 +135,8 @@ describe('SimulatorPool.bootSequential', () => {
       },
     );
 
-    const fast = results.get('fast')!;
-    const slow = results.get('slow')!;
+    const fast = results.find(r => r.preset === 'fast')!;
+    const slow = results.find(r => r.preset === 'slow')!;
     expect(fast.duration).toBeGreaterThanOrEqual(0);
     expect(slow.duration).toBeGreaterThan(fast.duration);
   });
@@ -149,12 +149,12 @@ describe('SimulatorPool.bootSequential', () => {
 
     // After sequential completion, pool should be empty
     expect(pool.size).toBe(0);
-    expect(results.size).toBe(2);
+    expect(results.length).toBe(2);
   });
 
   it('should handle empty device list', async () => {
     const results = await pool.bootSequential([], async () => 'done');
-    expect(results.size).toBe(0);
+    expect(results.length).toBe(0);
   });
 
   it('should handle single device', async () => {
@@ -163,9 +163,57 @@ describe('SimulatorPool.bootSequential', () => {
       async () => ({ result: 42 }),
     );
 
-    expect(results.size).toBe(1);
-    expect(results.get('solo-device')?.status).toBe('completed');
-    expect(results.get('solo-device')?.result).toEqual({ result: 42 });
+    expect(results.length).toBe(1);
+    expect(results.find(r => r.preset === 'solo-device')?.status).toBe('completed');
+    expect(results.find(r => r.preset === 'solo-device')?.result).toEqual({ result: 42 });
+  });
+
+  it('should preserve all results for duplicate presets', async () => {
+    const results = await pool.bootSequential(
+      ['iphone-17', 'iphone-17'],
+      async (_sim, preset) => {
+        return { tested: preset };
+      },
+    );
+
+    expect(results.length).toBe(2);
+    expect(results[0].preset).toBe('iphone-17');
+    expect(results[0].status).toBe('completed');
+    expect(results[1].preset).toBe('iphone-17');
+    expect(results[1].status).toBe('completed');
+  });
+
+  it('should return correct results for mixed duplicate presets', async () => {
+    let callCount = 0;
+    const results = await pool.bootSequential(
+      ['a', 'b', 'a'],
+      async (_sim, preset) => {
+        callCount++;
+        return { preset, call: callCount };
+      },
+    );
+
+    expect(results.length).toBe(3);
+    expect(results[0]).toMatchObject({ preset: 'a', status: 'completed' });
+    expect(results[0].result).toEqual({ preset: 'a', call: 1 });
+    expect(results[1]).toMatchObject({ preset: 'b', status: 'completed' });
+    expect(results[1].result).toEqual({ preset: 'b', call: 2 });
+    expect(results[2]).toMatchObject({ preset: 'a', status: 'completed' });
+    expect(results[2].result).toEqual({ preset: 'a', call: 3 });
+    expect(results.every(r => r.duration >= 0)).toBe(true);
+  });
+
+  it('should pass correct index to runner callback', async () => {
+    const receivedIndices: number[] = [];
+    await pool.bootSequential(
+      ['x', 'y', 'z'],
+      async (_sim, _preset, index) => {
+        receivedIndices.push(index);
+        return 'done';
+      },
+    );
+
+    expect(receivedIndices).toEqual([0, 1, 2]);
   });
 });
 


### PR DESCRIPTION
## Summary
- **pool.ts**: Changed `bootSequential()` return type from `Map<string, ...>` to `Array<{ preset, ... }>` and switched to index-based iteration, so duplicate presets (e.g. `['iphone-17', 'iphone-17']`) each get their own result entry instead of overwriting
- **workflow-engine.ts**: Updated runner callback and results loop to use index-based worker lookup instead of `find(w => w.preset === preset)`, preventing duplicate workers from being stuck in `pending` status
- **sequential-pool.test.ts**: Migrated all assertions from Map API to Array API; added 3 new tests covering duplicate presets, mixed duplicates with correct ordering, and index passing to the runner callback

Fixes #318

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npx jest tests/unit/sequential-pool.test.ts --no-coverage` — all 12 tests pass
- [ ] Manual verification: run workflow with duplicate device presets and confirm both results are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)