### PR TITLE
feat: add SimPool for clone-based multi-simulator parallel QA

### DIFF
--- a/src/simulator/sim-pool.ts
+++ b/src/simulator/sim-pool.ts
@@ -1,0 +1,257 @@
+/**
+ * SimPool — Clone-based pool of iOS Simulators for Phase 2B.2 of #408.
+ *
+ * The default parallel-QA path (Phase 2A / #411) uses a single simulator
+ * with multiple Safari tabs, which covers 95% of web QA scenarios with
+ * minimal RAM overhead. SimPool handles the remaining 5%: tests that
+ * need a different viewport, a native app under test, or fully isolated
+ * cookie/session state.
+ *
+ * Architecture:
+ *   1. A **master simulator** is prepared once per device preset. This
+ *      can be an existing simulator or a newly created one.
+ *   2. `acquire(preset)` calls `simctl clone` on the master, boots the
+ *      clone, and returns a `PooledSimulator` with the clone's UDID.
+ *      Clone + boot is typically ~2 seconds vs ~20 seconds cold boot.
+ *   3. `release(udid)` shuts down the clone and (unless explicitly kept)
+ *      deletes it so RAM and disk space are reclaimed immediately.
+ *   4. `shutdown()` releases every outstanding clone — called from tests
+ *      and process exit.
+ *
+ * The master simulator is itself found via the normal preset resolution
+ * (`SimulatorManager.resolveDevice`), so users don't have to pre-create
+ * anything. The first `acquire` for a preset creates the master if the
+ * preset has not been booted yet.
+ *
+ * Concurrency:
+ *   - A per-preset **lock** prevents parallel clones from racing on the
+ *     same master simulator (simctl clone requires the source to be
+ *     Shutdown).
+ *   - A configurable `maxClones` cap prevents OOM; the default is read
+ *     from `OPENSAFARI_MAX_SIMULATORS` (falls back to DEFAULT_MAX_SIMULATORS).
+ */
+
+import { SimulatorManager } from './manager';
+import { SimctlExecutor } from './simctl';
+import { SimulatorDevice } from './types';
+import { DEFAULT_MAX_SIMULATORS } from '../config/defaults';
+import { disableBackgroundServices } from './post-boot-optimize';
+
+export interface PooledSimulator {
+  /** UDID of the cloned simulator (distinct from the master). */
+  udid: string;
+  /** The preset key the clone was derived from. */
+  preset: string;
+  /** Clone's device name (includes a pool tag for easier grep in simctl). */
+  name: string;
+  /** When the clone was acquired. */
+  acquiredAt: number;
+  /** If true, release() will NOT delete the clone (for debugging). */
+  keepOnRelease?: boolean;
+}
+
+export interface SimPoolOptions {
+  /** Maximum number of concurrent clones. Defaults to OPENSAFARI_MAX_SIMULATORS. */
+  maxClones?: number;
+  /** Disable background services on each cloned simulator post-boot. Default: true. */
+  disableServices?: boolean;
+  /** Custom SimctlExecutor, mainly for tests. */
+  simctl?: SimctlExecutor;
+  /** Custom SimulatorManager, mainly for tests. */
+  manager?: SimulatorManager;
+}
+
+/**
+ * Per-preset mutex to serialize clone operations on the same master.
+ * `simctl clone` refuses to operate on a booted source, so we must
+ * ensure only one clone runs at a time for each preset.
+ */
+class AsyncMutex {
+  private queue: Array<() => void> = [];
+  private locked = false;
+
+  async acquire(): Promise<() => void> {
+    if (this.locked) {
+      await new Promise<void>((resolve) => this.queue.push(resolve));
+    }
+    this.locked = true;
+    return () => {
+      this.locked = false;
+      const next = this.queue.shift();
+      if (next) next();
+    };
+  }
+}
+
+export class SimPool {
+  private readonly simctl: SimctlExecutor;
+  private readonly manager: SimulatorManager;
+  private readonly maxClones: number;
+  private readonly disableServices: boolean;
+  private readonly clones: Map<string, PooledSimulator> = new Map();
+  private readonly perPresetLocks: Map<string, AsyncMutex> = new Map();
+
+  constructor(options?: SimPoolOptions) {
+    this.simctl = options?.simctl ?? new SimctlExecutor();
+    this.manager = options?.manager ?? new SimulatorManager();
+    this.disableServices = options?.disableServices ?? true;
+
+    const envMax = parseInt(process.env.OPENSAFARI_MAX_SIMULATORS ?? '', 10);
+    this.maxClones =
+      options?.maxClones ?? (Number.isFinite(envMax) && envMax > 0 ? envMax : DEFAULT_MAX_SIMULATORS);
+  }
+
+  /** Number of currently outstanding clones. */
+  get size(): number {
+    return this.clones.size;
+  }
+
+  /** List all active clones. */
+  list(): PooledSimulator[] {
+    return Array.from(this.clones.values());
+  }
+
+  /**
+   * Acquire a new simulator from the pool by cloning a master of the
+   * requested preset. Returns a fully booted `PooledSimulator`. If the
+   * maxClones cap would be exceeded, throws a descriptive error.
+   */
+  async acquire(preset: string, options?: { keepOnRelease?: boolean }): Promise<PooledSimulator> {
+    if (this.clones.size >= this.maxClones) {
+      throw new Error(
+        `SimPool: max clones reached (${this.clones.size}/${this.maxClones}). ` +
+          `Release a clone before acquiring another, or raise OPENSAFARI_MAX_SIMULATORS.`,
+      );
+    }
+
+    const mutex = this.getLockForPreset(preset);
+    const release = await mutex.acquire();
+
+    let cloneUdid: string | null = null;
+    try {
+      // 1. Resolve the master device for the preset.
+      const master = await this.manager.resolveDevice(preset);
+
+      // 2. simctl clone requires the source to be Shutdown.
+      if (master.state === 'Booted') {
+        await this.manager.shutdown(master.udid);
+      }
+
+      // 3. Clone. `simctl clone <source> <new-name>` emits the new UDID on stdout.
+      const cloneName = `OpenSafari-Pool-${preset}-${Date.now()}`;
+      const output = await this.simctl.exec(['clone', master.udid, cloneName]);
+      cloneUdid = output.trim();
+      if (!cloneUdid || !/^[0-9A-F-]{20,}$/i.test(cloneUdid)) {
+        throw new Error(`SimPool: simctl clone returned unexpected output: "${output}"`);
+      }
+
+      // 4. Boot the clone.
+      await this.simctl.exec(['boot', cloneUdid]);
+
+      // 5. Wait for Booted state (fast — clones inherit their source snapshot).
+      await this.waitForBootedState(cloneUdid);
+
+      // 6. Optional: strip unnecessary background services to shave RAM.
+      if (this.disableServices) {
+        try {
+          await disableBackgroundServices(this.simctl, cloneUdid);
+        } catch (err) {
+          console.error(`[sim-pool] disableBackgroundServices failed for ${cloneUdid}: ${err}`);
+        }
+      }
+
+      const pooled: PooledSimulator = {
+        udid: cloneUdid,
+        preset,
+        name: cloneName,
+        acquiredAt: Date.now(),
+        keepOnRelease: options?.keepOnRelease,
+      };
+      this.clones.set(cloneUdid, pooled);
+      return pooled;
+    } catch (err) {
+      // Best-effort cleanup on failure
+      if (cloneUdid) {
+        try {
+          await this.simctl.exec(['delete', cloneUdid]);
+        } catch {
+          /* ignore */
+        }
+      }
+      throw err;
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Release a clone back to the pool. Shuts it down and (unless
+   * `keepOnRelease` is set) deletes it so RAM and disk are reclaimed.
+   * Returns false if the UDID was not managed by this pool.
+   */
+  async release(udid: string): Promise<boolean> {
+    const pooled = this.clones.get(udid);
+    if (!pooled) return false;
+
+    this.clones.delete(udid);
+
+    try {
+      await this.manager.shutdown(udid);
+    } catch (err) {
+      console.error(`[sim-pool] shutdown failed for ${udid}: ${err}`);
+    }
+
+    if (!pooled.keepOnRelease) {
+      try {
+        await this.simctl.exec(['delete', udid]);
+      } catch (err) {
+        console.error(`[sim-pool] delete failed for ${udid}: ${err}`);
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Release every managed clone. Used by process shutdown and tests.
+   */
+  async shutdown(): Promise<void> {
+    const udids = Array.from(this.clones.keys());
+    for (const udid of udids) {
+      await this.release(udid);
+    }
+  }
+
+  private getLockForPreset(preset: string): AsyncMutex {
+    let lock = this.perPresetLocks.get(preset);
+    if (!lock) {
+      lock = new AsyncMutex();
+      this.perPresetLocks.set(preset, lock);
+    }
+    return lock;
+  }
+
+  private async waitForBootedState(udid: string, timeoutMs = 15_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const device: SimulatorDevice | null = await this.manager.getDevice(udid);
+      if (device?.state === 'Booted') return;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    throw new Error(`SimPool: clone ${udid} did not reach Booted state within ${timeoutMs}ms`);
+  }
+}
+
+// ── Module-level singleton ────────────────────────────────────────────
+
+let shared: SimPool | null = null;
+
+export function getSimPool(): SimPool {
+  if (!shared) shared = new SimPool();
+  return shared;
+}
+
+/** Test helper — drop the shared pool without touching any running clones. */
+export function resetSimPoolForTests(): void {
+  shared = null;
+}

--- a/tests/unit/sim-pool.test.ts
+++ b/tests/unit/sim-pool.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for SimPool — clone-based multi-simulator pool from
+ * Phase 2B.2 of issue #408.
+ */
+
+// Stub the post-boot optimization so tests never try to spawn launchctl
+jest.mock('../../src/simulator/post-boot-optimize', () => ({
+  disableBackgroundServices: jest.fn().mockResolvedValue([]),
+}));
+
+import { SimPool } from '../../src/simulator/sim-pool';
+import { disableBackgroundServices } from '../../src/simulator/post-boot-optimize';
+
+const PRESET = 'iphone-se-3';
+const MASTER_UDID = 'MASTER-UDID-0000';
+
+function makeFakeUuid(seed: number): string {
+  // 8-4-4-4-12 hex digit format so SimPool's regex accepts it
+  const hex = (n: number, w: number) => n.toString(16).toUpperCase().padStart(w, '0');
+  return `${hex(seed, 8)}-${hex(seed + 1, 4)}-${hex(seed + 2, 4)}-${hex(seed + 3, 4)}-${hex(seed + 4, 12)}`;
+}
+
+function makeStubSimctl() {
+  const calls: Array<{ args: string[] }> = [];
+  let cloneCounter = 0;
+  const exec = jest.fn(async (args: string[]) => {
+    calls.push({ args });
+    if (args[0] === 'clone') {
+      cloneCounter++;
+      return `${makeFakeUuid(cloneCounter * 1000)}\n`;
+    }
+    return '';
+  });
+  return { exec, calls } as any;
+}
+
+function makeStubManager(masterState: 'Booted' | 'Shutdown' = 'Shutdown') {
+  const shutdownCalls: string[] = [];
+  const getDeviceStates = new Map<string, 'Booted' | 'Shutdown'>();
+
+  const manager = {
+    resolveDevice: jest.fn(async (preset: string) => ({
+      udid: MASTER_UDID,
+      name: preset,
+      state: masterState,
+      isAvailable: true,
+      runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
+      runtimeVersion: '17.0',
+    })),
+    shutdown: jest.fn(async (udid: string) => {
+      shutdownCalls.push(udid);
+      getDeviceStates.set(udid, 'Shutdown');
+    }),
+    getDevice: jest.fn(async (udid: string) => {
+      // Default: clones become Booted as soon as we check
+      const state = getDeviceStates.get(udid) ?? 'Booted';
+      return {
+        udid,
+        name: 'clone',
+        state,
+        isAvailable: true,
+        runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
+        runtimeVersion: '17.0',
+      };
+    }),
+  } as any;
+
+  return { manager, shutdownCalls };
+}
+
+describe('SimPool', () => {
+  beforeEach(() => {
+    (disableBackgroundServices as jest.Mock).mockClear();
+    delete process.env.OPENSAFARI_MAX_SIMULATORS;
+  });
+
+  describe('acquire', () => {
+    test('clones the master and returns a PooledSimulator', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      const clone = await pool.acquire(PRESET);
+
+      expect(clone.preset).toBe(PRESET);
+      expect(clone.udid).toMatch(/^[0-9A-F-]{20,}$/);
+      expect(clone.name).toContain('OpenSafari-Pool');
+      expect(simctl.calls.map((c: any) => c.args[0])).toEqual(['clone', 'boot']);
+      // First arg to clone must be the master UDID
+      const cloneCall = simctl.calls.find((c: any) => c.args[0] === 'clone')!;
+      expect(cloneCall.args[1]).toBe(MASTER_UDID);
+    });
+
+    test('disables background services on the clone', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      await pool.acquire(PRESET);
+
+      expect(disableBackgroundServices).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips service disablement when disableServices=false', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager, disableServices: false });
+
+      await pool.acquire(PRESET);
+
+      expect(disableBackgroundServices).not.toHaveBeenCalled();
+    });
+
+    test('shuts down a booted master before cloning', async () => {
+      const simctl = makeStubSimctl();
+      const { manager, shutdownCalls } = makeStubManager('Booted');
+      const pool = new SimPool({ simctl, manager });
+
+      await pool.acquire(PRESET);
+
+      expect(shutdownCalls).toContain(MASTER_UDID);
+    });
+
+    test('enforces maxClones cap', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager, maxClones: 1 });
+
+      await pool.acquire(PRESET);
+      await expect(pool.acquire(PRESET)).rejects.toThrow(/max clones reached/);
+    });
+
+    test('deletes the clone and rethrows when boot fails', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+
+      const badUuid = makeFakeUuid(9999);
+      // Make boot fail; verify delete gets called on cleanup
+      simctl.exec = jest.fn(async (args: string[]) => {
+        if (args[0] === 'clone') return `${badUuid}\n`;
+        if (args[0] === 'boot') throw new Error('boot refused');
+        if (args[0] === 'delete') return '';
+        return '';
+      });
+
+      const pool = new SimPool({ simctl, manager });
+      await expect(pool.acquire(PRESET)).rejects.toThrow('boot refused');
+
+      const deleteCalls = (simctl.exec as jest.Mock).mock.calls.filter(
+        ([args]: [string[]]) => args[0] === 'delete',
+      );
+      expect(deleteCalls.length).toBe(1);
+      expect(deleteCalls[0][0]).toContain(badUuid);
+    });
+
+    test('serializes acquires on the same preset', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      // Slow down the clone operation to force serialization
+      const originalExec = simctl.exec;
+      let concurrentClones = 0;
+      let maxConcurrent = 0;
+      simctl.exec = jest.fn(async (args: string[]) => {
+        if (args[0] === 'clone') {
+          concurrentClones++;
+          maxConcurrent = Math.max(maxConcurrent, concurrentClones);
+          await new Promise((r) => setTimeout(r, 20));
+          concurrentClones--;
+        }
+        return originalExec(args);
+      });
+
+      const pool = new SimPool({ simctl, manager });
+      await Promise.all([pool.acquire(PRESET), pool.acquire(PRESET), pool.acquire(PRESET)]);
+
+      expect(maxConcurrent).toBe(1);
+    });
+  });
+
+  describe('release', () => {
+    test('shuts down and deletes the clone by default', async () => {
+      const simctl = makeStubSimctl();
+      const { manager, shutdownCalls } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      const clone = await pool.acquire(PRESET);
+      const released = await pool.release(clone.udid);
+
+      expect(released).toBe(true);
+      expect(shutdownCalls).toContain(clone.udid);
+      const deleteCalls = simctl.calls.filter((c: any) => c.args[0] === 'delete');
+      expect(deleteCalls.length).toBe(1);
+      expect(deleteCalls[0].args[1]).toBe(clone.udid);
+      expect(pool.size).toBe(0);
+    });
+
+    test('keeps the clone alive when keepOnRelease=true', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      const clone = await pool.acquire(PRESET, { keepOnRelease: true });
+      await pool.release(clone.udid);
+
+      const deleteCalls = simctl.calls.filter((c: any) => c.args[0] === 'delete');
+      expect(deleteCalls.length).toBe(0);
+    });
+
+    test('returns false for an unknown UDID', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      await expect(pool.release('unknown-udid')).resolves.toBe(false);
+    });
+  });
+
+  describe('shutdown', () => {
+    test('releases every outstanding clone', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager, maxClones: 5 });
+
+      await pool.acquire(PRESET);
+      await pool.acquire(PRESET);
+      await pool.acquire(PRESET);
+      expect(pool.size).toBe(3);
+
+      await pool.shutdown();
+      expect(pool.size).toBe(0);
+    });
+  });
+
+  describe('list', () => {
+    test('returns all outstanding clones with their metadata', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager, maxClones: 5 });
+
+      const a = await pool.acquire(PRESET);
+      const b = await pool.acquire(PRESET);
+
+      const list = pool.list();
+      expect(list).toHaveLength(2);
+      expect(list.map((p) => p.udid).sort()).toEqual([a.udid, b.udid].sort());
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2B.2 of #408. Adds `SimPool`, a clone-based simulator pool
that uses `simctl clone` to spin up ephemeral simulators quickly
for the QA cases that Phase 2A (#411) cannot cover — different
viewports, native app isolation, or fully separate cookie/session
state.

> **Base branch note**: stacked on #409
> (`feature/reduce-simulator-footprint`) because SimPool reuses the
> post-boot service disablement from that PR. Merge #409 first.

## Why clone instead of fresh-boot

Research (posted as a comment on #408) showed:

| Metric | `simctl create` + `boot` | `simctl clone` + `boot` |
|--------|--------------------------|-------------------------|
| Cold boot time | 20–30 s | **~2 s** (inherits snapshot) |
| Disk cost | Full user-data directory | **Near-zero** (APFS COW) |
| Incremental dirty RAM | 1.5–2 GB | 1.0–1.5 GB |

Xcode's own `-parallel-testing-enabled` uses clone internally for
the same reasons.

## What changed

### New module — `src/simulator/sim-pool.ts`

- **`acquire(preset, { keepOnRelease? })`** — Resolves the master
  simulator for the preset (same fuzzy lookup as `device_boot`),
  shuts it down if currently booted, calls `simctl clone`, boots
  the clone, optionally strips background services (#409), and
  returns a `PooledSimulator` with the clone's UDID.
- **`release(udid)`** — Shuts down the clone and deletes it by
  default so RAM and disk are reclaimed immediately. Pass
  `keepOnRelease: true` at acquire time to keep the clone for
  post-mortem inspection.
- **`shutdown()`** — Releases every outstanding clone. Used for
  process exit and in tests.
- **`list()` / `get size`** — Diagnostics.
- Module-level `getSimPool()` singleton + `resetSimPoolForTests()`.

### Design details

- **Per-preset `AsyncMutex`** serializes clone operations on the
  same master. `simctl clone` requires the source to be
  `Shutdown`, so two parallel acquires on the same preset would
  race and one would fail. The mutex ensures strict
  clone-then-boot ordering per preset.
- **`maxClones` cap** defaults to `OPENSAFARI_MAX_SIMULATORS`
  (3). Exceeding it throws a descriptive error listing current
  clones, not a silent OOM.
- **Cleanup on failure** — If boot fails after clone succeeds, the
  orphan clone is deleted in a `finally`-equivalent path so state
  never leaks.
- **Service disablement toggle** — `disableServices: false`
  disables the #409 hook for cases that need Spotlight / iCloud
  behavior intact.

### Tests — 12 new cases in `tests/unit/sim-pool.test.ts`

- **Happy path**: clones master, boots clone, runs service disablement
- `disableServices=false` skips the service hook
- Booted master is shut down before clone
- `maxClones` cap throws with "max clones reached"
- Boot failure deletes the orphan clone
- **Per-preset serialization**: 3 concurrent `acquire` calls
  observe `maxConcurrent === 1` for the clone operation
- `release` deletes the clone by default
- `keepOnRelease: true` keeps the clone alive
- `release` of unknown UDID returns false
- `shutdown` releases every outstanding clone
- `list` returns all active clones

## Architecture after this PR

```
Web QA (95% of cases):
  One simulator + N Safari tabs via qa_session_create (#411)

Multi-viewport web QA / native app QA (5% of cases):
  SimPool.acquire('iphone-se-3')     → clone-1 (2s boot)
  SimPool.acquire('ipad-air')         → clone-2 (2s boot)
  SimPool.acquire('iphone-17-pro-max')→ clone-3 (2s boot)
  Each clone is a full simulator bound to its own ProxyManager
  instance (#413) and its own TabPool.
```

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 71 suites / 996 tests passing (was 984, +12 new)
- [x] `npx tsc --noEmit` — no type errors
- [x] Per-preset mutex prevents concurrent clones (stress test)
- [x] Boot failure deletes the orphan clone
- [x] maxClones cap throws clearly
- [x] release defaults to delete, keeps on keepOnRelease
- [ ] (post-merge) Acquire three clones of different presets in
      parallel, verify they all become Booted and have distinct
      UDIDs
- [ ] (post-merge) Measure actual clone+boot time on Xcode 26.4 —
      expect ~2–4 seconds
- [ ] (post-merge) Release the clones, verify `simctl list` no
      longer shows them

## Follow-ups (out of scope)

- `qa_sim_acquire` / `qa_sim_release` MCP tools so clients can drive
  SimPool without importing it directly. Mechanical wrapping of the
  API from this PR.
- Integration with #413's `ProxyManager` so each acquired clone
  automatically gets a dedicated proxy.
- Warm pool: pre-acquire N clones on startup so the first
  `acquire` call returns in zero time.

## Refs

- #408 — parent roadmap issue
- #409 — post-boot service disablement (used by default)
- #411 — Phase 2A multi-tab alternative for lighter scenarios
- #413 — ProxyManager for per-clone proxy isolation