### PR TITLE
feat: route Safari tools to tab sessions via optional sessionId

### DIFF
--- a/src/tools/click.ts
+++ b/src/tools/click.ts
@@ -1,4 +1,5 @@
-import { MCPServer, getWebKitClient } from '../mcp-server';
+import { MCPServer } from '../mcp-server';
+import { resolveClient, sessionNotFoundError, noClientError } from './client-resolver';
 
 export function registerClickTool(server: MCPServer): void {
   server.registerTool(
@@ -11,18 +12,30 @@ export function registerClickTool(server: MCPServer): void {
           selector: { type: 'string', description: 'CSS selector of element to click' },
           x: { type: 'number', description: 'X coordinate to click' },
           y: { type: 'number', description: 'Y coordinate to click' },
+          sessionId: {
+            type: 'string',
+            description: 'Optional QA session id from qa_session_create. Routes the call to that specific Safari tab.',
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Optional simulator UDID. Ignored when sessionId is provided.',
+          },
         },
         required: [],
       },
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
-      const client = getWebKitClient();
-      if (!client)
-        return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
+      const resolved = resolveClient(params);
+      if (resolved.source === 'none' && resolved.sessionId) {
+        return sessionNotFoundError(resolved.sessionId);
+      }
+      if (!resolved.client) {
+        return noClientError();
+      }
       const target = params.selector
         ? (params.selector as string)
         : { x: params.x as number, y: params.y as number };
-      await client.click(target);
+      await resolved.client.click(target);
       return { content: [{ type: 'text' as const, text: 'clicked' }] };
     },
   );

--- a/src/tools/client-resolver.ts
+++ b/src/tools/client-resolver.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared helper to resolve the correct BrowserBackend for a tool call.
+ *
+ * Priority order:
+ *   1. If `params.sessionId` is present, return the TabClient registered
+ *      under that session id. Unknown session ids return null so the caller
+ *      can surface a structured error.
+ *   2. Otherwise fall back to the device-level client selected by
+ *      `getWebKitClient(params.deviceId)`.
+ *
+ * This lets tools accept an optional `sessionId` to target a specific
+ * Safari tab created via `qa_session_create`, while preserving the legacy
+ * "whichever tab the boot-time client is pinned to" behavior.
+ */
+
+import { BrowserBackend } from '../types/browser-backend';
+import { getWebKitClient } from '../mcp-server';
+import { getSessionManager } from '../session-manager';
+
+export interface ResolveResult {
+  client: BrowserBackend | null;
+  /** 'session' when a sessionId was matched, 'device' otherwise. */
+  source: 'session' | 'device' | 'none';
+  /** The sessionId the caller passed, if any. */
+  sessionId?: string;
+  /** Device ID the resolved client is associated with. */
+  deviceId?: string;
+}
+
+/**
+ * Resolve a BrowserBackend from a tool's params.
+ */
+export function resolveClient(params: Record<string, unknown>): ResolveResult {
+  const sessionId = typeof params.sessionId === 'string' && params.sessionId.length > 0
+    ? (params.sessionId as string)
+    : undefined;
+
+  if (sessionId) {
+    const info = getSessionManager().getTabSession(sessionId);
+    if (info) {
+      return { client: info.client, source: 'session', sessionId, deviceId: info.deviceId };
+    }
+    return { client: null, source: 'none', sessionId };
+  }
+
+  const deviceId = typeof params.deviceId === 'string' ? (params.deviceId as string) : undefined;
+  const client = getWebKitClient(deviceId);
+  return {
+    client: client ?? null,
+    source: client ? 'device' : 'none',
+    deviceId: deviceId ?? getSessionManager().getActiveDeviceId() ?? undefined,
+  };
+}
+
+/**
+ * Canonical "session not found" error body returned when `sessionId` was
+ * provided but the tab has been destroyed or never existed.
+ */
+export function sessionNotFoundError(sessionId: string): {
+  content: { type: 'text'; text: string }[];
+  isError: true;
+} {
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({
+        error: 'SESSION_NOT_FOUND',
+        message: `No QA session with id "${sessionId}". It may have been destroyed or never created. Call qa_session_list to see active sessions.`,
+        sessionId,
+      }),
+    }],
+    isError: true,
+  };
+}
+
+/**
+ * Canonical "no client" error body returned when neither a sessionId match
+ * nor a device-level client is available.
+ */
+export function noClientError(): {
+  content: { type: 'text'; text: string }[];
+  isError: true;
+} {
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({
+        error: 'NO_WEBKIT_CLIENT',
+        message: 'Safari not connected. Call device_boot or qa_session_create first.',
+      }),
+    }],
+    isError: true,
+  };
+}

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -1,5 +1,6 @@
-import { MCPServer, getWebKitClient } from '../mcp-server';
+import { MCPServer } from '../mcp-server';
 import { assertDomainAllowed } from '../security/domain-guard';
+import { resolveClient, sessionNotFoundError, noClientError } from './client-resolver';
 
 export function registerNavigateTool(server: MCPServer): void {
   server.registerTool(
@@ -15,6 +16,14 @@ export function registerNavigateTool(server: MCPServer): void {
             enum: ['load', 'domcontentloaded', 'networkidle'],
             description: 'Wait strategy',
           },
+          sessionId: {
+            type: 'string',
+            description: 'Optional QA session id from qa_session_create. Routes the call to that specific Safari tab.',
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Optional simulator UDID. Ignored when sessionId is provided.',
+          },
         },
         required: ['url'],
       },
@@ -22,10 +31,16 @@ export function registerNavigateTool(server: MCPServer): void {
     async (_sessionId: string, params: Record<string, unknown>) => {
       const url = params.url as string;
       assertDomainAllowed(url);
-      const client = getWebKitClient();
-      if (!client)
-        return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
-      const result = await client.navigate({ url, waitUntil: params.waitUntil as any });
+
+      const resolved = resolveClient(params);
+      if (resolved.source === 'none' && resolved.sessionId) {
+        return sessionNotFoundError(resolved.sessionId);
+      }
+      if (!resolved.client) {
+        return noClientError();
+      }
+
+      const result = await resolved.client.navigate({ url, waitUntil: params.waitUntil as any });
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     },
   );

--- a/src/tools/press.ts
+++ b/src/tools/press.ts
@@ -1,4 +1,5 @@
-import { MCPServer, getWebKitClient } from '../mcp-server';
+import { MCPServer } from '../mcp-server';
+import { resolveClient, sessionNotFoundError, noClientError } from './client-resolver';
 
 export function registerPressTool(server: MCPServer): void {
   server.registerTool(
@@ -9,15 +10,27 @@ export function registerPressTool(server: MCPServer): void {
         type: 'object' as const,
         properties: {
           key: { type: 'string', description: 'Key to press (e.g. Enter, Escape, Tab)' },
+          sessionId: {
+            type: 'string',
+            description: 'Optional QA session id from qa_session_create. Routes the call to that specific Safari tab.',
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Optional simulator UDID. Ignored when sessionId is provided.',
+          },
         },
         required: ['key'],
       },
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
-      const client = getWebKitClient();
-      if (!client)
-        return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
-      await client.press(params.key as string);
+      const resolved = resolveClient(params);
+      if (resolved.source === 'none' && resolved.sessionId) {
+        return sessionNotFoundError(resolved.sessionId);
+      }
+      if (!resolved.client) {
+        return noClientError();
+      }
+      await resolved.client.press(params.key as string);
       return { content: [{ type: 'text' as const, text: 'pressed' }] };
     },
   );

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -1,5 +1,6 @@
-import { MCPServer, getWebKitClient } from '../mcp-server';
+import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
+import { resolveClient, sessionNotFoundError, noClientError } from './client-resolver';
 
 export function registerScreenshotTool(server: MCPServer): void {
   server.registerTool(
@@ -11,14 +12,27 @@ export function registerScreenshotTool(server: MCPServer): void {
         properties: {
           format: { type: 'string', enum: ['png'], description: 'Image format' },
           fullPage: { type: 'boolean', description: 'Capture full page' },
+          sessionId: {
+            type: 'string',
+            description: 'Optional QA session id from qa_session_create. Routes the call to that specific Safari tab.',
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Optional simulator UDID. Ignored when sessionId is provided.',
+          },
         },
         required: [],
       },
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
-      const client = getWebKitClient();
-      if (!client)
-        return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
+      const resolved = resolveClient(params);
+      if (resolved.source === 'none' && resolved.sessionId) {
+        return sessionNotFoundError(resolved.sessionId);
+      }
+      const client = resolved.client;
+      if (!client) {
+        return noClientError();
+      }
 
       // Try WebKit protocol screenshot first, fall back to simctl
       let buffer: Buffer;

--- a/src/tools/scroll.ts
+++ b/src/tools/scroll.ts
@@ -1,4 +1,5 @@
-import { MCPServer, getWebKitClient } from '../mcp-server';
+import { MCPServer } from '../mcp-server';
+import { resolveClient, sessionNotFoundError, noClientError } from './client-resolver';
 
 export function registerScrollTool(server: MCPServer): void {
   server.registerTool(
@@ -10,15 +11,27 @@ export function registerScrollTool(server: MCPServer): void {
         properties: {
           direction: { type: 'string', enum: ['up', 'down', 'left', 'right'], description: 'Scroll direction' },
           amount: { type: 'number', description: 'Amount to scroll in pixels' },
+          sessionId: {
+            type: 'string',
+            description: 'Optional QA session id from qa_session_create. Routes the call to that specific Safari tab.',
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Optional simulator UDID. Ignored when sessionId is provided.',
+          },
         },
         required: ['direction', 'amount'],
       },
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
-      const client = getWebKitClient();
-      if (!client)
-        return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
-      await client.scroll(
+      const resolved = resolveClient(params);
+      if (resolved.source === 'none' && resolved.sessionId) {
+        return sessionNotFoundError(resolved.sessionId);
+      }
+      if (!resolved.client) {
+        return noClientError();
+      }
+      await resolved.client.scroll(
         params.direction as 'up' | 'down' | 'left' | 'right',
         params.amount as number,
       );

--- a/src/tools/type.ts
+++ b/src/tools/type.ts
@@ -1,4 +1,5 @@
-import { MCPServer, getWebKitClient } from '../mcp-server';
+import { MCPServer } from '../mcp-server';
+import { resolveClient, sessionNotFoundError, noClientError } from './client-resolver';
 
 export function registerTypeTool(server: MCPServer): void {
   server.registerTool(
@@ -11,15 +12,27 @@ export function registerTypeTool(server: MCPServer): void {
           selector: { type: 'string', description: 'CSS selector of element to type into' },
           text: { type: 'string', description: 'Text to type' },
           delay: { type: 'number', description: 'Delay between keystrokes in ms' },
+          sessionId: {
+            type: 'string',
+            description: 'Optional QA session id from qa_session_create. Routes the call to that specific Safari tab.',
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Optional simulator UDID. Ignored when sessionId is provided.',
+          },
         },
         required: ['selector', 'text'],
       },
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
-      const client = getWebKitClient();
-      if (!client)
-        return { content: [{ type: 'text' as const, text: 'Error: Safari not connected' }], isError: true };
-      await client.type(
+      const resolved = resolveClient(params);
+      if (resolved.source === 'none' && resolved.sessionId) {
+        return sessionNotFoundError(resolved.sessionId);
+      }
+      if (!resolved.client) {
+        return noClientError();
+      }
+      await resolved.client.type(
         params.selector as string,
         params.text as string,
         params.delay !== undefined ? { delay: params.delay as number } : undefined,

--- a/tests/unit/client-resolver.test.ts
+++ b/tests/unit/client-resolver.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the shared `resolveClient` helper used by session-aware
+ * tool handlers to route between a tab-scoped session and the device-level
+ * WebKit client.
+ */
+
+// Mock mcp-server so we can control getWebKitClient
+const mockGetWebKitClient = jest.fn();
+jest.mock('../../src/mcp-server', () => {
+  const actual = jest.requireActual('../../src/mcp-server');
+  return { ...actual, getWebKitClient: mockGetWebKitClient };
+});
+
+// Mock session-manager so we can control getTabSession + active device
+const mockGetTabSession = jest.fn();
+const mockGetActiveDeviceId = jest.fn();
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getTabSession: mockGetTabSession,
+    getActiveDeviceId: mockGetActiveDeviceId,
+  }),
+}));
+
+import { resolveClient, sessionNotFoundError, noClientError } from '../../src/tools/client-resolver';
+
+describe('resolveClient', () => {
+  const fakeTabClient = { id: 'tab-client' } as any;
+  const fakeDeviceClient = { id: 'device-client' } as any;
+
+  beforeEach(() => {
+    mockGetWebKitClient.mockReset();
+    mockGetTabSession.mockReset();
+    mockGetActiveDeviceId.mockReset().mockReturnValue(null);
+  });
+
+  test('returns the session client when sessionId matches', () => {
+    mockGetTabSession.mockReturnValue({
+      sessionId: 'sess-1',
+      deviceId: 'dev-1',
+      targetId: 't-1',
+      url: 'https://example.com',
+      createdAt: 1,
+      client: fakeTabClient,
+    });
+
+    const result = resolveClient({ sessionId: 'sess-1' });
+
+    expect(result.source).toBe('session');
+    expect(result.client).toBe(fakeTabClient);
+    expect(result.sessionId).toBe('sess-1');
+    expect(result.deviceId).toBe('dev-1');
+    expect(mockGetWebKitClient).not.toHaveBeenCalled();
+  });
+
+  test('returns source=none when sessionId is supplied but unknown', () => {
+    mockGetTabSession.mockReturnValue(null);
+
+    const result = resolveClient({ sessionId: 'ghost' });
+
+    expect(result.source).toBe('none');
+    expect(result.client).toBeNull();
+    expect(result.sessionId).toBe('ghost');
+    expect(mockGetWebKitClient).not.toHaveBeenCalled();
+  });
+
+  test('falls back to device client when no sessionId is provided', () => {
+    mockGetWebKitClient.mockReturnValue(fakeDeviceClient);
+
+    const result = resolveClient({ deviceId: 'dev-2' });
+
+    expect(result.source).toBe('device');
+    expect(result.client).toBe(fakeDeviceClient);
+    expect(mockGetWebKitClient).toHaveBeenCalledWith('dev-2');
+  });
+
+  test('returns source=none when no client is available', () => {
+    mockGetWebKitClient.mockReturnValue(null);
+
+    const result = resolveClient({});
+
+    expect(result.source).toBe('none');
+    expect(result.client).toBeNull();
+  });
+
+  test('ignores empty-string sessionId and uses device fallback', () => {
+    mockGetWebKitClient.mockReturnValue(fakeDeviceClient);
+
+    const result = resolveClient({ sessionId: '' });
+
+    expect(result.source).toBe('device');
+    expect(mockGetTabSession).not.toHaveBeenCalled();
+  });
+
+  test('carries the active device id in the fallback result when one exists', () => {
+    mockGetWebKitClient.mockReturnValue(fakeDeviceClient);
+    mockGetActiveDeviceId.mockReturnValue('active-dev');
+
+    const result = resolveClient({});
+
+    expect(result.deviceId).toBe('active-dev');
+  });
+});
+
+describe('sessionNotFoundError', () => {
+  test('returns structured SESSION_NOT_FOUND payload', () => {
+    const err = sessionNotFoundError('abc');
+    expect(err.isError).toBe(true);
+    const body = JSON.parse(err.content[0].text);
+    expect(body.error).toBe('SESSION_NOT_FOUND');
+    expect(body.sessionId).toBe('abc');
+    expect(body.message).toContain('qa_session_list');
+  });
+});
+
+describe('noClientError', () => {
+  test('returns structured NO_WEBKIT_CLIENT payload', () => {
+    const err = noClientError();
+    expect(err.isError).toBe(true);
+    const body = JSON.parse(err.content[0].text);
+    expect(body.error).toBe('NO_WEBKIT_CLIENT');
+    expect(body.message).toContain('device_boot');
+  });
+});


### PR DESCRIPTION
Re-opened from #412 (auto-closed when base branch was deleted). See #412 for full description. Refs #408 Phase 2A integration.