### PR TITLE
fix: generate completion prompts for sequential workflows (#318)

### DIFF
--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -259,9 +259,11 @@ export class SimulatorWorkflowEngine extends EventEmitter {
     this.checkWorkflowCompletion(state);
     this.persistWorkflow(state);
 
+    // Sequential mode: all devices have already run and shut down,
+    // so generate completion summaries instead of action prompts.
     const prompts = workers.map(w => ({
       workerName: w.name,
-      prompt: this.generateWorkerPrompt(w, options),
+      prompt: `[COMPLETED] ${w.name} on ${w.preset}: ${w.status}. Results available via workflow_collect.`,
     }));
 
     return { workflowId, workers: workers.map(w => ({ name: w.name, device: w.preset })), prompts };

--- a/tests/unit/sequential-pool.test.ts
+++ b/tests/unit/sequential-pool.test.ts
@@ -169,6 +169,25 @@ describe('SimulatorPool.bootSequential', () => {
   });
 });
 
+// Mock AuthManager
+jest.mock('../../src/auth/manager', () => ({
+  AuthManager: jest.fn().mockImplementation(() => ({
+    loadProfile: jest.fn().mockResolvedValue({ cookies: [], localStorage: {}, sessionStorage: {} }),
+  })),
+}));
+
+// Mock WorkflowPersistence
+jest.mock('../../src/orchestration/workflow-persistence', () => ({
+  WorkflowPersistence: jest.fn().mockImplementation(() => ({
+    save: jest.fn(),
+    loadAll: jest.fn().mockReturnValue([]),
+    remove: jest.fn(),
+  })),
+}));
+
+import { SimulatorWorkflowEngine } from '../../src/orchestration/workflow-engine';
+import { AuthManager } from '../../src/auth/manager';
+
 describe('WorkflowEngine sequential mode', () => {
   it('should accept mode parameter in WorkflowInitOptions', () => {
     // Type-level test: ensure mode is accepted
@@ -182,5 +201,127 @@ describe('WorkflowEngine sequential mode', () => {
   it('should default to concurrent mode', () => {
     const options: { devices: string[]; mode?: string } = { devices: ['iphone-17'] };
     expect(options.mode ?? 'concurrent').toBe('concurrent');
+  });
+
+  it('should generate completion prompts for sequential mode', async () => {
+    // Create a mocked pool with bootSequential returning a Map of results
+    const mockPool = {
+      bootSequential: jest.fn().mockImplementation(
+        async (presets: string[], _runner: unknown) => {
+          const results = new Map<string, { status: string; result?: unknown; error?: string; duration: number }>();
+          for (const preset of presets) {
+            results.set(preset, {
+              status: 'completed',
+              result: { tested: preset },
+              duration: 100,
+            });
+          }
+          return results;
+        },
+      ),
+      bootAll: jest.fn(),
+      shutdownAll: jest.fn(),
+      injectAuth: jest.fn(),
+    } as unknown as SimulatorPool;
+
+    const mockAuth = new AuthManager();
+    const engine = new SimulatorWorkflowEngine(mockPool, mockAuth);
+
+    const result = await engine.initWorkflow({
+      devices: ['iphone-17', 'ipad-pro'],
+      mode: 'sequential',
+      taskDescription: 'Test login flow',
+    });
+
+    // Verify prompts contain completion markers
+    expect(result.prompts).toHaveLength(2);
+    for (const p of result.prompts) {
+      expect(p.prompt).toContain('[COMPLETED]');
+      expect(p.prompt).toContain('Results available via workflow_collect');
+      expect(p.prompt).not.toContain('Use these tools');
+    }
+  });
+
+  it('should include worker name and preset in sequential completion prompts', async () => {
+    const mockPool = {
+      bootSequential: jest.fn().mockImplementation(
+        async (presets: string[], _runner: unknown) => {
+          const results = new Map<string, { status: string; result?: unknown; error?: string; duration: number }>();
+          for (const preset of presets) {
+            results.set(preset, {
+              status: 'completed',
+              result: { tested: preset },
+              duration: 50,
+            });
+          }
+          return results;
+        },
+      ),
+      bootAll: jest.fn(),
+      shutdownAll: jest.fn(),
+      injectAuth: jest.fn(),
+    } as unknown as SimulatorPool;
+
+    const mockAuth = new AuthManager();
+    const engine = new SimulatorWorkflowEngine(mockPool, mockAuth);
+
+    const result = await engine.initWorkflow({
+      devices: ['iphone-se'],
+      workerNames: ['mobile-tester'],
+      mode: 'sequential',
+    });
+
+    expect(result.prompts).toHaveLength(1);
+    expect(result.prompts[0].workerName).toBe('mobile-tester');
+    expect(result.prompts[0].prompt).toContain('mobile-tester');
+    expect(result.prompts[0].prompt).toContain('iphone-se');
+    expect(result.prompts[0].prompt).toContain('completed');
+  });
+
+  it('should show failed status in sequential prompts when device fails', async () => {
+    const mockPool = {
+      bootSequential: jest.fn().mockImplementation(
+        async (presets: string[], _runner: unknown) => {
+          const results = new Map<string, { status: string; result?: unknown; error?: string; duration: number }>();
+          for (const preset of presets) {
+            if (preset === 'bad-device') {
+              results.set(preset, {
+                status: 'failed',
+                error: 'Boot failed',
+                duration: 10,
+              });
+            } else {
+              results.set(preset, {
+                status: 'completed',
+                result: { ok: true },
+                duration: 100,
+              });
+            }
+          }
+          return results;
+        },
+      ),
+      bootAll: jest.fn(),
+      shutdownAll: jest.fn(),
+      injectAuth: jest.fn(),
+    } as unknown as SimulatorPool;
+
+    const mockAuth = new AuthManager();
+    const engine = new SimulatorWorkflowEngine(mockPool, mockAuth);
+
+    const result = await engine.initWorkflow({
+      devices: ['iphone-17', 'bad-device'],
+      mode: 'sequential',
+    });
+
+    expect(result.prompts).toHaveLength(2);
+
+    const goodPrompt = result.prompts.find(p => p.workerName === 'worker-iphone-17')!;
+    expect(goodPrompt.prompt).toContain('[COMPLETED]');
+    expect(goodPrompt.prompt).toContain('completed');
+
+    const badPrompt = result.prompts.find(p => p.workerName === 'worker-bad-device')!;
+    expect(badPrompt.prompt).toContain('[COMPLETED]');
+    expect(badPrompt.prompt).toContain('failed');
   });
 });


### PR DESCRIPTION
## Summary
- **Fix**: Sequential workflow mode (`initSequentialWorkflow`) was generating action prompts ("Use these tools with your assigned device") after all devices had already been shut down, producing dead prompts referencing non-existent devices.
- **Change**: Replace `generateWorkerPrompt()` call in sequential mode with completion summary prompts (`[COMPLETED] worker on preset: status. Results available via workflow_collect.`) that accurately reflect the finished state.
- **Tests**: Added 3 new test cases in `tests/unit/sequential-pool.test.ts` verifying sequential prompts contain `[COMPLETED]`, include worker name/preset, and correctly reflect failed device status.

Closes #318

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npx jest tests/unit/sequential-pool.test.ts --no-coverage` — all 12 tests pass (9 existing + 3 new)
- [ ] Verify concurrent mode prompts are unaffected (unchanged code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)