### PR TITLE
fix: use shared proxy port for MCP fallback client creation

### DIFF
--- a/src/simulator/proxy.ts
+++ b/src/simulator/proxy.ts
@@ -285,7 +285,8 @@ export class WebInspectorProxy {
     while (Date.now() - start < timeout) {
       try {
         const body = await this.httpGet(`http://localhost:${this._port}/json`);
-        if (body.startsWith('[')) return; // Valid JSON array = targets available
+        // Require at least one target — `[]` means proxy is up but no pages registered yet
+        if (body.startsWith('[') && body.trim() !== '[]') return;
       } catch { /* retry */ }
       await new Promise(r => setTimeout(r, 1000));
     }

--- a/src/tools/app-webview-connect.ts
+++ b/src/tools/app-webview-connect.ts
@@ -2,9 +2,9 @@ import { MCPServer, getWebKitClient } from '../mcp-server';
 import { WebKitClient } from '../webkit/client';
 import { setWebKitClient } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
+import { getSharedProxy } from '../simulator/proxy';
 
 const DEFAULT_PROXY_HOST = 'localhost';
-const DEFAULT_PROXY_PORT = 9222;
 
 /**
  * Determine whether a target looks like a Safari browser tab vs a native app WebView.
@@ -59,7 +59,7 @@ export function registerAppWebviewConnectTool(server: MCPServer): void {
       if (!client) {
         const newClient = new WebKitClient({
           host: DEFAULT_PROXY_HOST,
-          port: DEFAULT_PROXY_PORT,
+          port: getSharedProxy().port,
         });
         setWebKitClient(newClient, resolvedDeviceId);
         client = newClient;

--- a/src/tools/set-active-context.ts
+++ b/src/tools/set-active-context.ts
@@ -1,9 +1,9 @@
 import { MCPServer, getWebKitClient, setWebKitClient } from '../mcp-server';
 import { WebKitClient } from '../webkit/client';
 import { getSessionManager } from '../session-manager';
+import { getSharedProxy } from '../simulator/proxy';
 
 const DEFAULT_PROXY_HOST = 'localhost';
-const DEFAULT_PROXY_PORT = 9222;
 
 export function registerSetActiveContextTool(server: MCPServer): void {
   server.registerTool(
@@ -49,7 +49,7 @@ export function registerSetActiveContextTool(server: MCPServer): void {
       if (!probeClient) {
         const newClient = new WebKitClient({
           host: DEFAULT_PROXY_HOST,
-          port: DEFAULT_PROXY_PORT,
+          port: getSharedProxy().port,
         });
         setWebKitClient(newClient, resolvedDeviceId);
         probeClient = newClient;


### PR DESCRIPTION
## Summary

- **Critical bug**: `set_active_context` and `app_webview_connect` hardcoded `DEFAULT_PROXY_PORT = 9222` (Chrome DevTools port) instead of OpenSafari's actual proxy port (`9322`). When `device_boot`'s initial WebKit connection fails due to timing, these recovery paths create a fallback client on the wrong port — connecting to Chrome instead of Safari. This leaves **all MCP tools permanently broken** until the server is restarted.
- **Secondary bug**: `waitForForwarding()` in `proxy.ts` accepted an empty JSON array (`[]`) as a valid "ready" signal, meaning the proxy reported healthy before Safari had registered any pages with WebInspector.

## Root Cause

Discovered during live verification of #397 scroll fixes. All 11 scroll preservation tests passed when using `WebKitClient` directly (port 9322), but every MCP tool (`navigate`, `set_active_context`, `javascript`, etc.) failed with "Safari not connected" / "No page target discovered" because the fallback path connected to port 9222.

### Connection flow (before this fix)

```
device_boot → proxy.start() on 9322 → client.connect() FAILS (timing) → no client registered
     ↓
navigate → getWebKitClient() → null → "Safari not connected"
     ↓
set_active_context → getWebKitClient() → null → new WebKitClient(port: 9222) → connects to Chrome → FAIL
     ↓
ALL MCP TOOLS PERMANENTLY BROKEN (no recovery without server restart)
```

### Connection flow (after this fix)

```
device_boot → proxy.start() on 9322 → client.connect() FAILS (timing) → no client registered
     ↓
set_active_context → getWebKitClient() → null → new WebKitClient(port: getSharedProxy().port = 9322) → connects to Safari → SUCCESS
     ↓
ALL MCP TOOLS RECOVERED
```

## Changes

| File | Change |
|------|--------|
| `src/tools/set-active-context.ts` | Replace hardcoded `9222` with `getSharedProxy().port` |
| `src/tools/app-webview-connect.ts` | Replace hardcoded `9222` with `getSharedProxy().port` |
| `src/simulator/proxy.ts` | `waitForForwarding()` now requires non-empty target array (`[]` no longer counts as ready) |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 961 tests, 69 suites all passing
- [x] Verified scroll preservation tests (11/11 PASS) on iPhone 17 Pro (iOS 26.4)
- [ ] Full MCP tool integration test after fix: `device_boot` → `set_active_context` → `navigate` → `javascript`
- [ ] Verify `app_webview_connect` creates client on correct port when no existing client

🤖 Generated with [Claude Code](https://claude.com/claude-code)