### PR TITLE
feat: per-device proxy isolation via ProxyManager

### DIFF
--- a/src/simulator/proxy-manager.ts
+++ b/src/simulator/proxy-manager.ts
@@ -1,0 +1,148 @@
+/**
+ * ProxyManager — Per-device WebInspectorProxy registry.
+ *
+ * The legacy `getSharedProxy()` exposes a single `WebInspectorProxy`
+ * singleton that forces every booted simulator to multiplex through one
+ * port. This breaks multi-simulator parallel QA in three ways:
+ *
+ *   1. A single proxy connects to one socket at boot time. When more
+ *      simulators are booted after the proxy starts, their sockets are
+ *      never queried, so their Safari tabs are invisible.
+ *   2. Target selection races across simulators (see #408).
+ *   3. Shutting down one simulator cannot cleanly tear down "its" proxy
+ *      without affecting the others still attached to the same process.
+ *
+ * ProxyManager replaces that singleton with a `Map<deviceId, WebInspectorProxy>`.
+ * Each device gets its own proxy bound to that simulator's specific
+ * `com.apple.webinspectord_sim.socket`, on a unique port derived from the
+ * UDID hash (with collision fallback). Lifecycle is per-device:
+ *
+ *   - `getProxyForDevice(udid)` — lazy create + start a proxy for a
+ *     specific simulator; idempotent, reuses the existing instance.
+ *   - `stopProxyForDevice(udid)` — stop and delete one device's proxy.
+ *     Other devices' proxies are untouched.
+ *   - `stopAll()` — teardown all proxies (exposed for tests / shutdown).
+ *
+ * Phase 2B.1 of #408.
+ */
+
+import { WebInspectorProxy } from './proxy';
+
+const PROXY_PORT_BASE_DEFAULT = 9322;
+const PROXY_PORT_RANGE_DEFAULT = 100;
+
+interface ManagedProxy {
+  proxy: WebInspectorProxy;
+  deviceId: string;
+  port: number;
+}
+
+const managed: Map<string, ManagedProxy> = new Map();
+/** Ports reserved (in-use) by this manager across devices. */
+const reservedPorts: Set<number> = new Set();
+
+function getPortBase(): number {
+  const raw = process.env.OPENSAFARI_PROXY_PORT_BASE;
+  if (!raw) return PROXY_PORT_BASE_DEFAULT;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : PROXY_PORT_BASE_DEFAULT;
+}
+
+function getPortRange(): number {
+  const raw = process.env.OPENSAFARI_PROXY_PORT_RANGE;
+  if (!raw) return PROXY_PORT_RANGE_DEFAULT;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : PROXY_PORT_RANGE_DEFAULT;
+}
+
+/**
+ * Deterministic hash → port mapping so a given UDID tends to land on the
+ * same port across reboots. Falls back to linear probing when the hashed
+ * port is already reserved by another device.
+ */
+export function allocatePort(deviceId: string): number {
+  const base = getPortBase();
+  const range = getPortRange();
+
+  // djb2-style hash over the UDID
+  let hash = 5381;
+  for (let i = 0; i < deviceId.length; i++) {
+    hash = ((hash << 5) + hash + deviceId.charCodeAt(i)) | 0;
+  }
+  const offset = Math.abs(hash) % range;
+
+  // Note: device-list port is one below, so step by 2 to avoid collisions.
+  for (let step = 0; step < range; step++) {
+    const candidate = base + ((offset + step * 2) % range);
+    if (!reservedPorts.has(candidate)) {
+      reservedPorts.add(candidate);
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `ProxyManager: no free port in range ${base}-${base + range - 1} ` +
+      `(${reservedPorts.size} reserved). Raise OPENSAFARI_PROXY_PORT_RANGE.`,
+  );
+}
+
+/**
+ * Get or create a proxy dedicated to one simulator. The proxy is started
+ * bound to that simulator's webinspectord socket (via `targetUdid`), so
+ * its /json endpoint only shows Safari targets from that one device.
+ */
+export async function getProxyForDevice(deviceId: string): Promise<WebInspectorProxy> {
+  const existing = managed.get(deviceId);
+  if (existing) return existing.proxy;
+
+  const port = allocatePort(deviceId);
+  const proxy = new WebInspectorProxy({ port });
+  try {
+    await proxy.start({ targetUdid: deviceId });
+  } catch (err) {
+    reservedPorts.delete(port);
+    throw err;
+  }
+
+  managed.set(deviceId, { proxy, deviceId, port });
+  return proxy;
+}
+
+/** Return the proxy for a device without starting a new one. */
+export function peekProxyForDevice(deviceId: string): WebInspectorProxy | null {
+  return managed.get(deviceId)?.proxy ?? null;
+}
+
+/** Stop and forget a device's proxy. No-op if none exists. */
+export async function stopProxyForDevice(deviceId: string): Promise<void> {
+  const entry = managed.get(deviceId);
+  if (!entry) return;
+  try {
+    await entry.proxy.stop();
+  } catch (err) {
+    console.error(`[proxy-manager] Failed to stop proxy for ${deviceId}: ${err}`);
+  }
+  reservedPorts.delete(entry.port);
+  managed.delete(deviceId);
+}
+
+/** Stop every managed proxy. Used on process shutdown / from tests. */
+export async function stopAll(): Promise<void> {
+  const devices = Array.from(managed.keys());
+  for (const id of devices) {
+    await stopProxyForDevice(id);
+  }
+}
+
+/**
+ * List current managed proxies. Exported for diagnostics and tests.
+ */
+export function listManagedProxies(): Array<{ deviceId: string; port: number }> {
+  return Array.from(managed.values()).map(({ deviceId, port }) => ({ deviceId, port }));
+}
+
+/** Reset state. Test-only — does NOT stop running proxies. */
+export function resetProxyManagerState(): void {
+  managed.clear();
+  reservedPorts.clear();
+}

--- a/src/tools/device-boot.ts
+++ b/src/tools/device-boot.ts
@@ -1,6 +1,6 @@
 import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
-import { getSharedProxy } from '../simulator/proxy';
+import { getProxyForDevice } from '../simulator/proxy-manager';
 import { WebKitClient } from '../webkit/client';
 import { addManagedDevice } from '../reliability/zombie-cleanup';
 import { getSessionManager } from '../session-manager';
@@ -27,12 +27,16 @@ export function registerDeviceBootTool(server: MCPServer): void {
       // other MCP sessions' periodic cleanup won't shut it down as an orphan.
       addManagedDevice(device.udid);
 
-      // Auto-start the WebInspector proxy so WebKit debugging is available
-      let proxyStatus: { running: boolean; pid: number | null } = { running: false, pid: null };
+      // Auto-start a per-device WebInspector proxy so parallel sessions
+      // each get their own isolated proxy bound to their simulator's socket.
+      let proxyStatus: { running: boolean; pid: number | null; port: number | null } = {
+        running: false,
+        pid: null,
+        port: null,
+      };
       try {
-        const proxy = getSharedProxy();
-        await proxy.start({ targetUdid: device.udid });
-        proxyStatus = { running: proxy.running, pid: proxy.pid };
+        const proxy = await getProxyForDevice(device.udid);
+        proxyStatus = { running: proxy.running, pid: proxy.pid, port: proxy.port };
 
         // Open Safari so it registers with WebInspector, then connect WebKitClient
         try {

--- a/src/tools/device-shutdown.ts
+++ b/src/tools/device-shutdown.ts
@@ -1,6 +1,6 @@
 import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
-import { getSharedProxy } from '../simulator/proxy';
+import { stopProxyForDevice } from '../simulator/proxy-manager';
 import { getSessionManager } from '../session-manager';
 
 export function registerDeviceShutdownTool(server: MCPServer): void {
@@ -39,16 +39,14 @@ export function registerDeviceShutdownTool(server: MCPServer): void {
       // Remove simulator from SessionManager (also clears connection, updates active device)
       sm.removeSimulator(deviceId);
 
-      // Stop the WebInspector proxy if no more connections remain
-      const proxy = getSharedProxy();
+      // Stop this device's dedicated WebInspector proxy (other devices'
+      // proxies are untouched). #408 Phase 2B.1
       let proxyStopped = false;
-      if (proxy.running && sm.listConnections().length === 0) {
-        try {
-          await proxy.stop();
-          proxyStopped = true;
-        } catch (err) {
-          console.error(`[device_shutdown] Failed to stop proxy: ${err}`);
-        }
+      try {
+        await stopProxyForDevice(deviceId);
+        proxyStopped = true;
+      } catch (err) {
+        console.error(`[device_shutdown] Failed to stop proxy for ${deviceId}: ${err}`);
       }
 
       await manager.shutdown(deviceId);

--- a/tests/unit/proxy-manager.test.ts
+++ b/tests/unit/proxy-manager.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for ProxyManager — the per-device WebInspectorProxy registry
+ * introduced in Phase 2B.1 of issue #408.
+ */
+
+// Mock WebInspectorProxy so we can exercise the manager without spawning
+// real proxy processes. The mock records the constructor arguments and
+// exposes stubs for start/stop.
+const mockStart = jest.fn();
+const mockStop = jest.fn();
+const constructorCalls: Array<{ port: number; [k: string]: unknown }> = [];
+
+jest.mock('../../src/simulator/proxy', () => ({
+  WebInspectorProxy: jest.fn().mockImplementation(function (this: any, options: any) {
+    constructorCalls.push(options);
+    this.port = options.port;
+    this.pid = 12345;
+    this.running = false;
+    this.start = async (_startOptions?: { targetUdid?: string }) => {
+      this.running = true;
+      mockStart(_startOptions);
+    };
+    this.stop = async () => {
+      this.running = false;
+      mockStop();
+    };
+  }),
+}));
+
+import {
+  allocatePort,
+  getProxyForDevice,
+  peekProxyForDevice,
+  stopProxyForDevice,
+  stopAll,
+  listManagedProxies,
+  resetProxyManagerState,
+} from '../../src/simulator/proxy-manager';
+
+const UDID_A = 'AAAAAAAA-0000-0000-0000-000000000001';
+const UDID_B = 'BBBBBBBB-0000-0000-0000-000000000002';
+
+describe('ProxyManager', () => {
+  beforeEach(() => {
+    mockStart.mockReset();
+    mockStop.mockReset();
+    constructorCalls.length = 0;
+    resetProxyManagerState();
+    delete process.env.OPENSAFARI_PROXY_PORT_BASE;
+    delete process.env.OPENSAFARI_PROXY_PORT_RANGE;
+  });
+
+  describe('allocatePort', () => {
+    test('same UDID hashes to the same port', () => {
+      const p1 = allocatePort(UDID_A);
+      resetProxyManagerState();
+      const p2 = allocatePort(UDID_A);
+      expect(p1).toBe(p2);
+    });
+
+    test('different UDIDs get different ports in most cases', () => {
+      const p1 = allocatePort(UDID_A);
+      const p2 = allocatePort(UDID_B);
+      expect(p1).not.toBe(p2);
+    });
+
+    test('second allocation for a reserved port falls back linearly', () => {
+      // Small range so we can force a collision cheaply
+      process.env.OPENSAFARI_PROXY_PORT_BASE = '9500';
+      process.env.OPENSAFARI_PROXY_PORT_RANGE = '10';
+
+      const p1 = allocatePort('deviceA');
+      const p2 = allocatePort('deviceB');
+      const p3 = allocatePort('deviceC');
+
+      // All three fall within the range and are unique
+      const ports = [p1, p2, p3];
+      const unique = new Set(ports);
+      expect(unique.size).toBe(3);
+      for (const p of ports) {
+        expect(p).toBeGreaterThanOrEqual(9500);
+        expect(p).toBeLessThan(9510);
+      }
+    });
+
+    test('throws when the range is exhausted', () => {
+      process.env.OPENSAFARI_PROXY_PORT_BASE = '9600';
+      process.env.OPENSAFARI_PROXY_PORT_RANGE = '1';
+
+      // Range of 1 — exactly one slot for the entire host.
+      allocatePort('d1');
+      expect(() => allocatePort('d2')).toThrow(/no free port/);
+    });
+  });
+
+  describe('getProxyForDevice', () => {
+    test('creates a new proxy on first call', async () => {
+      const proxy = await getProxyForDevice(UDID_A);
+
+      expect(proxy).toBeDefined();
+      expect(proxy.running).toBe(true);
+      expect(constructorCalls).toHaveLength(1);
+      expect(constructorCalls[0].port).toBeGreaterThan(0);
+      expect(mockStart).toHaveBeenCalledWith({ targetUdid: UDID_A });
+    });
+
+    test('returns the same instance on subsequent calls for the same device', async () => {
+      const first = await getProxyForDevice(UDID_A);
+      const second = await getProxyForDevice(UDID_A);
+
+      expect(first).toBe(second);
+      expect(constructorCalls).toHaveLength(1);
+      expect(mockStart).toHaveBeenCalledTimes(1);
+    });
+
+    test('creates separate proxies per device with different ports', async () => {
+      const a = await getProxyForDevice(UDID_A);
+      const b = await getProxyForDevice(UDID_B);
+
+      expect(a).not.toBe(b);
+      expect(a.port).not.toBe(b.port);
+      expect(constructorCalls).toHaveLength(2);
+    });
+
+    test('releases the reserved port when start() throws', async () => {
+      // Force start() to fail for this one call
+      mockStart.mockImplementationOnce(() => {
+        throw new Error('proxy spawn failed');
+      });
+
+      await expect(getProxyForDevice(UDID_A)).rejects.toThrow('proxy spawn failed');
+
+      // The failed proxy should not be tracked
+      expect(peekProxyForDevice(UDID_A)).toBeNull();
+      // And the port should be free for a retry
+      const retry = await getProxyForDevice(UDID_A);
+      expect(retry).toBeDefined();
+    });
+  });
+
+  describe('stopProxyForDevice', () => {
+    test('stops only the target device proxy', async () => {
+      await getProxyForDevice(UDID_A);
+      await getProxyForDevice(UDID_B);
+
+      await stopProxyForDevice(UDID_A);
+
+      expect(mockStop).toHaveBeenCalledTimes(1);
+      expect(peekProxyForDevice(UDID_A)).toBeNull();
+      expect(peekProxyForDevice(UDID_B)).not.toBeNull();
+    });
+
+    test('is a no-op for a device with no proxy', async () => {
+      await stopProxyForDevice('unknown-device');
+      expect(mockStop).not.toHaveBeenCalled();
+    });
+
+    test('stopping then re-creating allocates a fresh proxy', async () => {
+      await getProxyForDevice(UDID_A);
+      await stopProxyForDevice(UDID_A);
+      const again = await getProxyForDevice(UDID_A);
+      expect(again).toBeDefined();
+      expect(mockStart).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('stopAll', () => {
+    test('stops every managed proxy', async () => {
+      await getProxyForDevice(UDID_A);
+      await getProxyForDevice(UDID_B);
+
+      await stopAll();
+
+      expect(mockStop).toHaveBeenCalledTimes(2);
+      expect(listManagedProxies()).toHaveLength(0);
+    });
+  });
+
+  describe('listManagedProxies', () => {
+    test('returns entries with deviceId and port', async () => {
+      await getProxyForDevice(UDID_A);
+      await getProxyForDevice(UDID_B);
+
+      const list = listManagedProxies();
+
+      expect(list).toHaveLength(2);
+      expect(list.map((l) => l.deviceId).sort()).toEqual([UDID_A, UDID_B].sort());
+      for (const entry of list) {
+        expect(entry.port).toBeGreaterThan(0);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2B.1 of #408. Replaces the `getSharedProxy()` singleton with a
per-device `ProxyManager` so parallel QA sessions targeting different
simulators each get their own `ios_webkit_debug_proxy` instance on
their own port, bound to their specific `com.apple.webinspectord_sim.socket`.

> **Base branch note**: stacked on #410 (`feature/udid-aware-socket-discovery`)
> because it depends on the `proxy.start({ targetUdid })` API added
> there. Merge #410 first, then this.

## Problem

The legacy `getSharedProxy()` returned a module-level singleton that
every device shared. When Simulator A booted first, the proxy picked
A's socket and was stuck with it — every Safari tab on Simulator B
(booted later) was invisible. This is the root architectural cause
of cross-device target contamination.

## What changed

### New module — `src/simulator/proxy-manager.ts`

- **`allocatePort(deviceId)`** — djb2 hash → deterministic port in
  `OPENSAFARI_PROXY_PORT_BASE..+RANGE`. Falls back to linear probing
  (step by 2 so the device-list port one-below does not overlap).
  Throws a clear error when the range is exhausted.
- **`getProxyForDevice(udid)`** — lazy creates a `WebInspectorProxy`
  bound to `targetUdid`, caches it in a `Map<udid, proxy>`, and
  returns the same instance on subsequent calls. Releases the
  reserved port if `start()` throws so retries don't leak.
- **`stopProxyForDevice(udid)`** — stops and forgets *one* device's
  proxy. Other devices' proxies are untouched.
- **`stopAll()`** — tears down every managed proxy (used by tests
  and process shutdown).
- **`peekProxyForDevice` / `listManagedProxies` / `resetProxyManagerState`**
  — diagnostics and test hooks.

### Port allocation behaviour

Deterministic per-UDID so a simulator tends to land on the same
port across reboots. Helps log grepping and external tools.

Environment overrides:
- `OPENSAFARI_PROXY_PORT_BASE` (default: 9322)
- `OPENSAFARI_PROXY_PORT_RANGE` (default: 100)

### Integration

- **`src/tools/device-boot.ts`** — swaps `getSharedProxy()` for
  `getProxyForDevice(device.udid)`. The returned proxy already has
  the correct `targetUdid` wired through from #410, so the
  WebKitClient below points at this device's dedicated port. The
  boot result now exposes `proxy.port` in its JSON payload.
- **`src/tools/device-shutdown.ts`** — swaps the conditional
  shared-proxy teardown for a direct `stopProxyForDevice(deviceId)`
  call. Other devices' proxies are left running.

### Tests — 13 new cases in `tests/unit/proxy-manager.test.ts`

- `allocatePort`: deterministic per-UDID mapping, unique ports for
  different UDIDs, linear fallback on collision, range exhaustion
- `getProxyForDevice`: first-call creation, idempotency, per-device
  isolation, port release when start() throws
- `stopProxyForDevice`: targeted teardown, no-op for unknown devices,
  re-create after stop
- `stopAll`, `listManagedProxies`

## Architecture after this PR

```
Session A → device_boot(UDID-1) → ProxyManager.getProxyForDevice(UDID-1)
                                → WebInspectorProxy on port 9322
                                → bound to socket /launchd_sim-1/...

Session B → device_boot(UDID-2) → ProxyManager.getProxyForDevice(UDID-2)
                                → WebInspectorProxy on port 9324
                                → bound to socket /launchd_sim-2/...

device_shutdown(UDID-1) → stopProxyForDevice(UDID-1)
                       → UDID-2's proxy stays running
```

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 70 suites / 992 tests passing (was 979, +13 new)
- [x] `npx tsc --noEmit` — no type errors
- [x] Deterministic hashing: same UDID → same port across resets
- [x] Two UDIDs → two different ports
- [x] Collision fallback uses linear probing
- [x] Range exhaustion throws a descriptive error
- [x] Port is released when `start()` throws, allowing clean retry
- [x] `stopProxyForDevice` kills only one device's proxy
- [ ] (post-merge) Boot two simulators → verify separate
      `ios_webkit_debug_proxy` processes on different ports via
      `pgrep -fl ios_webkit_debug_proxy`
- [ ] (post-merge) `curl http://localhost:PORT/json` for each proxy
      shows ONLY that simulator's Safari targets
- [ ] (post-merge) Shutting down sim-1 leaves sim-2's proxy alive
      and functional

## Follow-ups (out of scope)

- **PR F (Phase 2B.2)**: `SimPool` — clone-based multi-simulator
  pool using `simctl clone` for ~2s warm boot. Will use
  ProxyManager to get a proxy per cloned simulator.
- **Breaking change (Phase 3)**: Remove `activeDeviceId` from
  SessionManager; every tool must supply an explicit `deviceId`.

## Refs

- #408 — parent roadmap issue
- #410 — `proxy.start({ targetUdid })` dependency