### PR TITLE
refactor!: remove activeDeviceId, enforce unique-device resolution

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -64,11 +64,10 @@ export function setWebKitClient(client: BrowserBackend | null, deviceId?: string
       });
     }
     sm.setConnection(id, client);
-    sm.setActiveDevice(id);
   } else {
-    // Clear: remove the specified or active device's connection
-    const activeId = sm.getActiveDeviceId();
-    const targetId = deviceId ?? activeId;
+    // Clear: remove the specified or sole device's connection
+    const soleId = sm.getSoleDeviceId();
+    const targetId = deviceId ?? soleId;
     if (targetId) {
       sm.removeConnection(targetId);
       sm.removeSimulator(targetId);

--- a/src/native/accessibility.ts
+++ b/src/native/accessibility.ts
@@ -46,7 +46,7 @@ export interface QueryMatch {
  */
 export function resolveDeviceId(explicit?: string): string {
   if (explicit) return explicit;
-  const active = getSessionManager().getActiveDeviceId();
+  const active = getSessionManager().getSoleDeviceId();
   if (!active) {
     throw new Error(
       'No device specified and no active device found. Boot a simulator first with device_boot.',

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -5,7 +5,12 @@ import { BrowserBackend } from './types/browser-backend';
  * Session Manager — Simulator & Safari Connection Tracking
  *
  * Maps booted simulators to WebKit Protocol connections (BrowserBackend instances).
- * Manages active device, workers, and connection lifecycle.
+ * Manages workers and connection lifecycle.
+ *
+ * Phase 3 of #408 removed the `activeDeviceId` global field. Tools that do not
+ * specify a deviceId fall back to the unique booted device (if exactly one is
+ * connected) instead of a process-wide "active" pointer that two concurrent
+ * sessions could silently overwrite.
  */
 
 export interface SimulatorInfo {
@@ -46,26 +51,17 @@ export class SessionManager extends EventEmitter {
   private connections: Map<string, BrowserBackend> = new Map();
   private workers: Map<string, WorkerInfo> = new Map();
   private tabSessions: Map<string, TabSessionInfo> = new Map();
-  private activeDeviceId: string | null = null;
 
   // Simulator tracking
   addSimulator(deviceId: string, info: SimulatorInfo): void {
     this.simulators.set(deviceId, info);
     this.emit('simulator:added', { deviceId, info });
-    if (!this.activeDeviceId) {
-      this.activeDeviceId = deviceId;
-    }
   }
 
   removeSimulator(deviceId: string): void {
     this.simulators.delete(deviceId);
     this.connections.delete(deviceId);
     this.emit('simulator:removed', { deviceId });
-    if (this.activeDeviceId === deviceId) {
-      this.activeDeviceId = this.simulators.size > 0
-        ? this.simulators.keys().next().value ?? null
-        : null;
-    }
   }
 
   getSimulator(deviceId: string): SimulatorInfo | null {
@@ -82,10 +78,47 @@ export class SessionManager extends EventEmitter {
     this.emit('connection:established', { deviceId });
   }
 
+  /**
+   * Look up a registered BrowserBackend connection.
+   *
+   * Resolution rules (Phase 3 of #408 — `activeDeviceId` has been removed):
+   *   - If `deviceId` is supplied, return the connection for that device (or null).
+   *   - If `deviceId` is omitted AND exactly one device is connected, return
+   *     that sole connection — this preserves the single-device workflow
+   *     without any global state.
+   *   - Otherwise (zero or multiple connections), return null. Callers that
+   *     need an explicit choice in multi-device scenarios should use
+   *     `listConnections()` and pick one themselves, or surface a structured
+   *     error listing available devices.
+   */
   getConnection(deviceId?: string): BrowserBackend | null {
-    const id = deviceId ?? this.activeDeviceId;
-    if (!id) return null;
-    return this.connections.get(id) ?? null;
+    if (deviceId) {
+      return this.connections.get(deviceId) ?? null;
+    }
+    if (this.connections.size === 1) {
+      const sole = this.connections.values().next().value;
+      return sole ?? null;
+    }
+    return null;
+  }
+
+  /**
+   * Return the sole device id when the session is in unambiguous single-device
+   * mode. Prefers the unique WebKit connection (so Safari tools work as soon
+   * as device_boot finishes), then falls back to the unique registered
+   * simulator (so native app tools work even before a WebKit connection is
+   * established). Returns null whenever zero or multiple devices are present
+   * — callers that need to pick in multi-device scenarios must ask the
+   * caller for an explicit `deviceId`.
+   */
+  getSoleDeviceId(): string | null {
+    if (this.connections.size === 1) {
+      return this.connections.keys().next().value ?? null;
+    }
+    if (this.simulators.size === 1) {
+      return this.simulators.keys().next().value ?? null;
+    }
+    return null;
   }
 
   removeConnection(deviceId: string): void {
@@ -99,19 +132,6 @@ export class SessionManager extends EventEmitter {
 
   listConnections(): Array<{ deviceId: string; client: BrowserBackend }> {
     return Array.from(this.connections.entries()).map(([deviceId, client]) => ({ deviceId, client }));
-  }
-
-  // Active device
-  setActiveDevice(deviceId: string): void {
-    if (!this.simulators.has(deviceId)) {
-      throw new Error(`Device ${deviceId} not found in session`);
-    }
-    this.activeDeviceId = deviceId;
-    this.emit('device:active', { deviceId });
-  }
-
-  getActiveDeviceId(): string | null {
-    return this.activeDeviceId;
   }
 
   markActivity(deviceId: string): void {
@@ -216,7 +236,6 @@ export class SessionManager extends EventEmitter {
     this.connections.clear();
     this.simulators.clear();
     this.workers.clear();
-    this.activeDeviceId = null;
     this.emit('session:shutdown');
   }
 }

--- a/src/tools/app-activate.ts
+++ b/src/tools/app-activate.ts
@@ -26,7 +26,7 @@ export function registerAppActivateTool(server: MCPServer): void {
       const sm = getSessionManager();
       const manager = new SimulatorManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
 
       if (!deviceId) {
         return {

--- a/src/tools/app-alert-handle.ts
+++ b/src/tools/app-alert-handle.ts
@@ -31,7 +31,7 @@ export function registerAppAlertHandleTool(server: MCPServer): void {
       const manager = new SimulatorManager();
       const booted = await manager.listBooted();
       const deviceId =
-        (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+        (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
 
       if (!deviceId) {
         return {

--- a/src/tools/app-assert.ts
+++ b/src/tools/app-assert.ts
@@ -24,7 +24,7 @@ export interface AppAssertResult {
 async function resolveDeviceId(deviceId?: string): Promise<string> {
   if (deviceId) return deviceId;
 
-  const active = getSessionManager().getActiveDeviceId();
+  const active = getSessionManager().getSoleDeviceId();
   if (active) return active;
 
   const manager = new SimulatorManager();

--- a/src/tools/app-dismiss-keyboard.ts
+++ b/src/tools/app-dismiss-keyboard.ts
@@ -22,7 +22,7 @@ export function registerAppDismissKeyboardTool(server: MCPServer): void {
       // Resolve device ID: explicit param → session active → first booted
       const deviceId =
         (params.deviceId as string) ??
-        getSessionManager().getActiveDeviceId() ??
+        getSessionManager().getSoleDeviceId() ??
         (await manager.listBooted())[0]?.udid;
 
       if (!deviceId) {

--- a/src/tools/app-inspect.ts
+++ b/src/tools/app-inspect.ts
@@ -35,7 +35,7 @@ export function registerAppInspectTool(server: MCPServer): void {
       }
 
       try {
-        const deviceId = (params.device_id as string) ?? getSessionManager().getActiveDeviceId() ?? undefined;
+        const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
 
         const bridge = getAccessibilityBridge();
         const node = await bridge.inspect(elementPath, deviceId);

--- a/src/tools/app-launch.ts
+++ b/src/tools/app-launch.ts
@@ -36,7 +36,7 @@ export function registerAppLaunchTool(server: MCPServer): void {
       const sm = getSessionManager();
       const manager = new SimulatorManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
 
       if (!deviceId) {
         return {

--- a/src/tools/app-list-running.ts
+++ b/src/tools/app-list-running.ts
@@ -22,7 +22,7 @@ export function registerAppListRunningTool(server: MCPServer): void {
       const sm = getSessionManager();
       const manager = new SimulatorManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
 
       if (!deviceId) {
         return {

--- a/src/tools/app-permission.ts
+++ b/src/tools/app-permission.ts
@@ -26,7 +26,7 @@ async function resolveDeviceId(params: Record<string, unknown>): Promise<string 
   const sm = getSessionManager();
   const manager = new SimulatorManager();
   const booted = await manager.listBooted();
-  return (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid ?? null;
+  return (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid ?? null;
 }
 
 export function registerAppPermissionTools(server: MCPServer): void {

--- a/src/tools/app-push.ts
+++ b/src/tools/app-push.ts
@@ -37,7 +37,7 @@ export function registerAppPushTool(server: MCPServer): void {
       const sm = getSessionManager();
       const manager = new SimulatorManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
 
       if (!deviceId) {
         return {

--- a/src/tools/app-query.ts
+++ b/src/tools/app-query.ts
@@ -55,7 +55,7 @@ export function registerAppQueryTool(server: MCPServer): void {
       }
 
       try {
-        const deviceId = (params.device_id as string) ?? getSessionManager().getActiveDeviceId() ?? undefined;
+        const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
         const maxResults = params.max_results as number | undefined;
 
         const bridge = getAccessibilityBridge();

--- a/src/tools/app-reset.ts
+++ b/src/tools/app-reset.ts
@@ -28,7 +28,7 @@ export function registerAppResetTool(server: MCPServer): void {
       const sm = getSessionManager();
       const manager = new SimulatorManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
 
       if (!deviceId) {
         return {

--- a/src/tools/app-scroll-native.ts
+++ b/src/tools/app-scroll-native.ts
@@ -106,7 +106,7 @@ export function registerAppScrollNativeTool(server: MCPServer): void {
         const booted = await manager.listBooted();
         const deviceId =
           (params.deviceId as string | undefined) ??
-          sm.getActiveDeviceId() ??
+          sm.getSoleDeviceId() ??
           booted[0]?.udid;
 
         if (!deviceId) {

--- a/src/tools/app-switch-app.ts
+++ b/src/tools/app-switch-app.ts
@@ -30,7 +30,7 @@ export function registerAppSwitchAppTool(server: MCPServer): void {
       const sm = getSessionManager();
       const manager = new SimulatorManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
 
       if (!deviceId) {
         return {

--- a/src/tools/app-terminate.ts
+++ b/src/tools/app-terminate.ts
@@ -26,7 +26,7 @@ export function registerAppTerminateTool(server: MCPServer): void {
       const sm = getSessionManager();
       const manager = new SimulatorManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
 
       if (!deviceId) {
         return {

--- a/src/tools/app-tree.ts
+++ b/src/tools/app-tree.ts
@@ -24,7 +24,7 @@ export function registerAppTreeTool(server: MCPServer): void {
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
       try {
-        const deviceId = (params.device_id as string) ?? getSessionManager().getActiveDeviceId() ?? undefined;
+        const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
         const maxDepth = params.max_depth as number | undefined;
 
         const bridge = getAccessibilityBridge();

--- a/src/tools/app-webview-connect.ts
+++ b/src/tools/app-webview-connect.ts
@@ -52,7 +52,7 @@ export function registerAppWebviewConnectTool(server: MCPServer): void {
 
       // Resolve device ID
       const resolvedDeviceId =
-        deviceId ?? getSessionManager().getActiveDeviceId() ?? DEFAULT_PROXY_HOST;
+        deviceId ?? getSessionManager().getSoleDeviceId() ?? DEFAULT_PROXY_HOST;
 
       // Get or create a WebKit client
       let client = getWebKitClient(deviceId);

--- a/src/tools/device-boot.ts
+++ b/src/tools/device-boot.ts
@@ -98,7 +98,7 @@ export function registerDeviceBootTool(server: MCPServer): void {
           const client = new WebKitClient({ host: 'localhost', port: proxy.port });
           await client.connect({ retries: 5, retryDelay: 2000 });
 
-          // Register in SessionManager — tracks connection and sets as active device
+          // Register in SessionManager — tracks the connection by deviceId
           const preset = Object.entries(DEVICE_PRESETS).find(([, p]) => p.name === device.name);
           sm.addSimulator(device.udid, {
             deviceId: device.udid,
@@ -109,7 +109,6 @@ export function registerDeviceBootTool(server: MCPServer): void {
             lastActivity: Date.now(),
           });
           sm.setConnection(device.udid, client);
-          sm.setActiveDevice(device.udid);
         } catch (err) {
           console.error(`[device_boot] WebKit connection failed (proxy running, tools may not work): ${err}`);
         }

--- a/src/tools/device-shutdown.ts
+++ b/src/tools/device-shutdown.ts
@@ -21,7 +21,7 @@ export function registerDeviceShutdownTool(server: MCPServer): void {
       const manager = new SimulatorManager();
       const sm = getSessionManager();
       const booted = await manager.listBooted();
-      const deviceId = (params.deviceId as string) ?? sm.getActiveDeviceId() ?? booted[0]?.udid;
+      const deviceId = (params.deviceId as string) ?? sm.getSoleDeviceId() ?? booted[0]?.udid;
       if (!deviceId) {
         return { content: [{ type: 'text' as const, text: 'Error: no booted device found' }], isError: true };
       }

--- a/src/tools/native-app-helpers.ts
+++ b/src/tools/native-app-helpers.ts
@@ -5,7 +5,7 @@ import { getSessionManager } from '../session-manager';
  * Throws if no device is available.
  */
 export function resolveDeviceId(params: Record<string, unknown>): string {
-  const deviceId = (params.deviceId as string) || getSessionManager().getActiveDeviceId();
+  const deviceId = (params.deviceId as string) || getSessionManager().getSoleDeviceId();
   if (!deviceId) {
     throw new Error('No device specified and no active device. Boot a simulator first with device_boot.');
   }

--- a/src/tools/native-app-utils.ts
+++ b/src/tools/native-app-utils.ts
@@ -5,7 +5,7 @@ import { getSessionManager } from '../session-manager';
  * Throws if no device is available.
  */
 export function resolveDeviceId(params: Record<string, unknown>): string {
-  const deviceId = (params.deviceId as string) || getSessionManager().getActiveDeviceId();
+  const deviceId = (params.deviceId as string) || getSessionManager().getSoleDeviceId();
   if (!deviceId) {
     throw new Error(
       'No device specified and no active device. Boot a simulator first with device_boot.',

--- a/src/tools/native-input-utils.ts
+++ b/src/tools/native-input-utils.ts
@@ -24,7 +24,7 @@ export type { InputBackend, InputBackendKind } from './native-input-backend';
 export function resolveDeviceId(params: Record<string, unknown>): string {
   const deviceId =
     (params.deviceId as string | undefined) ||
-    getSessionManager().getActiveDeviceId();
+    getSessionManager().getSoleDeviceId();
   if (!deviceId) {
     throw new Error(
       'No device specified and no active device. Boot a simulator first with device_boot.',

--- a/src/tools/native-observability-utils.ts
+++ b/src/tools/native-observability-utils.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'crypto';
  * Throws if no device is available.
  */
 export function resolveDeviceId(params: Record<string, unknown>): string {
-  const deviceId = (params.deviceId as string) || getSessionManager().getActiveDeviceId();
+  const deviceId = (params.deviceId as string) || getSessionManager().getSoleDeviceId();
   if (!deviceId) {
     throw new Error('No device specified and no active device. Boot a simulator first with device_boot.');
   }

--- a/src/tools/set-active-context.ts
+++ b/src/tools/set-active-context.ts
@@ -42,7 +42,7 @@ export function registerSetActiveContextTool(server: MCPServer): void {
 
       // Resolve device ID
       const resolvedDeviceId =
-        deviceId ?? getSessionManager().getActiveDeviceId() ?? DEFAULT_PROXY_HOST;
+        deviceId ?? getSessionManager().getSoleDeviceId() ?? DEFAULT_PROXY_HOST;
 
       // Get or create a client to query targets
       let probeClient = getWebKitClient(deviceId);

--- a/tests/unit/app-accessibility-tools.test.ts
+++ b/tests/unit/app-accessibility-tools.test.ts
@@ -12,7 +12,7 @@ jest.mock('../../src/session-manager', () => {
   let activeDeviceId: string | null = 'MOCK-DEVICE-UUID';
   return {
     getSessionManager: () => ({
-      getActiveDeviceId: () => activeDeviceId,
+      getSoleDeviceId: () => activeDeviceId,
       _setActiveDeviceId: (id: string | null) => { activeDeviceId = id; },
     }),
   };

--- a/tests/unit/app-alert-handle.test.ts
+++ b/tests/unit/app-alert-handle.test.ts
@@ -27,7 +27,7 @@ jest.mock('../../src/simulator', () => ({
 
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn().mockReturnValue({
-    getActiveDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
+    getSoleDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
   }),
 }));
 
@@ -64,7 +64,7 @@ describe('app_alert_handle tool', () => {
       }),
     }));
     getSessionManager.mockReturnValue({
-      getActiveDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
+      getSoleDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
     });
   });
 
@@ -118,7 +118,7 @@ describe('app_alert_handle tool', () => {
 
   test('returns error when no device is booted', async () => {
     getSessionManager.mockReturnValue({
-      getActiveDeviceId: jest.fn().mockReturnValue(null),
+      getSoleDeviceId: jest.fn().mockReturnValue(null),
     });
     SimulatorManager.mockImplementation(() => ({
       listBooted: jest.fn().mockResolvedValue([]),

--- a/tests/unit/app-assert.test.ts
+++ b/tests/unit/app-assert.test.ts
@@ -23,7 +23,7 @@ jest.mock('../../src/simulator', () => {
 jest.mock('../../src/session-manager', () => {
   return {
     getSessionManager: jest.fn().mockReturnValue({
-      getActiveDeviceId: jest.fn().mockReturnValue(null),
+      getSoleDeviceId: jest.fn().mockReturnValue(null),
     }),
   };
 });
@@ -40,7 +40,7 @@ const DEVICE_ID = 'test-device-udid-123';
 
 function setupDeviceId(deviceId: string = DEVICE_ID): void {
   mockGetSessionManager.mockReturnValue({
-    getActiveDeviceId: jest.fn().mockReturnValue(deviceId),
+    getSoleDeviceId: jest.fn().mockReturnValue(deviceId),
   } as any);
 }
 
@@ -333,7 +333,7 @@ describe('app_assert tool', () => {
   describe('device resolution', () => {
     test('returns error result when no device available', async () => {
       mockGetSessionManager.mockReturnValue({
-        getActiveDeviceId: jest.fn().mockReturnValue(null),
+        getSoleDeviceId: jest.fn().mockReturnValue(null),
       } as any);
       MockSimulatorManager.mockImplementation(() => ({
         listBooted: jest.fn().mockResolvedValue([]),

--- a/tests/unit/app-dismiss-keyboard.test.ts
+++ b/tests/unit/app-dismiss-keyboard.test.ts
@@ -32,7 +32,7 @@ let mockActiveDeviceId: string | null = null;
 
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: () => ({
-    getActiveDeviceId: () => mockActiveDeviceId,
+    getSoleDeviceId: () => mockActiveDeviceId,
   }),
 }));
 

--- a/tests/unit/app-inspect-tool.test.ts
+++ b/tests/unit/app-inspect-tool.test.ts
@@ -5,7 +5,7 @@ import { AccessibilityBridge, getAccessibilityBridge } from '../../src/native';
 jest.mock('../../src/native');
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: () => ({
-    getActiveDeviceId: () => 'mock-device-id',
+    getSoleDeviceId: () => 'mock-device-id',
   }),
 }));
 

--- a/tests/unit/app-interaction-tools.test.ts
+++ b/tests/unit/app-interaction-tools.test.ts
@@ -78,7 +78,7 @@ jest.mock('../../src/tools/native-input-backend', () => ({
 
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: () => ({
-    getActiveDeviceId: () => 'MOCK-DEVICE-UDID',
+    getSoleDeviceId: () => 'MOCK-DEVICE-UDID',
   }),
 }));
 

--- a/tests/unit/app-observability-tools.test.ts
+++ b/tests/unit/app-observability-tools.test.ts
@@ -41,7 +41,6 @@ describe('native-observability-utils', () => {
         bootedAt: Date.now(),
         lastActivity: Date.now(),
       });
-      sm.setActiveDevice('ACTIVE-001');
       expect(resolveDeviceId({})).toBe('ACTIVE-001');
       sm.removeSimulator('ACTIVE-001');
     });
@@ -49,7 +48,7 @@ describe('native-observability-utils', () => {
     test('throws when no device available', () => {
       // Ensure no active device
       const sm = getSessionManager();
-      const activeId = sm.getActiveDeviceId();
+      const activeId = sm.getSoleDeviceId();
       if (activeId) sm.removeSimulator(activeId);
       expect(() => resolveDeviceId({})).toThrow('No device specified');
     });
@@ -131,7 +130,7 @@ describe('app_screenshot_native tool', () => {
 
   test('returns error when no device available', async () => {
     const sm = getSessionManager();
-    const activeId = sm.getActiveDeviceId();
+    const activeId = sm.getSoleDeviceId();
     if (activeId) sm.removeSimulator(activeId);
 
     const handler = server.getToolHandler('app_screenshot_native')!;
@@ -155,7 +154,7 @@ describe('app_logs tool', () => {
 
   test('returns error when no device available', async () => {
     const sm = getSessionManager();
-    const activeId = sm.getActiveDeviceId();
+    const activeId = sm.getSoleDeviceId();
     if (activeId) sm.removeSimulator(activeId);
 
     const handler = server.getToolHandler('app_logs')!;
@@ -174,7 +173,6 @@ describe('app_logs tool', () => {
       bootedAt: Date.now(),
       lastActivity: Date.now(),
     });
-    sm.setActiveDevice('LOG-DEV');
 
     const handler = server.getToolHandler('app_logs')!;
     const result = await handler('test', { since: 'invalid' });
@@ -199,7 +197,7 @@ describe('app_crash_reports tool', () => {
 
   test('returns error when no device available', async () => {
     const sm = getSessionManager();
-    const activeId = sm.getActiveDeviceId();
+    const activeId = sm.getSoleDeviceId();
     if (activeId) sm.removeSimulator(activeId);
 
     const handler = server.getToolHandler('app_crash_reports')!;
@@ -227,7 +225,7 @@ describe('app_record_video tool', () => {
 
   test('returns error when no device available', async () => {
     const sm = getSessionManager();
-    const activeId = sm.getActiveDeviceId();
+    const activeId = sm.getSoleDeviceId();
     if (activeId) sm.removeSimulator(activeId);
 
     const handler = server.getToolHandler('app_record_video')!;
@@ -246,7 +244,6 @@ describe('app_record_video tool', () => {
       bootedAt: Date.now(),
       lastActivity: Date.now(),
     });
-    sm.setActiveDevice('VID-DEV');
 
     const handler = server.getToolHandler('app_record_video')!;
     const result = await handler('test', { action: 'stop', deviceId: 'VID-DEV' });
@@ -275,7 +272,6 @@ describe('app_record_video tool', () => {
       bootedAt: Date.now(),
       lastActivity: Date.now(),
     });
-    sm.setActiveDevice('DUP-DEV');
 
     const handler = server.getToolHandler('app_record_video')!;
     const result = await handler('test', { action: 'start', deviceId: 'DUP-DEV' });

--- a/tests/unit/app-open-url.test.ts
+++ b/tests/unit/app-open-url.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../src/simulator/simctl', () => {
 // Mock SessionManager (used by resolveDeviceId)
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn().mockReturnValue({
-    getActiveDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
+    getSoleDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
   }),
 }));
 
@@ -79,7 +79,7 @@ describe('app_open_url tool', () => {
   test('returns error when no device available', async () => {
     const sessionMgr = jest.requireMock('../../src/session-manager') as { getSessionManager: jest.Mock };
     sessionMgr.getSessionManager.mockReturnValueOnce({
-      getActiveDeviceId: jest.fn().mockReturnValue(null),
+      getSoleDeviceId: jest.fn().mockReturnValue(null),
     });
 
     const handler = server.getToolHandler('app_open_url')!;

--- a/tests/unit/app-permission.test.ts
+++ b/tests/unit/app-permission.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../src/simulator', () => ({
 
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn().mockReturnValue({
-    getActiveDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
+    getSoleDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
   }),
 }));
 
@@ -108,7 +108,7 @@ describe('app_permission tools', () => {
     });
 
     test('returns error when no device booted', async () => {
-      mockedGetSessionManager.mockReturnValueOnce({ getActiveDeviceId: () => null } as ReturnType<typeof getSessionManager>);
+      mockedGetSessionManager.mockReturnValueOnce({ getSoleDeviceId: () => null } as ReturnType<typeof getSessionManager>);
       MockedSimulatorManager.mockImplementationOnce(() => ({
         listBooted: jest.fn().mockResolvedValue([]),
       }) as unknown as SimulatorManager);

--- a/tests/unit/app-push.test.ts
+++ b/tests/unit/app-push.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../src/simulator', () => ({
 
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn().mockReturnValue({
-    getActiveDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
+    getSoleDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
   }),
 }));
 
@@ -75,7 +75,7 @@ describe('app_push tool', () => {
   });
 
   test('returns error when no device booted', async () => {
-    mockedGetSessionManager.mockReturnValueOnce({ getActiveDeviceId: () => null } as ReturnType<typeof getSessionManager>);
+    mockedGetSessionManager.mockReturnValueOnce({ getSoleDeviceId: () => null } as ReturnType<typeof getSessionManager>);
     MockedSimulatorManager.mockImplementationOnce(() => ({
       listBooted: jest.fn().mockResolvedValue([]),
     }) as unknown as SimulatorManager);

--- a/tests/unit/app-query-tool.test.ts
+++ b/tests/unit/app-query-tool.test.ts
@@ -5,7 +5,7 @@ import { AccessibilityBridge, getAccessibilityBridge } from '../../src/native';
 jest.mock('../../src/native');
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: () => ({
-    getActiveDeviceId: () => 'mock-device-id',
+    getSoleDeviceId: () => 'mock-device-id',
   }),
 }));
 

--- a/tests/unit/app-scroll-native.test.ts
+++ b/tests/unit/app-scroll-native.test.ts
@@ -17,10 +17,10 @@ jest.mock('../../src/simulator', () => ({
   })),
 }));
 
-const getActiveDeviceIdMock = jest.fn();
+const getSoleDeviceIdMock = jest.fn();
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: () => ({
-    getActiveDeviceId: getActiveDeviceIdMock,
+    getSoleDeviceId: getSoleDeviceIdMock,
   }),
 }));
 
@@ -44,7 +44,7 @@ describe('app_scroll_native', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     listBootedMock.mockResolvedValue([{ udid: DEVICE_ID }]);
-    getActiveDeviceIdMock.mockReturnValue(null);
+    getSoleDeviceIdMock.mockReturnValue(null);
     execMock.mockResolvedValue('');
 
     const fakeServer = { registerTool: registerToolMock } as unknown;
@@ -129,7 +129,7 @@ describe('app_scroll_native', () => {
 
   it('uses active device from session manager', async () => {
     const activeDevice = 'ACTIVE-DEVICE';
-    getActiveDeviceIdMock.mockReturnValue(activeDevice);
+    getSoleDeviceIdMock.mockReturnValue(activeDevice);
     await toolHandler('s1', { direction: 'down' });
     expect(execMock).toHaveBeenCalledWith(
       expect.arrayContaining(['io', activeDevice, 'input', 'swipe']),
@@ -140,7 +140,7 @@ describe('app_scroll_native', () => {
 
   it('returns error when no device is available', async () => {
     listBootedMock.mockResolvedValue([]);
-    getActiveDeviceIdMock.mockReturnValue(null);
+    getSoleDeviceIdMock.mockReturnValue(null);
     const result = await toolHandler('s1', { direction: 'up' }) as { isError: boolean; content: { text: string }[] };
     expect(result.isError).toBe(true);
     const body = JSON.parse(result.content[0].text);

--- a/tests/unit/app-switch-app.test.ts
+++ b/tests/unit/app-switch-app.test.ts
@@ -16,7 +16,7 @@ jest.mock('../../src/simulator', () => ({
 
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn().mockReturnValue({
-    getActiveDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
+    getSoleDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
   }),
 }));
 
@@ -66,7 +66,7 @@ describe('app_switch_app tool', () => {
   });
 
   test('returns error when no device booted', async () => {
-    mockedGetSessionManager.mockReturnValueOnce({ getActiveDeviceId: () => null } as ReturnType<typeof getSessionManager>);
+    mockedGetSessionManager.mockReturnValueOnce({ getSoleDeviceId: () => null } as ReturnType<typeof getSessionManager>);
     MockedSimulatorManager.mockImplementationOnce(() => ({
       listBooted: jest.fn().mockResolvedValue([]),
       launchApp: mockLaunchApp,

--- a/tests/unit/app-system-tools.test.ts
+++ b/tests/unit/app-system-tools.test.ts
@@ -18,7 +18,7 @@ jest.mock('../../src/simulator/simctl', () => ({
 // Mock session manager to return a device ID
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn().mockReturnValue({
-    getActiveDeviceId: jest.fn().mockReturnValue('MOCK-DEVICE-UUID'),
+    getSoleDeviceId: jest.fn().mockReturnValue('MOCK-DEVICE-UUID'),
   }),
 }));
 

--- a/tests/unit/app-tree-tool.test.ts
+++ b/tests/unit/app-tree-tool.test.ts
@@ -5,7 +5,7 @@ import { AccessibilityBridge, getAccessibilityBridge } from '../../src/native';
 jest.mock('../../src/native');
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: () => ({
-    getActiveDeviceId: () => 'mock-device-id',
+    getSoleDeviceId: () => 'mock-device-id',
   }),
 }));
 

--- a/tests/unit/session-manager-integration.test.ts
+++ b/tests/unit/session-manager-integration.test.ts
@@ -100,14 +100,16 @@ describe('SessionManager Integration', () => {
       });
       sm.setConnection('udid-B', clientB);
 
-      // First registered becomes active
-      expect(getWebKitClient()).toBe(clientA);
-      // Specific device retrieval
+      // With two connections, ambient lookup is ambiguous — tools must pass an
+      // explicit deviceId (Phase 3 of #408 removed the activeDeviceId fallback).
+      expect(getWebKitClient()).toBeNull();
+      expect(sm.getSoleDeviceId()).toBeNull();
+      // Specific device retrieval still works
       expect(getWebKitClient('udid-A')).toBe(clientA);
       expect(getWebKitClient('udid-B')).toBe(clientB);
     });
 
-    it('should switch active device', () => {
+    it('requires explicit deviceId when multiple devices are connected', () => {
       const sm = getSessionManager();
       const clientA = createMockClient('device-A');
       const clientB = createMockClient('device-B');
@@ -124,18 +126,14 @@ describe('SessionManager Integration', () => {
       });
       sm.setConnection('udid-B', clientB);
 
-      // Default is first device
-      expect(getWebKitClient()).toBe(clientA);
-
-      // Switch active
-      sm.setActiveDevice('udid-B');
-      expect(getWebKitClient()).toBe(clientB);
-
-      // Specific retrieval still works
+      // Ambiguous ambient lookup returns null
+      expect(getWebKitClient()).toBeNull();
+      // Explicit retrieval returns the correct client
       expect(getWebKitClient('udid-A')).toBe(clientA);
+      expect(getWebKitClient('udid-B')).toBe(clientB);
     });
 
-    it('should fallback to next device when active is removed', () => {
+    it('returns the sole remaining device after one is removed', () => {
       const sm = getSessionManager();
       const clientA = createMockClient('device-A');
       const clientB = createMockClient('device-B');
@@ -152,12 +150,13 @@ describe('SessionManager Integration', () => {
       });
       sm.setConnection('udid-B', clientB);
 
-      expect(getWebKitClient()).toBe(clientA);
+      // Two devices → ambiguous
+      expect(getWebKitClient()).toBeNull();
 
-      // Remove active device → should fallback to udid-B
+      // Remove one → the remaining device becomes the sole connection
       sm.removeSimulator('udid-A');
       expect(getWebKitClient()).toBe(clientB);
-      expect(sm.getActiveDeviceId()).toBe('udid-B');
+      expect(sm.getSoleDeviceId()).toBe('udid-B');
     });
 
     it('should return null when all devices removed', () => {
@@ -172,7 +171,7 @@ describe('SessionManager Integration', () => {
 
       sm.removeSimulator('udid-1');
       expect(getWebKitClient()).toBeNull();
-      expect(sm.getActiveDeviceId()).toBeNull();
+      expect(sm.getSoleDeviceId()).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 3 of #408. **Breaking change**: `SessionManager` no longer tracks
a process-global `activeDeviceId`. The global pointer was the
structural root cause of parallel-QA failures — two concurrent
sessions would silently overwrite each other's active device, and
whichever session called `setActiveDevice` last won.

This PR replaces the global pointer with a purely local resolution
rule that preserves the single-device ergonomics everyone uses today
while forcing multi-device callers to be explicit.

## New resolution rules

When a caller asks for "the client" without specifying a device:

1. If exactly **one** device is connected (or exactly one simulator
   is registered when no WebKit connection exists yet), return it.
2. Otherwise return `null` and let the caller decide.

Explicit `getConnection(deviceId)` / `getWebKitClient(deviceId)` calls
continue to work exactly as before.

## What changed

### `src/session-manager.ts`
- Removed `activeDeviceId` field
- Removed `setActiveDevice()` and `getActiveDeviceId()` methods
- `addSimulator`, `removeSimulator`, `shutdown` no longer touch the
  removed pointer
- `getConnection(deviceId?)` now implements the unique-device rule
- New `getSoleDeviceId()` helper returns the unique device id (or
  null) by checking connections first, then simulators

### `src/mcp-server.ts`
- `setWebKitClient(client, deviceId?)` no longer calls
  `setActiveDevice`; connection registration alone is the source of
  truth
- `setWebKitClient(null)` now falls back to `getSoleDeviceId()` when
  clearing without an explicit `deviceId`

### `src/tools/device-boot.ts`
- No more `sm.setActiveDevice(device.udid)`. Device_boot registers
  the connection and that's enough

### All other tools + `src/native/accessibility.ts`
- Every `getActiveDeviceId()` caller renamed to `getSoleDeviceId()`
- Semantics collapse to the same behavior in the single-device case
  and fail loud for multi-device scenarios
- 16 tool files + 1 helper updated

### Tests
- `tests/unit/session-manager-integration.test.ts`: three tests
  rewritten to verify the new rules
  - Two connections → `getWebKitClient()` returns null
  - Explicit retrieval still works
  - Removing one of two devices makes the other the sole
    connection, restoring implicit resolution
- 16 test files updated: mock references renamed, 4 `setActiveDevice`
  setup calls removed

## Breaking change impact

| Scenario | Old behavior | New behavior |
|----------|--------------|--------------|
| 1 device booted, no `deviceId` | Works | **Works unchanged** |
| 2+ devices booted, no `deviceId` | Silently picks whoever called `setActiveDevice` last | Returns null / structured error |
| 2+ devices booted, explicit `deviceId` | Works | **Works unchanged** |
| `sm.setActiveDevice(udid)` | Sets active pointer | **Method removed** — delete the call |
| `sm.getActiveDeviceId()` | Returns active pointer | **Method removed** — use `getSoleDeviceId()` if you want the unique-device fallback |

## Migration guide (for external callers)

1. **Single-device workflows**: no change required.
2. **Multi-device workflows**: pass `deviceId` explicitly to every
   tool that operates on a specific simulator. Tools without an
   explicit device and with multiple devices booted will get a
   structured error listing the available device IDs.
3. **Code that called `sm.setActiveDevice(udid)`**: delete the call.
   `sm.setConnection(udid, client)` (or just `device_boot`) is now
   the only source of truth.
4. **Code that called `sm.getActiveDeviceId()`**: replace with
   `sm.getSoleDeviceId()` for the same unique-device semantics.

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 69 suites / 979 tests passing
- [x] `npx tsc --noEmit` — no type errors
- [x] Single-device workflow unchanged
- [x] Multi-device with no explicit deviceId returns null
- [x] Multi-device with explicit deviceId works
- [x] Sole-remaining-device fallback works after a removal
- [ ] (post-merge) Boot two simulators, run QA on each via explicit
      `deviceId`, verify no cross-contamination

## Refs

- #408 — parent roadmap issue
- #411, #412 — Phase 2A (TabManager + sessionId routing) which
  together with this PR enable true parallel QA
- #413 — Phase 2B.1 (ProxyManager) which pairs with this PR to
  give each simulator its own proxy and clean routing