### PR TITLE
feat: harden input backend with default-deny focus-input policy

### DIFF
--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -4,11 +4,17 @@
  * Provides three backends (selected via auto-detection):
  *   1. SimctlInputBackend   — `xcrun simctl io <device> input` (Xcode 15–16)
  *   2. WebKitInputBackend   — JavaScript touch events via WebKit protocol (Xcode 26+, Safari)
- *   3. AppleScriptInputBackend — osascript + CGEvent (fallback, requires window focus)
+ *   3. AppleScriptInputBackend — osascript + CGEvent (opt-in only, requires window focus)
  *
  * On Xcode 26+ where `simctl io input` was removed, the WebKit backend provides
- * focus-free touch injection for Safari web content.  The AppleScript backend is
- * the last resort and requires the Simulator window to be in the foreground.
+ * focus-free touch injection for Safari web content.
+ *
+ * The AppleScript backend is **default-deny**: it is only instantiated when the
+ * caller explicitly opts in via the `OPENSAFARI_ALLOW_FOCUS_INPUT=1` environment
+ * variable. Without the opt-in, `getInputBackend()` throws
+ * `HeadlessInputUnavailableError` with actionable remediation guidance. This
+ * prevents the surprising focus-theft / mouse-movement behavior that motivated
+ * issues #403 and #405.
  */
 
 import { execFile } from 'child_process';
@@ -418,12 +424,61 @@ export class WebKitInputBackend implements InputBackend {
   }
 }
 
+// ── HeadlessInputUnavailableError ────────────────────────────────────────────
+
+/**
+ * Environment variable that opts in to the focus-stealing AppleScript / CGEvent
+ * input backend. When unset (the default), `getInputBackend()` refuses to
+ * instantiate `AppleScriptInputBackend` and throws `HeadlessInputUnavailableError`
+ * instead, preventing silent focus theft.
+ */
+export const OPENSAFARI_ALLOW_FOCUS_INPUT_ENV = 'OPENSAFARI_ALLOW_FOCUS_INPUT';
+
+function isFocusInputAllowed(): boolean {
+  const value = process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV];
+  return value === '1' || value === 'true';
+}
+
+/**
+ * Thrown by `getInputBackend()` when no headless input method is available and
+ * the caller has not opted in to the focus-stealing fallback. The error carries
+ * structured fields so MCP clients can surface actionable remediation to users
+ * without parsing the human-readable message.
+ */
+export class HeadlessInputUnavailableError extends Error {
+  readonly name = 'HeadlessInputUnavailableError' as const;
+  readonly deviceId: string;
+  readonly reason: 'no-simctl' | 'no-webkit' | 'webkit-disconnected';
+  readonly remediation: readonly string[];
+
+  constructor(
+    deviceId: string,
+    reason: HeadlessInputUnavailableError['reason'],
+  ) {
+    const remediation = [
+      "Safari QA: call `set_active_context({ context: 'safari' })` to enable WebKitInputBackend",
+      `Native apps: opt in to the CGEvent fallback by setting ${OPENSAFARI_ALLOW_FOCUS_INPUT_ENV}=1 ` +
+        '(WARNING: will move the mouse cursor and bring Simulator.app to the foreground)',
+    ] as const;
+    const message =
+      `No headless input backend available for device ${deviceId} (reason: ${reason}).\n` +
+      remediation.map((line) => `  - ${line}`).join('\n');
+    super(message);
+    this.deviceId = deviceId;
+    this.reason = reason;
+    this.remediation = remediation;
+    // Preserve prototype chain across the TypeScript down-compile
+    Object.setPrototypeOf(this, HeadlessInputUnavailableError.prototype);
+  }
+}
+
 // ── Backend detection & singleton ────────────────────────────────────────────
 
 let simctlAvailable: boolean | null = null;
 let detectionPromise: Promise<boolean> | null = null;
 let cachedSimctlBackend: SimctlInputBackend | null = null;
 let cachedAppleScriptBackend: AppleScriptInputBackend | null = null;
+let focusInputOptInWarned = false;
 
 /**
  * Probe whether `simctl io input` is available by attempting a no-op tap at (0,0).
@@ -443,17 +498,43 @@ async function probeSimctlInput(deviceId: string): Promise<boolean> {
 }
 
 /**
- * Get the input backend using a 3-tier fallback strategy:
+ * Attempt a single WebKit reconnect for a client that exists but reports
+ * `isConnected() === false`. Returns true if the client is usable after the
+ * attempt. Never throws — transient failures fall through to Tier 3.
+ */
+async function tryReconnectWebKit(client: BrowserBackend): Promise<boolean> {
+  try {
+    await client.connect();
+    return client.isConnected();
+  } catch (err) {
+    console.error(
+      `[input-backend] WebKit reconnect attempt failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Get the input backend using a 3-tier fallback strategy with default-deny
+ * hardening for the focus-stealing path:
  *
  *   1. **SimctlInputBackend** — `simctl io input` (headless, any app, Xcode ≤16)
- *   2. **WebKitInputBackend** — JS touch events via WebKit protocol (headless, Safari only)
- *   3. **AppleScriptInputBackend** — CGEvent mouse synthesis (requires Simulator focus)
+ *   2. **WebKitInputBackend** — JS touch events via WebKit protocol (headless,
+ *      Safari only). If the supplied client exists but reports disconnected,
+ *      one reconnect attempt is made before giving up.
+ *   3. **AppleScriptInputBackend** — CGEvent mouse synthesis, requires
+ *      Simulator window focus. **Default-deny**: only instantiated when
+ *      `OPENSAFARI_ALLOW_FOCUS_INPUT=1` (or `true`) is set in the environment.
+ *      Without opt-in, this function throws `HeadlessInputUnavailableError`
+ *      instead of silently stealing focus.
  *
- * The simctl probe result is cached for the process lifetime.
- * WebKit availability is checked on each call (connection state can change).
+ * The simctl probe result is cached for the process lifetime. WebKit
+ * availability is checked on each call (connection state can change).
  *
- * @param deviceId   Simulator UDID
- * @param webkitClient  Optional active WebKit/Safari connection for Tier 2
+ * @param deviceId      Simulator UDID
+ * @param webkitClient  Optional WebKit/Safari connection for Tier 2
+ * @throws {HeadlessInputUnavailableError} When no headless method is available
+ *         and `OPENSAFARI_ALLOW_FOCUS_INPUT` is not set
  */
 export async function getInputBackend(
   deviceId: string,
@@ -478,18 +559,41 @@ export async function getInputBackend(
     return cachedSimctlBackend;
   }
 
-  // Tier 2: WebKit JS touch injection (headless, Safari web content only)
-  if (webkitClient && webkitClient.isConnected()) {
-    return new WebKitInputBackend(webkitClient);
+  // Tier 2: WebKit JS touch injection (headless, Safari web content only).
+  // If the client is present but disconnected, try a one-shot reconnect so
+  // transient drops (proxy restart, tab churn) do not flip us to Tier 3.
+  if (webkitClient) {
+    if (webkitClient.isConnected()) {
+      return new WebKitInputBackend(webkitClient);
+    }
+    const reconnected = await tryReconnectWebKit(webkitClient);
+    if (reconnected) {
+      return new WebKitInputBackend(webkitClient);
+    }
   }
 
-  // Tier 3: AppleScript/CGEvent fallback (requires Simulator window focus)
-  if (!cachedAppleScriptBackend) {
+  // Tier 3: AppleScript/CGEvent fallback — DEFAULT-DENY.
+  // Without explicit opt-in, refuse to return a backend that would move the
+  // mouse cursor or steal Simulator focus. See issue #405.
+  if (!isFocusInputAllowed()) {
+    const reason: HeadlessInputUnavailableError['reason'] = !webkitClient
+      ? 'no-webkit'
+      : 'webkit-disconnected';
+    const err = new HeadlessInputUnavailableError(deviceId, reason);
+    console.error(`[input-backend] ${err.message}`);
+    throw err;
+  }
+
+  if (!focusInputOptInWarned) {
     console.error(
-      '[input-backend] No headless input method available — ' +
-      'using AppleScript/CGEvent fallback (requires Simulator window focus). ' +
-      'Connect to Safari for focus-free operation on Xcode 26+.',
+      `[input-backend] ${OPENSAFARI_ALLOW_FOCUS_INPUT_ENV}=1 is set — ` +
+        'AppleScript/CGEvent backend is enabled. ' +
+        'This will move the physical mouse cursor and activate Simulator.app.',
     );
+    focusInputOptInWarned = true;
+  }
+
+  if (!cachedAppleScriptBackend) {
     cachedAppleScriptBackend = new AppleScriptInputBackend();
   }
   return cachedAppleScriptBackend;
@@ -501,6 +605,7 @@ export function resetInputBackend(): void {
   detectionPromise = null;
   cachedSimctlBackend = null;
   cachedAppleScriptBackend = null;
+  focusInputOptInWarned = false;
 }
 
 // Re-export for convenience

--- a/src/tools/native-input-utils.ts
+++ b/src/tools/native-input-utils.ts
@@ -9,7 +9,12 @@ import { getSessionManager } from '../session-manager';
 import { SimctlExecutor } from '../simulator/simctl';
 
 // Re-export input backend for tool files
-export { getInputBackend, resetInputBackend } from './native-input-backend';
+export {
+  getInputBackend,
+  resetInputBackend,
+  HeadlessInputUnavailableError,
+  OPENSAFARI_ALLOW_FOCUS_INPUT_ENV,
+} from './native-input-backend';
 export type { InputBackend } from './native-input-backend';
 
 /**

--- a/tests/unit/native-input-backend.test.ts
+++ b/tests/unit/native-input-backend.test.ts
@@ -11,6 +11,8 @@ import {
   WebKitInputBackend,
   getInputBackend,
   resetInputBackend,
+  HeadlessInputUnavailableError,
+  OPENSAFARI_ALLOW_FOCUS_INPUT_ENV,
   HID_TO_APPLESCRIPT,
   SENDKEY_TO_APPLESCRIPT,
   HID_TO_WEBKIT_KEY,
@@ -427,9 +429,20 @@ describe('WebKit key mappings', () => {
 // ── Auto-detection (3-tier fallback) ─────────────────────────────────────
 
 describe('getInputBackend', () => {
+  const originalEnv = process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV];
+
   beforeEach(() => {
     execMock.mockClear();
     resetInputBackend();
+    delete process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV];
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV];
+    } else {
+      process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV] = originalEnv;
+    }
   });
 
   test('returns SimctlInputBackend when simctl io input succeeds', async () => {
@@ -456,24 +469,124 @@ describe('getInputBackend', () => {
     expect(backend).toBeInstanceOf(WebKitInputBackend);
   });
 
-  test('returns AppleScriptInputBackend when simctl fails and no webkitClient', async () => {
+  // ── Default-deny behavior (issue #405) ──────────────────────────────────
+
+  test('throws HeadlessInputUnavailableError when simctl fails and no webkitClient', async () => {
     execMock.mockRejectedValueOnce(new Error('not supported'));
+    await expect(getInputBackend(DEVICE)).rejects.toBeInstanceOf(
+      HeadlessInputUnavailableError,
+    );
+  });
+
+  test('throws HeadlessInputUnavailableError when webkitClient is null', async () => {
+    execMock.mockRejectedValueOnce(new Error('not supported'));
+    await expect(getInputBackend(DEVICE, null)).rejects.toBeInstanceOf(
+      HeadlessInputUnavailableError,
+    );
+  });
+
+  test('throws HeadlessInputUnavailableError reason=no-webkit when no client is supplied', async () => {
+    execMock.mockRejectedValueOnce(new Error('not supported'));
+    try {
+      await getInputBackend(DEVICE);
+      fail('expected HeadlessInputUnavailableError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HeadlessInputUnavailableError);
+      const hErr = err as HeadlessInputUnavailableError;
+      expect(hErr.reason).toBe('no-webkit');
+      expect(hErr.deviceId).toBe(DEVICE);
+    }
+  });
+
+  test('thrown error message includes both remediation options', async () => {
+    execMock.mockRejectedValueOnce(new Error('not supported'));
+    try {
+      await getInputBackend(DEVICE);
+      fail('expected HeadlessInputUnavailableError');
+    } catch (err) {
+      const hErr = err as HeadlessInputUnavailableError;
+      expect(hErr.message).toContain("set_active_context({ context: 'safari' })");
+      expect(hErr.message).toContain('OPENSAFARI_ALLOW_FOCUS_INPUT=1');
+      expect(hErr.remediation).toHaveLength(2);
+    }
+  });
+
+  // ── WebKit reconnect retry (issue #405) ─────────────────────────────────
+
+  test('attempts a one-shot WebKit reconnect when client is disconnected', async () => {
+    execMock.mockRejectedValueOnce(new Error('not supported'));
+    const isConnected = jest
+      .fn()
+      .mockReturnValueOnce(false) // initial check
+      .mockReturnValueOnce(true); // after reconnect succeeds
+    const connect = jest.fn().mockResolvedValue(undefined);
+    const mockClient = { isConnected, connect } as any;
+
+    const backend = await getInputBackend(DEVICE, mockClient);
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(backend).toBeInstanceOf(WebKitInputBackend);
+  });
+
+  test('falls through to strict guard when WebKit reconnect fails', async () => {
+    execMock.mockRejectedValueOnce(new Error('not supported'));
+    const isConnected = jest.fn().mockReturnValue(false);
+    const connect = jest.fn().mockRejectedValue(new Error('proxy dead'));
+    const mockClient = { isConnected, connect } as any;
+
+    await expect(getInputBackend(DEVICE, mockClient)).rejects.toBeInstanceOf(
+      HeadlessInputUnavailableError,
+    );
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  test('reconnect error reason is webkit-disconnected', async () => {
+    execMock.mockRejectedValueOnce(new Error('not supported'));
+    const mockClient = {
+      isConnected: jest.fn().mockReturnValue(false),
+      connect: jest.fn().mockRejectedValue(new Error('proxy dead')),
+    } as any;
+    try {
+      await getInputBackend(DEVICE, mockClient);
+      fail('expected HeadlessInputUnavailableError');
+    } catch (err) {
+      expect((err as HeadlessInputUnavailableError).reason).toBe(
+        'webkit-disconnected',
+      );
+    }
+  });
+
+  // ── Env var opt-in (issue #405) ─────────────────────────────────────────
+
+  test('returns AppleScriptInputBackend when OPENSAFARI_ALLOW_FOCUS_INPUT=1', async () => {
+    execMock.mockRejectedValueOnce(new Error('not supported'));
+    process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV] = '1';
     const backend = await getInputBackend(DEVICE);
     expect(backend).toBeInstanceOf(AppleScriptInputBackend);
   });
 
-  test('returns AppleScriptInputBackend when webkitClient is disconnected', async () => {
+  test('returns AppleScriptInputBackend when OPENSAFARI_ALLOW_FOCUS_INPUT=true', async () => {
     execMock.mockRejectedValueOnce(new Error('not supported'));
-    const mockClient = { isConnected: () => false } as any;
-    const backend = await getInputBackend(DEVICE, mockClient);
+    process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV] = 'true';
+    const backend = await getInputBackend(DEVICE);
     expect(backend).toBeInstanceOf(AppleScriptInputBackend);
   });
 
-  test('returns AppleScriptInputBackend when webkitClient is null', async () => {
+  test('ignores opt-in values other than "1" or "true"', async () => {
     execMock.mockRejectedValueOnce(new Error('not supported'));
+    process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV] = 'yes';
+    await expect(getInputBackend(DEVICE)).rejects.toBeInstanceOf(
+      HeadlessInputUnavailableError,
+    );
+  });
+
+  test('opt-in also works when webkitClient is null', async () => {
+    execMock.mockRejectedValueOnce(new Error('not supported'));
+    process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV] = '1';
     const backend = await getInputBackend(DEVICE, null);
     expect(backend).toBeInstanceOf(AppleScriptInputBackend);
   });
+
+  // ── Caching / identity ──────────────────────────────────────────────────
 
   test('caches the simctl detection result', async () => {
     execMock.mockResolvedValueOnce('');


### PR DESCRIPTION
## Summary

Closes part 1 of #405. This PR makes the `AppleScriptInputBackend`
focus-stealing path **default-deny** so that `getInputBackend()` refuses
to silently move the mouse or activate `Simulator.app` unless the caller
explicitly opts in. This plugs the structural gap left by #403 / #404,
where the WebKit backend fixed the common Safari case but the soft
fallback still surprised users in several degraded scenarios.

## What changed

- **`src/tools/native-input-backend.ts`**
  - New `HeadlessInputUnavailableError` class with structured
    `deviceId`, `reason` (`no-webkit` | `webkit-disconnected`), and
    `remediation[]` fields. Exported for MCP clients that want to catch
    it by type.
  - New `OPENSAFARI_ALLOW_FOCUS_INPUT_ENV` constant and
    `isFocusInputAllowed()` helper. Accepts `1` or `true`; everything
    else is ignored so ambiguous values can't accidentally re-enable the
    backend.
  - `getInputBackend()` tier 2 now performs a one-shot reconnect when
    the WebKit client exists but reports `isConnected() === false`, so
    transient drops (proxy restart, tab churn) do not flip the caller
    to tier 3.
  - Tier 3 throws `HeadlessInputUnavailableError` instead of caching a
    silent `AppleScriptInputBackend`. The error message includes both
    remediation options verbatim.
  - When the opt-in is honored, a one-time warning is logged via
    `console.error` so users see the risk they just accepted.
- **`src/tools/native-input-utils.ts`**
  - Re-exports `HeadlessInputUnavailableError` and
    `OPENSAFARI_ALLOW_FOCUS_INPUT_ENV` from the shared barrel.
- **`tests/unit/native-input-backend.test.ts`**
  - Flipped the legacy "returns AppleScriptInputBackend when ..." tests
    to assert `HeadlessInputUnavailableError` under the new default.
  - New tests for the env var opt-in (`1`, `true`, and rejection of
    `yes`), the structured error fields, and the exact remediation text
    so the user-facing message cannot silently drift.
  - New tests for the WebKit reconnect retry: success path, failure
    path, and the correct `reason` code on failure.

No production tools needed updates in this PR — they already forward
errors through their existing `try/catch` and `isError: true`
response. PR 2 (#tracked separately) will add a `backend` field to
tool results for observability.

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 69 suites / 987 tests passing (was 979, +8 new)
- [x] `npx jest native-input-backend` — 51 tests covering the new
      behavior
- [x] Default-deny path: `getInputBackend()` throws a typed
      `HeadlessInputUnavailableError` when neither simctl nor WebKit is
      available and the env var is unset
- [x] Opt-in path: `OPENSAFARI_ALLOW_FOCUS_INPUT=1` restores the legacy
      `AppleScriptInputBackend`
- [x] Reconnect retry: a mocked client whose `isConnected()` flips from
      `false` to `true` after `connect()` yields a `WebKitInputBackend`
- [x] Reconnect failure: `connect()` rejecting is swallowed and the
      strict guard fires with `reason === 'webkit-disconnected'`
- [x] Remediation message asserted verbatim in at least one test to
      catch drift

## Refs

- #403 — original Xcode 26 input breakage
- #404 — PR that added `WebKitInputBackend`
- #405 — parent issue with the full verification checklist for the
  hardening effort