### PR TITLE
feat: SimPool supports custom master UDID for pre-configured snapshots

### DIFF
--- a/src/simulator/sim-pool.ts
+++ b/src/simulator/sim-pool.ts
@@ -90,6 +90,16 @@ export class SimPool {
   private readonly disableServices: boolean;
   private readonly clones: Map<string, PooledSimulator> = new Map();
   private readonly perPresetLocks: Map<string, AsyncMutex> = new Map();
+  /**
+   * Per-preset override for the master UDID to clone from. When a preset
+   * key is mapped here, `acquire(preset)` will clone that explicit UDID
+   * instead of letting `resolveDevice(preset)` pick the first match.
+   *
+   * Use `setMaster(preset, udid)` to pre-configure a master simulator with
+   * cookies, logins, permissions, or installed apps, and every clone
+   * derived from it will inherit that state (APFS copy-on-write).
+   */
+  private readonly masterOverrides: Map<string, string> = new Map();
 
   constructor(options?: SimPoolOptions) {
     this.simctl = options?.simctl ?? new SimctlExecutor();
@@ -112,11 +122,44 @@ export class SimPool {
   }
 
   /**
+   * Register a specific simulator UDID as the master for a preset. Every
+   * subsequent `acquire(preset)` will clone from this UDID instead of
+   * whichever simulator `resolveDevice(preset)` happens to pick first.
+   *
+   * Use this when you have a pre-configured simulator with cookies,
+   * logins, permissions, or installed apps that every clone should
+   * inherit. Each clone gets an APFS copy-on-write snapshot of the
+   * master's filesystem, so the inherited state is identical.
+   *
+   * Passing `null` clears the override and falls back to preset lookup.
+   */
+  setMaster(preset: string, masterUdid: string | null): void {
+    if (masterUdid === null) {
+      this.masterOverrides.delete(preset);
+    } else {
+      this.masterOverrides.set(preset, masterUdid);
+    }
+  }
+
+  /** Return the registered master UDID for a preset, or null if none. */
+  getMaster(preset: string): string | null {
+    return this.masterOverrides.get(preset) ?? null;
+  }
+
+  /**
    * Acquire a new simulator from the pool by cloning a master of the
    * requested preset. Returns a fully booted `PooledSimulator`. If the
    * maxClones cap would be exceeded, throws a descriptive error.
+   *
+   * Master selection order:
+   *   1. `options.masterUdid` (explicit per-call override)
+   *   2. `setMaster(preset, udid)` (pool-level override)
+   *   3. `SimulatorManager.resolveDevice(preset)` (default preset lookup)
    */
-  async acquire(preset: string, options?: { keepOnRelease?: boolean }): Promise<PooledSimulator> {
+  async acquire(
+    preset: string,
+    options?: { keepOnRelease?: boolean; masterUdid?: string },
+  ): Promise<PooledSimulator> {
     if (this.clones.size >= this.maxClones) {
       throw new Error(
         `SimPool: max clones reached (${this.clones.size}/${this.maxClones}). ` +
@@ -130,7 +173,17 @@ export class SimPool {
     let cloneUdid: string | null = null;
     try {
       // 1. Resolve the master device for the preset.
-      const master = await this.manager.resolveDevice(preset);
+      //    Per-call masterUdid beats pool-level setMaster beats preset lookup.
+      const explicitMaster = options?.masterUdid ?? this.masterOverrides.get(preset);
+      const master = explicitMaster
+        ? await this.manager.getDevice(explicitMaster)
+        : await this.manager.resolveDevice(preset);
+      if (!master) {
+        throw new Error(
+          `SimPool: master UDID "${explicitMaster}" not found. ` +
+            `Use xcrun simctl list devices to verify it exists.`,
+        );
+      }
 
       // 2. simctl clone requires the source to be Shutdown.
       if (master.state === 'Booted') {

--- a/tests/unit/sim-pool.test.ts
+++ b/tests/unit/sim-pool.test.ts
@@ -245,4 +245,138 @@ describe('SimPool', () => {
       expect(list.map((p) => p.udid).sort()).toEqual([a.udid, b.udid].sort());
     });
   });
+
+  // ── Custom master UDID support (Phase 4.2 of #408) ──────────────────────
+
+  describe('custom master UDID', () => {
+    const CUSTOM_MASTER = 'CUSTOM-MASTER-1234567890AB';
+
+    function attachCustomMaster(managerStub: any, masterUdid: string) {
+      // Extend the stub so `getDevice(masterUdid)` returns a valid device
+      // instead of falling back to the default clone stub.
+      const originalGetDevice = managerStub.getDevice;
+      managerStub.getDevice = jest.fn(async (udid: string) => {
+        if (udid === masterUdid) {
+          return {
+            udid: masterUdid,
+            name: 'Pre-Configured Master',
+            state: 'Shutdown',
+            isAvailable: true,
+            runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
+            runtimeVersion: '17.0',
+          };
+        }
+        return originalGetDevice(udid);
+      });
+    }
+
+    test('setMaster + getMaster round-trip', () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      expect(pool.getMaster(PRESET)).toBeNull();
+      pool.setMaster(PRESET, CUSTOM_MASTER);
+      expect(pool.getMaster(PRESET)).toBe(CUSTOM_MASTER);
+      pool.setMaster(PRESET, null);
+      expect(pool.getMaster(PRESET)).toBeNull();
+    });
+
+    test('acquire uses the registered master instead of preset lookup', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      attachCustomMaster(manager, CUSTOM_MASTER);
+      const pool = new SimPool({ simctl, manager });
+      pool.setMaster(PRESET, CUSTOM_MASTER);
+
+      await pool.acquire(PRESET);
+
+      // resolveDevice should NOT be called — we went straight to getDevice
+      expect(manager.resolveDevice).not.toHaveBeenCalled();
+      // Clone source must be our custom master UDID
+      const cloneCall = simctl.calls.find((c: any) => c.args[0] === 'clone')!;
+      expect(cloneCall.args[1]).toBe(CUSTOM_MASTER);
+    });
+
+    test('per-call masterUdid overrides setMaster for that one call', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const OTHER_MASTER = 'OTHER-MASTER-0000000001AB';
+      attachCustomMaster(manager, CUSTOM_MASTER);
+      attachCustomMaster(manager, OTHER_MASTER);
+      const pool = new SimPool({ simctl, manager });
+      pool.setMaster(PRESET, CUSTOM_MASTER);
+
+      // Explicit per-call override
+      await pool.acquire(PRESET, { masterUdid: OTHER_MASTER });
+
+      const cloneCall = simctl.calls.find((c: any) => c.args[0] === 'clone')!;
+      expect(cloneCall.args[1]).toBe(OTHER_MASTER);
+
+      // The pool-level setMaster is untouched for subsequent acquires
+      simctl.calls.length = 0;
+      await pool.acquire(PRESET);
+      const secondClone = simctl.calls.find((c: any) => c.args[0] === 'clone')!;
+      expect(secondClone.args[1]).toBe(CUSTOM_MASTER);
+    });
+
+    test('acquire without setMaster falls back to preset lookup', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      const pool = new SimPool({ simctl, manager });
+
+      await pool.acquire(PRESET);
+
+      expect(manager.resolveDevice).toHaveBeenCalledWith(PRESET);
+      const cloneCall = simctl.calls.find((c: any) => c.args[0] === 'clone')!;
+      expect(cloneCall.args[1]).toBe(MASTER_UDID);
+    });
+
+    test('throws when the explicit master UDID does not exist', async () => {
+      const simctl = makeStubSimctl();
+      const { manager } = makeStubManager();
+      // getDevice returns null for unknown UDIDs
+      manager.getDevice = jest.fn(async (udid: string) => {
+        if (udid === 'GHOST-MASTER') return null;
+        return { udid, name: 'x', state: 'Booted', isAvailable: true, runtime: '', runtimeVersion: '' };
+      });
+      const pool = new SimPool({ simctl, manager });
+      pool.setMaster(PRESET, 'GHOST-MASTER');
+
+      await expect(pool.acquire(PRESET)).rejects.toThrow(/master UDID "GHOST-MASTER" not found/);
+    });
+
+    test('a booted custom master is shut down before cloning', async () => {
+      const simctl = makeStubSimctl();
+      const { manager, shutdownCalls } = makeStubManager();
+      // Custom master is currently Booted
+      manager.getDevice = jest.fn(async (udid: string) => {
+        if (udid === CUSTOM_MASTER) {
+          return {
+            udid: CUSTOM_MASTER,
+            name: 'Pre-Configured Master',
+            state: 'Booted',
+            isAvailable: true,
+            runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
+            runtimeVersion: '17.0',
+          };
+        }
+        // Clones default to Booted
+        return {
+          udid,
+          name: 'clone',
+          state: 'Booted',
+          isAvailable: true,
+          runtime: '',
+          runtimeVersion: '',
+        };
+      });
+      const pool = new SimPool({ simctl, manager });
+      pool.setMaster(PRESET, CUSTOM_MASTER);
+
+      await pool.acquire(PRESET);
+
+      expect(shutdownCalls).toContain(CUSTOM_MASTER);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 4.2 of #408. Extends `SimPool` so teams can point the pool at
a **specific master simulator** instead of letting
`resolveDevice(preset)` pick the first match. This unlocks a
powerful workflow: pre-configure one simulator with cookies, logins,
granted permissions, or installed apps, then every clone acquired
from the pool inherits that exact state via APFS copy-on-write.

> **Base branch note**: stacked on #414
> (`feature/sim-pool-clone-based`). Merge #414 first.

## Why this matters

Without custom master support, every clone starts from a stock iOS
Simulator — no cookies, no logins, no apps installed. Tests that
need authenticated state have to perform login flows inside every
clone, which is slow and flaky.

With custom master support, the workflow becomes:

1. Create a simulator once: `xcrun simctl create "QA Master" "iPhone SE (3rd generation)"`
2. Boot it, configure it: cookies, logins, granted permissions, installed apps
3. Shut it down
4. Register it as the master: `pool.setMaster('iphone-se-3', '<master-udid>')`
5. Every `pool.acquire('iphone-se-3')` now returns a clone with the
   exact same state, booted in ~2 seconds

## API additions

```ts
// Register or unregister a master UDID for a preset
pool.setMaster(preset: string, masterUdid: string | null): void

// Read back the registered master
pool.getMaster(preset: string): string | null

// Per-call override beats setMaster for that one acquire
pool.acquire(preset, { masterUdid })
```

### Resolution order

Inside `SimPool.acquire()`:

1. `options.masterUdid` — explicit per-call override
2. `this.masterOverrides.get(preset)` — pool-level `setMaster`
3. `this.manager.resolveDevice(preset)` — default preset lookup

When an explicit master is supplied, SimPool calls
`manager.getDevice(udid)` directly instead of `resolveDevice(preset)`.
A clear error is thrown when the UDID does not exist, pointing the
caller at `xcrun simctl list devices` to verify.

A custom master that is currently Booted is shut down before cloning
(same rule as the default path) because `simctl clone` requires the
source to be Shutdown.

## Tests — 6 new cases

- **setMaster + getMaster round-trip**: set / read / clear
- **acquire uses the registered master**: `resolveDevice` is never
  called and the clone source is the custom UDID
- **per-call `masterUdid` overrides setMaster**: for one acquire
  only, without affecting subsequent ones
- **acquire without setMaster**: falls back to preset lookup exactly
  as before
- **explicit master UDID that does not exist**: throws a descriptive
  error
- **booted custom master**: gets shut down before cloning

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 71 suites / 1002 tests (was 996, +6 new)
- [x] `npx tsc --noEmit` — no type errors
- [x] Pool-level setMaster is respected across multiple acquires
- [x] Per-call masterUdid does not clobber pool-level setMaster
- [x] Error path: unknown UDID fails fast with a usable message
- [ ] (post-merge) Real-world test: create master with cookies set,
      acquire 3 clones, verify all 3 inherit the cookies

## Example usage

```ts
// One-time setup: prepare a master simulator with logged-in state
// (done manually or via a setup script)
//   xcrun simctl create "QA Master" "iPhone SE (3rd generation)"
//   xcrun simctl boot <master-udid>
//   ... perform login, accept permissions, etc ...
//   xcrun simctl shutdown <master-udid>

// Runtime: register and use
const pool = new SimPool();
pool.setMaster('iphone-se-3', '<master-udid>');

// Every clone now inherits the cookies / logins / permissions
const clone1 = await pool.acquire('iphone-se-3'); // ~2 seconds
const clone2 = await pool.acquire('iphone-se-3'); // ~2 seconds

// Per-call override for a one-off test
const clean = await pool.acquire('iphone-se-3', {
  masterUdid: '<clean-master-udid>',
});
```

## Follow-ups (out of scope)

- `qa_sim_pool_set_master` MCP tool so clients can configure masters
  at runtime without restarting the server.
- Auto-detection of master candidates (simulators named
  `QA-Master-*` or tagged with a metadata file).
- Integration with `WarmSimPool` from #416 so warm clones also
  inherit the custom master (they already do, since WarmSimPool
  delegates to the base SimPool on cache miss).

## Refs

- #408 — parent roadmap issue
- #414 — `SimPool` base
- #416 — `WarmSimPool` (compatible — custom masters work through
  the warm path too)