### PR TITLE
feat: add WarmSimPool for zero-latency simulator acquire

### DIFF
--- a/src/simulator/sim-pool.ts
+++ b/src/simulator/sim-pool.ts
@@ -1,0 +1,257 @@
+/**
+ * SimPool — Clone-based pool of iOS Simulators for Phase 2B.2 of #408.
+ *
+ * The default parallel-QA path (Phase 2A / #411) uses a single simulator
+ * with multiple Safari tabs, which covers 95% of web QA scenarios with
+ * minimal RAM overhead. SimPool handles the remaining 5%: tests that
+ * need a different viewport, a native app under test, or fully isolated
+ * cookie/session state.
+ *
+ * Architecture:
+ *   1. A **master simulator** is prepared once per device preset. This
+ *      can be an existing simulator or a newly created one.
+ *   2. `acquire(preset)` calls `simctl clone` on the master, boots the
+ *      clone, and returns a `PooledSimulator` with the clone's UDID.
+ *      Clone + boot is typically ~2 seconds vs ~20 seconds cold boot.
+ *   3. `release(udid)` shuts down the clone and (unless explicitly kept)
+ *      deletes it so RAM and disk space are reclaimed immediately.
+ *   4. `shutdown()` releases every outstanding clone — called from tests
+ *      and process exit.
+ *
+ * The master simulator is itself found via the normal preset resolution
+ * (`SimulatorManager.resolveDevice`), so users don't have to pre-create
+ * anything. The first `acquire` for a preset creates the master if the
+ * preset has not been booted yet.
+ *
+ * Concurrency:
+ *   - A per-preset **lock** prevents parallel clones from racing on the
+ *     same master simulator (simctl clone requires the source to be
+ *     Shutdown).
+ *   - A configurable `maxClones` cap prevents OOM; the default is read
+ *     from `OPENSAFARI_MAX_SIMULATORS` (falls back to DEFAULT_MAX_SIMULATORS).
+ */
+
+import { SimulatorManager } from './manager';
+import { SimctlExecutor } from './simctl';
+import { SimulatorDevice } from './types';
+import { DEFAULT_MAX_SIMULATORS } from '../config/defaults';
+import { disableBackgroundServices } from './post-boot-optimize';
+
+export interface PooledSimulator {
+  /** UDID of the cloned simulator (distinct from the master). */
+  udid: string;
+  /** The preset key the clone was derived from. */
+  preset: string;
+  /** Clone's device name (includes a pool tag for easier grep in simctl). */
+  name: string;
+  /** When the clone was acquired. */
+  acquiredAt: number;
+  /** If true, release() will NOT delete the clone (for debugging). */
+  keepOnRelease?: boolean;
+}
+
+export interface SimPoolOptions {
+  /** Maximum number of concurrent clones. Defaults to OPENSAFARI_MAX_SIMULATORS. */
+  maxClones?: number;
+  /** Disable background services on each cloned simulator post-boot. Default: true. */
+  disableServices?: boolean;
+  /** Custom SimctlExecutor, mainly for tests. */
+  simctl?: SimctlExecutor;
+  /** Custom SimulatorManager, mainly for tests. */
+  manager?: SimulatorManager;
+}
+
+/**
+ * Per-preset mutex to serialize clone operations on the same master.
+ * `simctl clone` refuses to operate on a booted source, so we must
+ * ensure only one clone runs at a time for each preset.
+ */
+class AsyncMutex {
+  private queue: Array<() => void> = [];
+  private locked = false;
+
+  async acquire(): Promise<() => void> {
+    if (this.locked) {
+      await new Promise<void>((resolve) => this.queue.push(resolve));
+    }
+    this.locked = true;
+    return () => {
+      this.locked = false;
+      const next = this.queue.shift();
+      if (next) next();
+    };
+  }
+}
+
+export class SimPool {
+  private readonly simctl: SimctlExecutor;
+  private readonly manager: SimulatorManager;
+  private readonly maxClones: number;
+  private readonly disableServices: boolean;
+  private readonly clones: Map<string, PooledSimulator> = new Map();
+  private readonly perPresetLocks: Map<string, AsyncMutex> = new Map();
+
+  constructor(options?: SimPoolOptions) {
+    this.simctl = options?.simctl ?? new SimctlExecutor();
+    this.manager = options?.manager ?? new SimulatorManager();
+    this.disableServices = options?.disableServices ?? true;
+
+    const envMax = parseInt(process.env.OPENSAFARI_MAX_SIMULATORS ?? '', 10);
+    this.maxClones =
+      options?.maxClones ?? (Number.isFinite(envMax) && envMax > 0 ? envMax : DEFAULT_MAX_SIMULATORS);
+  }
+
+  /** Number of currently outstanding clones. */
+  get size(): number {
+    return this.clones.size;
+  }
+
+  /** List all active clones. */
+  list(): PooledSimulator[] {
+    return Array.from(this.clones.values());
+  }
+
+  /**
+   * Acquire a new simulator from the pool by cloning a master of the
+   * requested preset. Returns a fully booted `PooledSimulator`. If the
+   * maxClones cap would be exceeded, throws a descriptive error.
+   */
+  async acquire(preset: string, options?: { keepOnRelease?: boolean }): Promise<PooledSimulator> {
+    if (this.clones.size >= this.maxClones) {
+      throw new Error(
+        `SimPool: max clones reached (${this.clones.size}/${this.maxClones}). ` +
+          `Release a clone before acquiring another, or raise OPENSAFARI_MAX_SIMULATORS.`,
+      );
+    }
+
+    const mutex = this.getLockForPreset(preset);
+    const release = await mutex.acquire();
+
+    let cloneUdid: string | null = null;
+    try {
+      // 1. Resolve the master device for the preset.
+      const master = await this.manager.resolveDevice(preset);
+
+      // 2. simctl clone requires the source to be Shutdown.
+      if (master.state === 'Booted') {
+        await this.manager.shutdown(master.udid);
+      }
+
+      // 3. Clone. `simctl clone <source> <new-name>` emits the new UDID on stdout.
+      const cloneName = `OpenSafari-Pool-${preset}-${Date.now()}`;
+      const output = await this.simctl.exec(['clone', master.udid, cloneName]);
+      cloneUdid = output.trim();
+      if (!cloneUdid || !/^[0-9A-F-]{20,}$/i.test(cloneUdid)) {
+        throw new Error(`SimPool: simctl clone returned unexpected output: "${output}"`);
+      }
+
+      // 4. Boot the clone.
+      await this.simctl.exec(['boot', cloneUdid]);
+
+      // 5. Wait for Booted state (fast — clones inherit their source snapshot).
+      await this.waitForBootedState(cloneUdid);
+
+      // 6. Optional: strip unnecessary background services to shave RAM.
+      if (this.disableServices) {
+        try {
+          await disableBackgroundServices(this.simctl, cloneUdid);
+        } catch (err) {
+          console.error(`[sim-pool] disableBackgroundServices failed for ${cloneUdid}: ${err}`);
+        }
+      }
+
+      const pooled: PooledSimulator = {
+        udid: cloneUdid,
+        preset,
+        name: cloneName,
+        acquiredAt: Date.now(),
+        keepOnRelease: options?.keepOnRelease,
+      };
+      this.clones.set(cloneUdid, pooled);
+      return pooled;
+    } catch (err) {
+      // Best-effort cleanup on failure
+      if (cloneUdid) {
+        try {
+          await this.simctl.exec(['delete', cloneUdid]);
+        } catch {
+          /* ignore */
+        }
+      }
+      throw err;
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Release a clone back to the pool. Shuts it down and (unless
+   * `keepOnRelease` is set) deletes it so RAM and disk are reclaimed.
+   * Returns false if the UDID was not managed by this pool.
+   */
+  async release(udid: string): Promise<boolean> {
+    const pooled = this.clones.get(udid);
+    if (!pooled) return false;
+
+    this.clones.delete(udid);
+
+    try {
+      await this.manager.shutdown(udid);
+    } catch (err) {
+      console.error(`[sim-pool] shutdown failed for ${udid}: ${err}`);
+    }
+
+    if (!pooled.keepOnRelease) {
+      try {
+        await this.simctl.exec(['delete', udid]);
+      } catch (err) {
+        console.error(`[sim-pool] delete failed for ${udid}: ${err}`);
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Release every managed clone. Used by process shutdown and tests.
+   */
+  async shutdown(): Promise<void> {
+    const udids = Array.from(this.clones.keys());
+    for (const udid of udids) {
+      await this.release(udid);
+    }
+  }
+
+  private getLockForPreset(preset: string): AsyncMutex {
+    let lock = this.perPresetLocks.get(preset);
+    if (!lock) {
+      lock = new AsyncMutex();
+      this.perPresetLocks.set(preset, lock);
+    }
+    return lock;
+  }
+
+  private async waitForBootedState(udid: string, timeoutMs = 15_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const device: SimulatorDevice | null = await this.manager.getDevice(udid);
+      if (device?.state === 'Booted') return;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    throw new Error(`SimPool: clone ${udid} did not reach Booted state within ${timeoutMs}ms`);
+  }
+}
+
+// ── Module-level singleton ────────────────────────────────────────────
+
+let shared: SimPool | null = null;
+
+export function getSimPool(): SimPool {
+  if (!shared) shared = new SimPool();
+  return shared;
+}
+
+/** Test helper — drop the shared pool without touching any running clones. */
+export function resetSimPoolForTests(): void {
+  shared = null;
+}

--- a/src/simulator/warm-sim-pool.ts
+++ b/src/simulator/warm-sim-pool.ts
@@ -1,0 +1,213 @@
+/**
+ * WarmSimPool — Pre-booted clone pool wrapping `SimPool`.
+ *
+ * The base `SimPool` (Phase 2B.2 of #408) already makes `acquire` fast by
+ * using `simctl clone` (~2 s) instead of cold boot (~20 s). WarmSimPool
+ * pushes that further: it keeps N clones **pre-acquired** in a ready
+ * queue so typical `acquire()` calls return in essentially zero time.
+ *
+ * Lifecycle:
+ *   1. `warmUp(preset, count?)` pre-acquires up to `count` clones of a
+ *      preset and parks them in the ready queue.
+ *   2. `acquire(preset)` pulls one ready clone out of the queue if any
+ *      match the preset; otherwise falls back to the base SimPool.
+ *   3. `release(udid)` forwards to the base SimPool (which shuts down
+ *      and deletes the clone).
+ *   4. Every `acquire` triggers a non-blocking background `replenish()`
+ *      so the queue refills up to `warmTargets[preset]`.
+ *
+ * Configuration:
+ *   - `OPENSAFARI_WARM_POOL_SIZE` (default 1) — default warm target
+ *     for every preset. Applied the first time a preset is observed.
+ *
+ * The warm pool is orthogonal to `SimPool`'s `maxClones` cap: warm
+ * clones count toward the cap, so raise both together in high-
+ * concurrency environments.
+ *
+ * Phase 4.1 of #408.
+ */
+
+import { SimPool, PooledSimulator } from './sim-pool';
+
+const DEFAULT_WARM_POOL_SIZE = 1;
+
+function defaultWarmTarget(): number {
+  const raw = process.env.OPENSAFARI_WARM_POOL_SIZE;
+  if (!raw) return DEFAULT_WARM_POOL_SIZE;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_WARM_POOL_SIZE;
+}
+
+export interface WarmSimPoolOptions {
+  /** Optional override for an existing base pool. */
+  basePool?: SimPool;
+  /** Default warm target for any preset not explicitly configured. */
+  defaultWarmTarget?: number;
+}
+
+/**
+ * A per-preset FIFO queue of ready-to-hand-out clones.
+ */
+export class WarmSimPool {
+  private readonly base: SimPool;
+  private readonly ready: Map<string, PooledSimulator[]> = new Map();
+  private readonly warmTargets: Map<string, number> = new Map();
+  private readonly defaultTarget: number;
+  /** In-flight replenish promises, so we don't kick off duplicate work. */
+  private readonly replenishInFlight: Set<string> = new Set();
+
+  constructor(options?: WarmSimPoolOptions) {
+    this.base = options?.basePool ?? new SimPool();
+    this.defaultTarget = options?.defaultWarmTarget ?? defaultWarmTarget();
+  }
+
+  /** Number of clones currently idle in the warm queue. */
+  get warmSize(): number {
+    let total = 0;
+    for (const arr of this.ready.values()) total += arr.length;
+    return total;
+  }
+
+  /** Warm count for a specific preset. */
+  warmCountFor(preset: string): number {
+    return this.ready.get(preset)?.length ?? 0;
+  }
+
+  /**
+   * Set the desired warm target for a specific preset. Replenishment
+   * runs in the background until the pool reaches this count.
+   */
+  setWarmTarget(preset: string, target: number): void {
+    if (target < 0) {
+      throw new Error(`warm target must be >= 0 (got ${target})`);
+    }
+    this.warmTargets.set(preset, target);
+  }
+
+  /**
+   * Pre-acquire clones so that the pool reaches the requested warm
+   * target for `preset`. Called explicitly at startup or lazily on
+   * first `acquire`. Resolves once all clones have been booted.
+   */
+  async warmUp(preset: string, count?: number): Promise<void> {
+    const target = count ?? this.targetFor(preset);
+    this.warmTargets.set(preset, target);
+    const missing = target - this.warmCountFor(preset);
+    if (missing <= 0) return;
+
+    const results = await Promise.allSettled(
+      Array.from({ length: missing }, () => this.base.acquire(preset)),
+    );
+    const bucket = this.ready.get(preset) ?? [];
+    for (const r of results) {
+      if (r.status === 'fulfilled') {
+        bucket.push(r.value);
+      } else {
+        console.error(`[warm-sim-pool] warmUp failed for ${preset}: ${r.reason}`);
+      }
+    }
+    this.ready.set(preset, bucket);
+  }
+
+  /**
+   * Acquire a simulator for the preset. Returns a ready clone from the
+   * warm queue when available; otherwise falls back to `SimPool.acquire`.
+   * Triggers a background replenish so the queue refills.
+   */
+  async acquire(preset: string, options?: { keepOnRelease?: boolean }): Promise<PooledSimulator> {
+    const bucket = this.ready.get(preset);
+    let clone: PooledSimulator;
+    if (bucket && bucket.length > 0) {
+      // Warm hit — no boot latency
+      clone = bucket.shift()!;
+      if (options?.keepOnRelease) {
+        clone.keepOnRelease = true;
+      }
+    } else {
+      clone = await this.base.acquire(preset, options);
+    }
+
+    // Kick off replenish without awaiting so the caller gets their clone
+    // immediately. Errors are logged, not thrown.
+    void this.replenish(preset).catch((err) => {
+      console.error(`[warm-sim-pool] background replenish failed for ${preset}: ${err}`);
+    });
+
+    return clone;
+  }
+
+  /**
+   * Refill the warm queue for `preset` up to its target. Safe to call
+   * concurrently — a per-preset in-flight flag prevents duplicate work.
+   */
+  async replenish(preset: string): Promise<void> {
+    if (this.replenishInFlight.has(preset)) return;
+    this.replenishInFlight.add(preset);
+    try {
+      const target = this.targetFor(preset);
+      while (this.warmCountFor(preset) < target) {
+        let clone: PooledSimulator;
+        try {
+          clone = await this.base.acquire(preset);
+        } catch (err) {
+          console.error(`[warm-sim-pool] replenish acquire failed for ${preset}: ${err}`);
+          return; // Stop refilling on failure; user can retry later
+        }
+        const bucket = this.ready.get(preset) ?? [];
+        bucket.push(clone);
+        this.ready.set(preset, bucket);
+      }
+    } finally {
+      this.replenishInFlight.delete(preset);
+    }
+  }
+
+  /**
+   * Release a clone back to the underlying SimPool. Warm clones are
+   * NOT recycled because they may be in a dirty state (cookies, DOM,
+   * app launches) after the caller used them; we delete and re-create
+   * instead so each acquire gets a clean snapshot.
+   */
+  async release(udid: string): Promise<boolean> {
+    return this.base.release(udid);
+  }
+
+  /**
+   * Shut down the warm pool: delete every ready clone and tear down
+   * the base pool. Used by process exit and tests.
+   */
+  async shutdown(): Promise<void> {
+    for (const [, bucket] of this.ready) {
+      while (bucket.length > 0) {
+        const clone = bucket.shift()!;
+        try {
+          await this.base.release(clone.udid);
+        } catch (err) {
+          console.error(`[warm-sim-pool] release-on-shutdown failed for ${clone.udid}: ${err}`);
+        }
+      }
+    }
+    this.ready.clear();
+    this.warmTargets.clear();
+    this.replenishInFlight.clear();
+    await this.base.shutdown();
+  }
+
+  private targetFor(preset: string): number {
+    return this.warmTargets.get(preset) ?? this.defaultTarget;
+  }
+}
+
+// ── Module-level singleton ────────────────────────────────────────────
+
+let shared: WarmSimPool | null = null;
+
+export function getWarmSimPool(): WarmSimPool {
+  if (!shared) shared = new WarmSimPool();
+  return shared;
+}
+
+/** Test helper — drop the shared instance. */
+export function resetWarmSimPoolForTests(): void {
+  shared = null;
+}

--- a/tests/unit/sim-pool.test.ts
+++ b/tests/unit/sim-pool.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for SimPool — clone-based multi-simulator pool from
+ * Phase 2B.2 of issue #408.
+ */
+
+// Stub the post-boot optimization so tests never try to spawn launchctl
+jest.mock('../../src/simulator/post-boot-optimize', () => ({
+  disableBackgroundServices: jest.fn().mockResolvedValue([]),
+}));
+
+import { SimPool } from '../../src/simulator/sim-pool';
+import { disableBackgroundServices } from '../../src/simulator/post-boot-optimize';
+
+const PRESET = 'iphone-se-3';
+const MASTER_UDID = 'MASTER-UDID-0000';
+
+function makeFakeUuid(seed: number): string {
+  // 8-4-4-4-12 hex digit format so SimPool's regex accepts it
+  const hex = (n: number, w: number) => n.toString(16).toUpperCase().padStart(w, '0');
+  return `${hex(seed, 8)}-${hex(seed + 1, 4)}-${hex(seed + 2, 4)}-${hex(seed + 3, 4)}-${hex(seed + 4, 12)}`;
+}
+
+function makeStubSimctl() {
+  const calls: Array<{ args: string[] }> = [];
+  let cloneCounter = 0;
+  const exec = jest.fn(async (args: string[]) => {
+    calls.push({ args });
+    if (args[0] === 'clone') {
+      cloneCounter++;
+      return `${makeFakeUuid(cloneCounter * 1000)}\n`;
+    }
+    return '';
+  });
+  return { exec, calls } as any;
+}
+
+function makeStubManager(masterState: 'Booted' | 'Shutdown' = 'Shutdown') {
+  const shutdownCalls: string[] = [];
+  const getDeviceStates = new Map<string, 'Booted' | 'Shutdown'>();
+
+  const manager = {
+    resolveDevice: jest.fn(async (preset: string) => ({
+      udid: MASTER_UDID,
+      name: preset,
+      state: masterState,
+      isAvailable: true,
+      runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
+      runtimeVersion: '17.0',
+    })),
+    shutdown: jest.fn(async (udid: string) => {
+      shutdownCalls.push(udid);
+      getDeviceStates.set(udid, 'Shutdown');
+    }),
+    getDevice: jest.fn(async (udid: string) => {
+      // Default: clones become Booted as soon as we check
+      const state = getDeviceStates.get(udid) ?? 'Booted';
+      return {
+        udid,
+        name: 'clone',
+        state,
+        isAvailable: true,
+        runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
+        runtimeVersion: '17.0',
+      };
+    }),
+  } as any;
+
+  return { manager, shutdownCalls };
+}
+
+describe('SimPool', () => {
+  beforeEach(() => {
+    (disableBackgroundServices as jest.Mock).mockClear();
+    delete process.env.OPENSAFARI_MAX_SIMULATORS;
+  });
+
+  describe('acquire', () => {
+    test('clones the master and returns a PooledSimulator', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      const clone = await pool.acquire(PRESET);
+
+      expect(clone.preset).toBe(PRESET);
+      expect(clone.udid).toMatch(/^[0-9A-F-]{20,}$/);
+      expect(clone.name).toContain('OpenSafari-Pool');
+      expect(simctl.calls.map((c: any) => c.args[0])).toEqual(['clone', 'boot']);
+      // First arg to clone must be the master UDID
+      const cloneCall = simctl.calls.find((c: any) => c.args[0] === 'clone')!;
+      expect(cloneCall.args[1]).toBe(MASTER_UDID);
+    });
+
+    test('disables background services on the clone', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      await pool.acquire(PRESET);
+
+      expect(disableBackgroundServices).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips service disablement when disableServices=false', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager, disableServices: false });
+
+      await pool.acquire(PRESET);
+
+      expect(disableBackgroundServices).not.toHaveBeenCalled();
+    });
+
+    test('shuts down a booted master before cloning', async () => {
+      const simctl = makeStubSimctl();
+      const { manager, shutdownCalls } = makeStubManager('Booted');
+      const pool = new SimPool({ simctl, manager });
+
+      await pool.acquire(PRESET);
+
+      expect(shutdownCalls).toContain(MASTER_UDID);
+    });
+
+    test('enforces maxClones cap', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager, maxClones: 1 });
+
+      await pool.acquire(PRESET);
+      await expect(pool.acquire(PRESET)).rejects.toThrow(/max clones reached/);
+    });
+
+    test('deletes the clone and rethrows when boot fails', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+
+      const badUuid = makeFakeUuid(9999);
+      // Make boot fail; verify delete gets called on cleanup
+      simctl.exec = jest.fn(async (args: string[]) => {
+        if (args[0] === 'clone') return `${badUuid}\n`;
+        if (args[0] === 'boot') throw new Error('boot refused');
+        if (args[0] === 'delete') return '';
+        return '';
+      });
+
+      const pool = new SimPool({ simctl, manager });
+      await expect(pool.acquire(PRESET)).rejects.toThrow('boot refused');
+
+      const deleteCalls = (simctl.exec as jest.Mock).mock.calls.filter(
+        ([args]: [string[]]) => args[0] === 'delete',
+      );
+      expect(deleteCalls.length).toBe(1);
+      expect(deleteCalls[0][0]).toContain(badUuid);
+    });
+
+    test('serializes acquires on the same preset', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      // Slow down the clone operation to force serialization
+      const originalExec = simctl.exec;
+      let concurrentClones = 0;
+      let maxConcurrent = 0;
+      simctl.exec = jest.fn(async (args: string[]) => {
+        if (args[0] === 'clone') {
+          concurrentClones++;
+          maxConcurrent = Math.max(maxConcurrent, concurrentClones);
+          await new Promise((r) => setTimeout(r, 20));
+          concurrentClones--;
+        }
+        return originalExec(args);
+      });
+
+      const pool = new SimPool({ simctl, manager });
+      await Promise.all([pool.acquire(PRESET), pool.acquire(PRESET), pool.acquire(PRESET)]);
+
+      expect(maxConcurrent).toBe(1);
+    });
+  });
+
+  describe('release', () => {
+    test('shuts down and deletes the clone by default', async () => {
+      const simctl = makeStubSimctl();
+      const { manager, shutdownCalls } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      const clone = await pool.acquire(PRESET);
+      const released = await pool.release(clone.udid);
+
+      expect(released).toBe(true);
+      expect(shutdownCalls).toContain(clone.udid);
+      const deleteCalls = simctl.calls.filter((c: any) => c.args[0] === 'delete');
+      expect(deleteCalls.length).toBe(1);
+      expect(deleteCalls[0].args[1]).toBe(clone.udid);
+      expect(pool.size).toBe(0);
+    });
+
+    test('keeps the clone alive when keepOnRelease=true', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      const clone = await pool.acquire(PRESET, { keepOnRelease: true });
+      await pool.release(clone.udid);
+
+      const deleteCalls = simctl.calls.filter((c: any) => c.args[0] === 'delete');
+      expect(deleteCalls.length).toBe(0);
+    });
+
+    test('returns false for an unknown UDID', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      await expect(pool.release('unknown-udid')).resolves.toBe(false);
+    });
+  });
+
+  describe('shutdown', () => {
+    test('releases every outstanding clone', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager, maxClones: 5 });
+
+      await pool.acquire(PRESET);
+      await pool.acquire(PRESET);
+      await pool.acquire(PRESET);
+      expect(pool.size).toBe(3);
+
+      await pool.shutdown();
+      expect(pool.size).toBe(0);
+    });
+  });
+
+  describe('list', () => {
+    test('returns all outstanding clones with their metadata', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager, maxClones: 5 });
+
+      const a = await pool.acquire(PRESET);
+      const b = await pool.acquire(PRESET);
+
+      const list = pool.list();
+      expect(list).toHaveLength(2);
+      expect(list.map((p) => p.udid).sort()).toEqual([a.udid, b.udid].sort());
+    });
+  });
+});

--- a/tests/unit/warm-sim-pool.test.ts
+++ b/tests/unit/warm-sim-pool.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for WarmSimPool — the pre-booted clone pool introduced in
+ * Phase 4.1 of issue #408.
+ */
+
+import { WarmSimPool } from '../../src/simulator/warm-sim-pool';
+
+type FakeClone = { udid: string; preset: string; name: string; acquiredAt: number; keepOnRelease?: boolean };
+
+class FakeBasePool {
+  acquire = jest.fn<Promise<FakeClone>, [string, any?]>();
+  release = jest.fn<Promise<boolean>, [string]>();
+  shutdown = jest.fn<Promise<void>, []>();
+
+  constructor() {
+    let counter = 0;
+    this.acquire.mockImplementation(async (preset: string, opts?: any) => {
+      counter++;
+      return {
+        udid: `clone-${preset}-${counter}`,
+        preset,
+        name: `OpenSafari-Pool-${preset}-${counter}`,
+        acquiredAt: Date.now(),
+        keepOnRelease: opts?.keepOnRelease,
+      };
+    });
+    this.release.mockResolvedValue(true);
+    this.shutdown.mockResolvedValue(undefined);
+  }
+}
+
+const PRESET = 'iphone-se-3';
+
+describe('WarmSimPool', () => {
+  let base: FakeBasePool;
+  let pool: WarmSimPool;
+
+  beforeEach(() => {
+    base = new FakeBasePool();
+    pool = new WarmSimPool({ basePool: base as any, defaultWarmTarget: 2 });
+  });
+
+  describe('warmUp', () => {
+    test('pre-acquires the requested number of clones', async () => {
+      await pool.warmUp(PRESET, 3);
+
+      expect(base.acquire).toHaveBeenCalledTimes(3);
+      expect(pool.warmCountFor(PRESET)).toBe(3);
+      expect(pool.warmSize).toBe(3);
+    });
+
+    test('uses the default target when count is omitted', async () => {
+      await pool.warmUp(PRESET);
+
+      expect(base.acquire).toHaveBeenCalledTimes(2); // defaultWarmTarget = 2
+      expect(pool.warmCountFor(PRESET)).toBe(2);
+    });
+
+    test('skips when the pool is already full', async () => {
+      await pool.warmUp(PRESET, 2);
+      base.acquire.mockClear();
+
+      await pool.warmUp(PRESET, 2);
+
+      expect(base.acquire).not.toHaveBeenCalled();
+    });
+
+    test('partial failure does not prevent other warm clones', async () => {
+      base.acquire.mockImplementationOnce(async () => {
+        throw new Error('boot failed');
+      });
+
+      await pool.warmUp(PRESET, 3);
+
+      // 2 of 3 succeeded
+      expect(pool.warmCountFor(PRESET)).toBe(2);
+    });
+  });
+
+  describe('acquire', () => {
+    test('returns a warm clone and triggers background replenish', async () => {
+      await pool.warmUp(PRESET, 2);
+      base.acquire.mockClear();
+
+      const clone = await pool.acquire(PRESET);
+      expect(clone).toBeDefined();
+
+      // Background replenish kicks in asynchronously. Flush the microtask
+      // queue a couple of times so the async loop completes.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // Replenish should have topped the queue back to the target
+      expect(pool.warmCountFor(PRESET)).toBe(2);
+      // Exactly one replenish acquire happened (to replace the one we took)
+      expect(base.acquire).toHaveBeenCalledTimes(1);
+    });
+
+    test('falls back to base.acquire when the warm queue is empty', async () => {
+      const clone = await pool.acquire(PRESET);
+
+      expect(clone).toBeDefined();
+      expect(base.acquire).toHaveBeenCalled();
+    });
+
+    test('propagates keepOnRelease on warm clones', async () => {
+      await pool.warmUp(PRESET, 1);
+
+      const clone = await pool.acquire(PRESET, { keepOnRelease: true });
+      expect(clone.keepOnRelease).toBe(true);
+    });
+
+    test('multiple concurrent warm hits deplete the queue correctly', async () => {
+      await pool.warmUp(PRESET, 3);
+      base.acquire.mockClear();
+
+      const [c1, c2, c3] = await Promise.all([
+        pool.acquire(PRESET),
+        pool.acquire(PRESET),
+        pool.acquire(PRESET),
+      ]);
+
+      expect(new Set([c1.udid, c2.udid, c3.udid]).size).toBe(3);
+    });
+  });
+
+  describe('replenish', () => {
+    test('refills up to the configured target', async () => {
+      pool.setWarmTarget(PRESET, 3);
+      await pool.replenish(PRESET);
+      expect(pool.warmCountFor(PRESET)).toBe(3);
+    });
+
+    test('stops and logs on acquire failure', async () => {
+      pool.setWarmTarget(PRESET, 3);
+      base.acquire.mockRejectedValueOnce(new Error('no free port'));
+
+      await pool.replenish(PRESET);
+
+      // First call failed → replenish returned without adding anything
+      expect(pool.warmCountFor(PRESET)).toBe(0);
+    });
+
+    test('in-flight lock prevents duplicate work', async () => {
+      pool.setWarmTarget(PRESET, 2);
+      // Slow down acquires so both calls run in parallel
+      let resolveFirst: (v: any) => void = () => {};
+      const pending = new Promise<FakeClone>((r) => {
+        resolveFirst = r;
+      });
+      base.acquire.mockImplementationOnce(() => pending);
+      base.acquire.mockImplementationOnce(async () => ({
+        udid: 'clone-2',
+        preset: PRESET,
+        name: 'x',
+        acquiredAt: 0,
+      }));
+
+      const a = pool.replenish(PRESET);
+      const b = pool.replenish(PRESET);
+
+      resolveFirst({ udid: 'clone-1', preset: PRESET, name: 'x', acquiredAt: 0 });
+      await Promise.all([a, b]);
+
+      // The second call should have been a no-op because the first was in flight
+      expect(base.acquire).toHaveBeenCalledTimes(2); // exactly to reach target=2
+    });
+  });
+
+  describe('setWarmTarget', () => {
+    test('rejects negative targets', () => {
+      expect(() => pool.setWarmTarget(PRESET, -1)).toThrow(/must be >= 0/);
+    });
+
+    test('target=0 disables warming for that preset', async () => {
+      pool.setWarmTarget(PRESET, 0);
+      await pool.replenish(PRESET);
+      expect(pool.warmCountFor(PRESET)).toBe(0);
+    });
+  });
+
+  describe('shutdown', () => {
+    test('releases every ready clone', async () => {
+      await pool.warmUp(PRESET, 3);
+      expect(pool.warmCountFor(PRESET)).toBe(3);
+
+      await pool.shutdown();
+
+      expect(base.release).toHaveBeenCalledTimes(3);
+      expect(pool.warmCountFor(PRESET)).toBe(0);
+      expect(base.shutdown).toHaveBeenCalled();
+    });
+  });
+
+  describe('release', () => {
+    test('forwards to base.release', async () => {
+      const ok = await pool.release('some-udid');
+      expect(ok).toBe(true);
+      expect(base.release).toHaveBeenCalledWith('some-udid');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4.1 of #408. SimPool (#414) already made `acquire` ~2 seconds
by using `simctl clone` instead of cold boot. WarmSimPool takes this
further: it keeps N clones **pre-acquired** in a ready queue so
typical `acquire()` calls return in essentially zero time.

> **Base branch note**: stacked on #414
> (`feature/sim-pool-clone-based`). Merge #414 first.

## Why pre-warm

| Metric | Cold boot | SimPool clone | WarmSimPool hit |
|--------|-----------|---------------|-----------------|
| Time to usable simulator | 20–30 s | ~2 s | **~0 ms** |
| Dirty RAM per clone | ~1.5 GB | ~1.5 GB | ~1.5 GB (up front) |
| Works with existing QA flows | Yes | Yes | Yes |

WarmSimPool trades RAM (clones held idle) for latency. Ideal for
interactive workflows where human reviewers cannot afford a 2-second
pause between device switches.

## What changed

### New module — `src/simulator/warm-sim-pool.ts`

- **`warmUp(preset, count?)`** — pre-acquire `count` clones of a
  preset (or the default target) and park them in the ready queue.
  Partial failures are logged but do not block other warm clones.
- **`acquire(preset, options?)`** — return a warm clone from the
  queue when available, otherwise fall back to `SimPool.acquire`.
  Always triggers a non-blocking background replenish.
- **`replenish(preset)`** — refill the queue for a preset up to its
  target. Protected by a per-preset in-flight flag so concurrent
  callers do not spawn duplicate work. Stops and logs (does not
  throw) when `base.acquire` fails.
- **`setWarmTarget(preset, n)`** — per-preset target. Rejects
  negative values.
- **`release(udid)`** — forwards to the base pool. Warm clones are
  **not** recycled from used state because they might be dirty
  (cookies, DOM, app launches) — each acquire always gets a fresh
  snapshot.
- **`shutdown()`** — release every ready clone and tear down the base.
- Module-level `getWarmSimPool()` singleton + `resetWarmSimPoolForTests`.

### Configuration

- **`OPENSAFARI_WARM_POOL_SIZE`** (default: 1) — default warm target
  for every preset that has not been explicitly configured via
  `setWarmTarget`.

### Design notes

- The warm pool is **orthogonal to `SimPool.maxClones`**: warm clones
  count toward the cap, so raise both together in high-concurrency
  environments.
- `acquire()` fires `replenish()` with `void` so the caller gets
  their clone immediately, then the pool refills in the background.
- In-flight replenish flag prevents the duplicate-work scenario
  where two concurrent `acquire` calls both try to top up the queue.
- Released clones are **deleted**, not returned to the warm queue,
  because a returning clone may be in an unknown state.

## Architecture

```
Caller → WarmSimPool.acquire("iphone-se-3")
       → warm queue has ready clone? → YES → return immediately (<1ms)
                                              └─ kick off replenish in background
                                     → NO  → SimPool.acquire("iphone-se-3") (~2s)
                                              └─ kick off replenish in background

Background replenish:
  while warmCountFor("iphone-se-3") < target:
    SimPool.acquire("iphone-se-3")  → add to ready queue
```

## Tests (15 new cases)

- **warmUp**: exact count, default target, idempotency when full,
  partial failure survival
- **acquire**: warm hit with background replenish, fallback to base
  when queue is empty, `keepOnRelease` propagation, concurrent
  depletion correctness
- **replenish**: refill up to target, stop on acquire failure,
  in-flight lock prevents duplicate work
- **setWarmTarget**: negative values rejected, target=0 disables
  warming for that preset
- **shutdown**: releases every ready clone, forwards to `base.shutdown`
- **release**: forwards to base

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 72 suites / 1011 tests (was 996, +15 new)
- [x] `npx tsc --noEmit` — no type errors
- [x] Warm hit returns in O(1) without calling the base pool
- [x] Background replenish refills the queue after each acquire
- [x] Concurrent acquires deplete the queue without races
- [x] Partial warmUp failure does not block other clones
- [x] Per-preset in-flight lock prevents duplicate replenish
- [x] Shutdown releases every ready clone
- [ ] (post-merge) Measure real `acquire` latency against a warm
      queue of 2 on Xcode 26.4 — expect < 50 ms

## Follow-ups (out of scope)

- **PR I (Phase 4.2)**: Custom master UDID support so teams can
  pre-configure a master simulator with cookies, logins, and
  permissions, then clone from it via `SimPool`.
- `qa_warm_sim_pool_config` MCP tool so clients can tune
  `warmTargets` at runtime without restarting the server.

## Refs

- #408 — parent roadmap issue
- #414 — `SimPool` base
- #409 — post-boot optimization used via the base pool