### PR TITLE
feat: surface input backend identifier in native tool results

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,45 @@ Multiple Claude Code sessions can share the same proxy. When a session detects a
 
 ---
 
+## Input Backend Selection
+
+OpenSafari dispatches native input (`app_tap`, `app_swipe_native`,
+`app_scroll_native`, `app_double_tap`, `app_type_text`, `app_key_input`)
+through a 3-tier fallback chain and surfaces the selected path in each tool
+result via a `backend` field.
+
+| Tier | Backend | Identifier | Headless? | When used |
+|------|---------|------------|-----------|-----------|
+| 1 | `SimctlInputBackend` | `simctl` | Yes | Xcode ≤16 (where `simctl io input` is available) |
+| 2 | `WebKitInputBackend` | `webkit` | Yes | Xcode 26+ with an active Safari WebKit connection |
+| 3 | `AppleScriptInputBackend` | `applescript` | **No** | Opt-in only — moves the mouse cursor and activates Simulator.app |
+
+Example tool result:
+
+```json
+{ "status": "tapped", "x": 100, "y": 200, "deviceId": "…", "backend": "webkit" }
+```
+
+### Focus-theft protection (`OPENSAFARI_ALLOW_FOCUS_INPUT`)
+
+Tier 3 is **default-deny**. On Xcode 26+ with no Safari connection,
+`getInputBackend()` throws `HeadlessInputUnavailableError` instead of
+silently moving the physical mouse cursor. To re-enable the legacy
+AppleScript/CGEvent fallback (for example, to automate a non-Safari native
+app), opt in with an environment variable:
+
+```bash
+# Only set this if you understand the consequences — it WILL move your
+# mouse cursor and bring Simulator.app to the foreground.
+OPENSAFARI_ALLOW_FOCUS_INPUT=1 opensafari serve
+```
+
+Accepted values are `1` and `true`; anything else is ignored. When the
+opt-in is honored, a one-time warning is logged to stderr at the first
+tool call.
+
+---
+
 ## Relationship to OpenChrome
 
 OpenSafari is the **Safari/iOS counterpart** to [OpenChrome](https://github.com/shaun0927/openchrome). Same philosophy, same architecture — different browser.

--- a/src/tools/app-double-tap.ts
+++ b/src/tools/app-double-tap.ts
@@ -68,6 +68,7 @@ export function registerAppDoubleTapTool(server: MCPServer): void {
                 x,
                 y,
                 deviceId,
+                backend: backend.kind,
               }),
             },
           ],

--- a/src/tools/app-key-input.ts
+++ b/src/tools/app-key-input.ts
@@ -61,6 +61,7 @@ export function registerAppKeyInputTool(server: MCPServer): void {
                 key,
                 keyCode,
                 deviceId,
+                backend: backend.kind,
               }),
             },
           ],

--- a/src/tools/app-scroll-native.ts
+++ b/src/tools/app-scroll-native.ts
@@ -140,6 +140,7 @@ export function registerAppScrollNativeTool(server: MCPServer): void {
                 from: { x, y },
                 to: { x: endX, y: endY },
                 deviceId,
+                backend: backend.kind,
               }),
             },
           ],

--- a/src/tools/app-swipe.ts
+++ b/src/tools/app-swipe.ts
@@ -120,6 +120,7 @@ export function registerAppSwipeNativeTool(server: MCPServer): void {
                 distance,
                 duration,
                 deviceId,
+                backend: backend.kind,
               }),
             },
           ],

--- a/src/tools/app-tap.ts
+++ b/src/tools/app-tap.ts
@@ -65,6 +65,7 @@ export function registerAppTapTool(server: MCPServer): void {
                 y,
                 duration,
                 deviceId,
+                backend: backend.kind,
               }),
             },
           ],

--- a/src/tools/app-type.ts
+++ b/src/tools/app-type.ts
@@ -57,6 +57,7 @@ export function registerAppTypeTextTool(server: MCPServer): void {
                 status: 'typed',
                 length: text.length,
                 deviceId,
+                backend: backend.kind,
               }),
             },
           ],

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -30,7 +30,18 @@ function delay(ms: number): Promise<void> {
 
 // ── Interface ────────────────────────────────────────────────────────────────
 
+/**
+ * Stable identifier for each concrete input backend. Included in tool call
+ * results so MCP clients and users can audit which path dispatched their
+ * input — useful when diagnosing focus-theft reports or confirming that a
+ * call stayed on a headless tier.
+ */
+export type InputBackendKind = 'simctl' | 'webkit' | 'applescript';
+
 export interface InputBackend {
+  /** Stable identifier used for observability / audit logging. */
+  readonly kind: InputBackendKind;
+
   tap(deviceId: string, x: number, y: number, duration?: number): Promise<void>;
   swipe(
     deviceId: string,
@@ -52,6 +63,7 @@ export interface InputBackend {
  * Available on Xcode versions that ship the `input` subcommand (typically ≤ 16).
  */
 export class SimctlInputBackend implements InputBackend {
+  readonly kind = 'simctl' as const;
   private simctl: SimctlExecutor;
 
   constructor(simctl?: SimctlExecutor) {
@@ -142,6 +154,7 @@ const SENDKEY_TO_APPLESCRIPT: Record<string, number> = {
  * Coordinate translation assumes Simulator is at default "Point Accurate" (1:1) zoom.
  */
 export class AppleScriptInputBackend implements InputBackend {
+  readonly kind = 'applescript' as const;
   /** macOS title bar height in points. */
   private static readonly TITLE_BAR_HEIGHT = 28;
 
@@ -322,6 +335,7 @@ const SENDKEY_TO_WEBKIT_KEY: Record<string, string> = {
  *     scroll is supplemented with an explicit `window.scrollBy()` call
  */
 export class WebKitInputBackend implements InputBackend {
+  readonly kind = 'webkit' as const;
   constructor(private client: BrowserBackend) {}
 
   async tap(_deviceId: string, x: number, y: number, duration?: number): Promise<void> {

--- a/src/tools/native-input-utils.ts
+++ b/src/tools/native-input-utils.ts
@@ -15,7 +15,7 @@ export {
   HeadlessInputUnavailableError,
   OPENSAFARI_ALLOW_FOCUS_INPUT_ENV,
 } from './native-input-backend';
-export type { InputBackend } from './native-input-backend';
+export type { InputBackend, InputBackendKind } from './native-input-backend';
 
 /**
  * Resolve the target device UDID from explicit param or the active device.

--- a/tests/unit/app-interaction-tools.test.ts
+++ b/tests/unit/app-interaction-tools.test.ts
@@ -47,6 +47,7 @@ jest.mock('../../src/tools/native-input-backend', () => ({
     const { SimctlExecutor } = require('../../src/simulator/simctl');
     const simctl = new SimctlExecutor();
     return {
+      kind: 'simctl' as const,
       tap: async (deviceId: string, x: number, y: number, duration?: number) => {
         if (duration && duration > 0) {
           await simctl.exec(['io', deviceId, 'input', 'press', String(x), String(y), String(duration)]);
@@ -112,6 +113,7 @@ describe('app_tap tool', () => {
     expect(body.status).toBe('tapped');
     expect(body.x).toBe(100);
     expect(body.y).toBe(200);
+    expect(body.backend).toBe('simctl');
     expect(execMock).toHaveBeenCalledWith(
       ['io', 'MOCK-DEVICE-UDID', 'input', 'tap', '100', '200'],
     );
@@ -174,6 +176,7 @@ describe('app_double_tap tool', () => {
     const result = await handler('s', { x: 100, y: 200 });
     const body = parseResult(result as any);
     expect(body.status).toBe('double_tapped');
+    expect(body.backend).toBe('simctl');
     // Two exec calls for the two taps
     expect(execMock).toHaveBeenCalledTimes(2);
     expect(execMock).toHaveBeenNthCalledWith(
@@ -215,6 +218,7 @@ describe('app_type_text tool', () => {
     const body = parseResult(result as any);
     expect(body.status).toBe('typed');
     expect(body.length).toBe(11);
+    expect(body.backend).toBe('simctl');
     expect(execMock).toHaveBeenCalledWith(
       ['io', 'MOCK-DEVICE-UDID', 'input', 'text', 'hello world'],
     );
@@ -259,6 +263,7 @@ describe('app_swipe_native tool', () => {
     expect(body.status).toBe('swiped');
     expect(body.direction).toBe('up');
     expect(body.to.y).toBe(200); // 500 - 300
+    expect(body.backend).toBe('simctl');
   });
 
   test('swipes down', async () => {
@@ -336,6 +341,7 @@ describe('app_key_input tool', () => {
     expect(body.status).toBe('key_pressed');
     expect(body.key).toBe('return');
     expect(body.keyCode).toBe('40');
+    expect(body.backend).toBe('simctl');
     expect(execMock).toHaveBeenCalledWith(
       ['io', 'MOCK-DEVICE-UDID', 'input', 'keypress', '40'],
     );

--- a/tests/unit/app-scroll-native.test.ts
+++ b/tests/unit/app-scroll-native.test.ts
@@ -68,6 +68,7 @@ describe('app_scroll_native', () => {
     const body = JSON.parse(result.content[0].text);
     expect(body.status).toBe('scrolled');
     expect(body.direction).toBe('up');
+    expect(body.backend).toBe('simctl');
   });
 
   it('scrolls down with correct simctl args', async () => {

--- a/tests/unit/native-input-backend.test.ts
+++ b/tests/unit/native-input-backend.test.ts
@@ -67,6 +67,10 @@ describe('SimctlInputBackend', () => {
     backend = new SimctlInputBackend({ exec: execMock } as any);
   });
 
+  test('exposes kind="simctl" for observability', () => {
+    expect(backend.kind).toBe('simctl');
+  });
+
   test('tap sends simctl io input tap', async () => {
     await backend.tap(DEVICE, 100, 200);
     expect(execMock).toHaveBeenCalledWith(
@@ -147,6 +151,10 @@ describe('AppleScriptInputBackend', () => {
     execFileMock.mockClear();
     execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
     backend = new AppleScriptInputBackend();
+  });
+
+  test('exposes kind="applescript" for observability', () => {
+    expect(backend.kind).toBe('applescript');
   });
 
   test('tap activates Simulator and calls osascript click', async () => {
@@ -325,6 +333,10 @@ describe('WebKitInputBackend', () => {
     backend = new WebKitInputBackend(mockClient as any);
   });
 
+  test('exposes kind="webkit" for observability', () => {
+    expect(backend.kind).toBe('webkit');
+  });
+
   test('tap delegates to client.click for normal tap', async () => {
     await backend.tap(DEVICE, 100, 200);
     expect(mockClient.click).toHaveBeenCalledWith({ x: 100, y: 200 });
@@ -449,6 +461,7 @@ describe('getInputBackend', () => {
     execMock.mockResolvedValueOnce('');
     const backend = await getInputBackend(DEVICE);
     expect(backend).toBeInstanceOf(SimctlInputBackend);
+    expect(backend.kind).toBe('simctl');
     expect(execMock).toHaveBeenCalledWith(
       ['io', DEVICE, 'input', 'tap', '0', '0'],
       { timeout: 5000 },
@@ -460,6 +473,7 @@ describe('getInputBackend', () => {
     const mockClient = { isConnected: () => true } as any;
     const backend = await getInputBackend(DEVICE, mockClient);
     expect(backend).toBeInstanceOf(SimctlInputBackend);
+    expect(backend.kind).toBe('simctl');
   });
 
   test('returns WebKitInputBackend when simctl fails but webkitClient is connected', async () => {
@@ -467,6 +481,7 @@ describe('getInputBackend', () => {
     const mockClient = { isConnected: () => true } as any;
     const backend = await getInputBackend(DEVICE, mockClient);
     expect(backend).toBeInstanceOf(WebKitInputBackend);
+    expect(backend.kind).toBe('webkit');
   });
 
   // ── Default-deny behavior (issue #405) ──────────────────────────────────
@@ -562,6 +577,7 @@ describe('getInputBackend', () => {
     process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV] = '1';
     const backend = await getInputBackend(DEVICE);
     expect(backend).toBeInstanceOf(AppleScriptInputBackend);
+    expect(backend.kind).toBe('applescript');
   });
 
   test('returns AppleScriptInputBackend when OPENSAFARI_ALLOW_FOCUS_INPUT=true', async () => {
@@ -569,6 +585,7 @@ describe('getInputBackend', () => {
     process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV] = 'true';
     const backend = await getInputBackend(DEVICE);
     expect(backend).toBeInstanceOf(AppleScriptInputBackend);
+    expect(backend.kind).toBe('applescript');
   });
 
   test('ignores opt-in values other than "1" or "true"', async () => {
@@ -584,6 +601,7 @@ describe('getInputBackend', () => {
     process.env[OPENSAFARI_ALLOW_FOCUS_INPUT_ENV] = '1';
     const backend = await getInputBackend(DEVICE, null);
     expect(backend).toBeInstanceOf(AppleScriptInputBackend);
+    expect(backend.kind).toBe('applescript');
   });
 
   // ── Caching / identity ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes part 2 of #405. This PR adds an observability hook that lets
MCP clients audit which input backend dispatched each native tool
call. Combined with the default-deny hardening from #406, this makes
focus-theft incidents attributable and greatly simplifies diagnosing
"did that automation really stay headless?" questions.

## What changed

- **`src/tools/native-input-backend.ts`**
  - New exported type `InputBackendKind = 'simctl' | 'webkit' | 'applescript'`.
  - `InputBackend` interface gains `readonly kind: InputBackendKind`.
  - Each concrete class (`SimctlInputBackend`, `WebKitInputBackend`,
    `AppleScriptInputBackend`) now exposes its literal kind via a
    readonly field.
- **`src/tools/native-input-utils.ts`**
  - Re-exports `InputBackendKind` from the shared barrel.
- **Tool files**
  - `app-tap.ts`, `app-swipe.ts`, `app-scroll-native.ts`,
    `app-double-tap.ts`, `app-type.ts`, `app-key-input.ts` all include
    `backend: backend.kind` in their success response JSON.
- **`README.md`**
  - New "Input Backend Selection" section documenting the tier table,
    the new `backend` field, and the `OPENSAFARI_ALLOW_FOCUS_INPUT`
    opt-in landed in the hardening PR.
- **Tests**
  - `tests/unit/native-input-backend.test.ts` — asserts `kind` on each
    backend class and on every `getInputBackend()` return path.
  - `tests/unit/app-interaction-tools.test.ts` — asserts the `backend`
    field appears in `app_tap`, `app_double_tap`, `app_type_text`,
    `app_swipe_native`, and `app_key_input` results. Mock
    `getInputBackend` gains a `kind: 'simctl'` property so tool
    output matches the real shape.
  - `tests/unit/app-scroll-native.test.ts` — asserts
    `body.backend === 'simctl'` on the scroll-up test, which exercises
    the real `getInputBackend()` path.

## Example output

```json
{
  "status": "tapped",
  "x": 100,
  "y": 200,
  "deviceId": "D7D26213-C3E9-4623-BCCB-984CDF5D0793",
  "backend": "webkit"
}
```

Clients can now grep audit logs for `"backend":"applescript"` to
confirm no tool call ever dipped into the focus-stealing tier.

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 69 suites / 982 tests passing
- [x] Backend-level assertions: each concrete class reports the
      expected `kind` constant
- [x] Tool-level assertions: successful `app_tap`, `app_double_tap`,
      `app_type_text`, `app_swipe_native`, `app_key_input`, and
      `app_scroll_native` results include `backend: 'simctl'` when
      the mock returns a SimctlInputBackend shape
- [x] README accurately describes the new field and the opt-in env
      var behavior

## Dependencies / ordering note

This PR is **logically stacked on top of #406** (the default-deny
hardening). The two PRs touch `src/tools/native-input-backend.ts` at
different locations so the expected rebase conflict is trivial — both
changes are additive. Review and merge order can go either way; after
#406 merges, this branch will be rebased onto the new `develop` tip
before merge.

## Refs

- #405 — parent issue with the verification checklist
- #406 — default-deny hardening PR