### PR TITLE
fix: pass target UDID to socket discovery during proxy startup

### DIFF
--- a/src/simulator/proxy.ts
+++ b/src/simulator/proxy.ts
@@ -67,12 +67,12 @@ export class WebInspectorProxy {
     this._deviceListPort = options.deviceListPort ?? envDeviceListPort ?? (this._port - 1);
   }
 
-  async findSocketPath(): Promise<string | null> {
-    return findSocketPath();
+  async findSocketPath(targetUdid?: string): Promise<string | null> {
+    return findSocketPath(targetUdid ? { targetUdid } : undefined);
   }
 
   /** Start the proxy process. Resolves once the proxy is ready. */
-  async start(): Promise<void> {
+  async start(options?: { targetUdid?: string }): Promise<void> {
     if (this._running) return;
 
     // Check if our device-list port already has a healthy proxy (from another session)
@@ -109,7 +109,7 @@ export class WebInspectorProxy {
       throw new Error('ios_webkit_debug_proxy not found. Install: brew install ios-webkit-debug-proxy');
     }
 
-    const socketPath = await this.findSocketPath();
+    const socketPath = await this.findSocketPath(options?.targetUdid);
     if (!socketPath) {
       throw new Error('Web Inspector socket not found. Is a simulator booted?');
     }

--- a/src/tools/device-boot.ts
+++ b/src/tools/device-boot.ts
@@ -31,7 +31,7 @@ export function registerDeviceBootTool(server: MCPServer): void {
       let proxyStatus: { running: boolean; pid: number | null } = { running: false, pid: null };
       try {
         const proxy = getSharedProxy();
-        await proxy.start();
+        await proxy.start({ targetUdid: device.udid });
         proxyStatus = { running: proxy.running, pid: proxy.pid };
 
         // Open Safari so it registers with WebInspector, then connect WebKitClient


### PR DESCRIPTION
## Summary

Phase 2.1 of #408. This is a **3-line fix** with outsized impact: it
ensures the WebInspector proxy connects to the *correct* simulator's
socket when multiple simulators are booted, eliminating the root cause
of cross-device target contamination in parallel sessions.

## Problem

`socket-finder.ts` already supports UDID-scoped discovery via its
`targetUdid` parameter — it uses `lsof -U` to match
`com.apple.webinspectord_sim.socket` paths to the `launchd_sim` PID
that owns each simulator. However, neither `proxy.start()` nor
`device-boot.ts` passed the UDID through. The socket-finder fell back
to its mtime-sorted heuristic, picking whichever socket was "newest"
— effectively random when two simulators boot close together.

**Before:**
```
device_boot("iPhone SE")  → proxy.start()  → findSocketPath()       → random socket
device_boot("iPhone 17")  → proxy.start()  → findSocketPath()       → random socket
```

**After:**
```
device_boot("iPhone SE")  → proxy.start({targetUdid: SE_UDID})  → findSocketPath(SE_UDID)  → SE's socket
device_boot("iPhone 17")  → proxy.start({targetUdid: PRO_UDID}) → findSocketPath(PRO_UDID) → 17's socket
```

## What changed

- **`src/simulator/proxy.ts`**
  - `findSocketPath(targetUdid?: string)` — forwards the UDID to the
    socket-finder's `FindSocketOptions`.
  - `start(options?: { targetUdid?: string })` — accepts optional UDID
    and passes it to `findSocketPath()`.
- **`src/tools/device-boot.ts`**
  - Passes `{ targetUdid: device.udid }` to `proxy.start()`.

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 69 suites / 979 tests (no regressions)
- [x] `npx tsc --noEmit` — no type errors
- [x] No other callers of `proxy.start()` without args exist in the codebase
- [ ] (post-merge) Boot two simulators → verify each proxy connects to
      the correct simulator's socket via `lsof -U | grep webinspector`

## Refs

- #408 — parent issue (parallel QA optimization)
- `src/simulator/socket-finder.ts:29-41` — existing UDID support