### PR TITLE
feat: Flutter semantics activation for reliable accessibility tree

### DIFF
--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -21,3 +21,4 @@ export type {
 } from './types';
 export { AccessibilityBridge, AccessibilityBridgeError, getAccessibilityBridge } from './accessibility-bridge';
 export type { AXNode, AXFrame, AXQuery, AXQueryResult, AXDumpOptions, AXQueryOptions } from './ax-types';
+export { ensureSemanticsActive, countNodes } from './semantics-activator';

--- a/src/native/semantics-activator.ts
+++ b/src/native/semantics-activator.ts
@@ -1,0 +1,101 @@
+/**
+ * Flutter Semantics Activator
+ *
+ * Flutter lazily builds its accessibility/semantics tree — it only populates
+ * native UIAccessibilityElement objects when an assistive technology (e.g.
+ * VoiceOver) is detected. This module forces semantics activation so that
+ * `app_tree`, `app_query`, and `app_inspect` return a populated tree for
+ * Flutter apps.
+ *
+ * Strategy:
+ * 1. Quick-check: if the tree already has enough nodes, skip activation.
+ * 2. Enable the Accessibility Inspector flag via `simctl spawn defaults write`
+ *    — this triggers Flutter's semantics without full VoiceOver side effects.
+ * 3. Poll until the tree populates or timeout.
+ */
+
+import { getAccessibilityBridge } from './accessibility-bridge';
+import type { AXNode } from './ax-types';
+
+const DEFAULT_TIMEOUT_MS = 3000;
+const POLL_INTERVAL_MS = 300;
+const MIN_NODE_THRESHOLD = 5;
+
+/**
+ * Count all nodes in an accessibility tree (recursive).
+ */
+export function countNodes(node: AXNode): number {
+  let count = 1;
+  if (node.children) {
+    for (const child of node.children) {
+      count += countNodes(child);
+    }
+  }
+  return count;
+}
+
+/**
+ * Attempt to activate Flutter semantics for a given simulator device.
+ *
+ * Returns `true` if the accessibility tree has enough nodes (semantics active),
+ * `false` if activation failed or timed out.
+ *
+ * This is a no-op for native (non-Flutter) apps that already expose a full
+ * accessibility tree.
+ */
+export async function ensureSemanticsActive(
+  deviceId: string,
+  options?: { timeout?: number; minNodes?: number },
+): Promise<boolean> {
+  const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS;
+  const minNodes = options?.minNodes ?? MIN_NODE_THRESHOLD;
+  const bridge = getAccessibilityBridge();
+
+  // Quick check: if tree already has enough nodes, semantics is active
+  try {
+    const tree = await bridge.dumpTree({ deviceId, maxDepth: 4 });
+    if (countNodes(tree) >= minNodes) {
+      return true;
+    }
+  } catch {
+    // Tree dump failed — device may not be ready, continue with activation attempt
+  }
+
+  // Activate accessibility inspection via simctl defaults write.
+  // This sets the flag that triggers Flutter's SemanticsBinding to populate
+  // the semantics tree, without enabling full VoiceOver spoken feedback.
+  try {
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const execFileAsync = promisify(execFile);
+
+    await execFileAsync('xcrun', [
+      'simctl', 'spawn', deviceId,
+      'defaults', 'write', 'com.apple.Accessibility',
+      'AccessibilityEnabled', '-bool', 'YES',
+    ], { timeout: 5000 });
+  } catch {
+    // If defaults write fails, still try polling — maybe semantics will populate naturally
+  }
+
+  // Poll until tree populates or timeout
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    try {
+      const tree = await bridge.dumpTree({ deviceId, maxDepth: 4 });
+      if (countNodes(tree) >= minNodes) {
+        return true;
+      }
+    } catch {
+      // Continue polling
+    }
+  }
+
+  // Timeout — semantics may not be available (release build without Semantics widgets)
+  return false;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/tools/app-inspect.ts
+++ b/src/tools/app-inspect.ts
@@ -1,5 +1,5 @@
 import { MCPServer } from '../mcp-server';
-import { getAccessibilityBridge } from '../native';
+import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import { getSessionManager } from '../session-manager';
 
 export function registerAppInspectTool(server: MCPServer): void {
@@ -38,6 +38,12 @@ export function registerAppInspectTool(server: MCPServer): void {
         const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
 
         const bridge = getAccessibilityBridge();
+
+        // Ensure Flutter semantics are activated before inspecting
+        if (deviceId) {
+          await ensureSemanticsActive(deviceId);
+        }
+
         const node = await bridge.inspect(elementPath, deviceId);
 
         return {

--- a/src/tools/app-query.ts
+++ b/src/tools/app-query.ts
@@ -1,5 +1,5 @@
 import { MCPServer } from '../mcp-server';
-import { getAccessibilityBridge } from '../native';
+import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import { getSessionManager } from '../session-manager';
 
 export function registerAppQueryTool(server: MCPServer): void {
@@ -59,6 +59,12 @@ export function registerAppQueryTool(server: MCPServer): void {
         const maxResults = params.max_results as number | undefined;
 
         const bridge = getAccessibilityBridge();
+
+        // Ensure Flutter semantics are activated before querying
+        if (deviceId) {
+          await ensureSemanticsActive(deviceId);
+        }
+
         const result = await bridge.query(
           { identifier, label, text, role },
           { deviceId, maxResults },

--- a/src/tools/app-tree.ts
+++ b/src/tools/app-tree.ts
@@ -1,5 +1,5 @@
 import { MCPServer } from '../mcp-server';
-import { getAccessibilityBridge } from '../native';
+import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import { getSessionManager } from '../session-manager';
 
 export function registerAppTreeTool(server: MCPServer): void {
@@ -28,6 +28,12 @@ export function registerAppTreeTool(server: MCPServer): void {
         const maxDepth = params.max_depth as number | undefined;
 
         const bridge = getAccessibilityBridge();
+
+        // Ensure Flutter semantics are activated before reading the tree
+        if (deviceId) {
+          await ensureSemanticsActive(deviceId);
+        }
+
         const tree = await bridge.dumpTree({ deviceId, maxDepth });
 
         return {

--- a/tests/unit/semantics-activator.test.ts
+++ b/tests/unit/semantics-activator.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for Flutter Semantics Activator
+ *
+ * Tests the ensureSemanticsActive() function that forces Flutter apps
+ * to populate their accessibility/semantics tree.
+ */
+
+import { countNodes } from '../../src/native/semantics-activator';
+import type { AXNode } from '../../src/native/ax-types';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockDumpTree = jest.fn();
+const mockExecFile = jest.fn();
+
+jest.mock('../../src/native/accessibility-bridge', () => ({
+  getAccessibilityBridge: () => ({
+    dumpTree: mockDumpTree,
+  }),
+}));
+
+jest.mock('child_process', () => ({
+  execFile: mockExecFile,
+}));
+
+jest.mock('util', () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+// Import after mocks
+import { ensureSemanticsActive } from '../../src/native/semantics-activator';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTree(nodeCount: number): AXNode {
+  const root: AXNode = {
+    role: 'AXGroup',
+    traits: [],
+    frame: { x: 0, y: 0, width: 390, height: 844 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    path: '',
+    children: [],
+  };
+
+  for (let i = 0; i < nodeCount - 1; i++) {
+    root.children!.push({
+      role: i % 2 === 0 ? 'AXButton' : 'AXStaticText',
+      label: `Element ${i}`,
+      traits: [],
+      frame: { x: 10, y: 50 + i * 44, width: 370, height: 40 },
+      visible: true,
+      enabled: true,
+      focused: false,
+      path: `${i}`,
+    });
+  }
+
+  return root;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('countNodes', () => {
+  it('counts a single node', () => {
+    const node: AXNode = {
+      role: 'AXGroup',
+      traits: [],
+      frame: { x: 0, y: 0, width: 100, height: 100 },
+      visible: true,
+      enabled: true,
+      focused: false,
+      path: '',
+    };
+    expect(countNodes(node)).toBe(1);
+  });
+
+  it('counts nested nodes recursively', () => {
+    const tree = makeTree(6);
+    expect(countNodes(tree)).toBe(6);
+  });
+
+  it('counts deeply nested tree', () => {
+    const root: AXNode = {
+      role: 'AXGroup',
+      traits: [],
+      frame: { x: 0, y: 0, width: 100, height: 100 },
+      visible: true,
+      enabled: true,
+      focused: false,
+      path: '',
+      children: [{
+        role: 'AXGroup',
+        traits: [],
+        frame: { x: 0, y: 0, width: 100, height: 100 },
+        visible: true,
+        enabled: true,
+        focused: false,
+        path: '0',
+        children: [{
+          role: 'AXButton',
+          label: 'Deep',
+          traits: [],
+          frame: { x: 0, y: 0, width: 100, height: 44 },
+          visible: true,
+          enabled: true,
+          focused: false,
+          path: '0/0',
+        }],
+      }],
+    };
+    expect(countNodes(root)).toBe(3);
+  });
+});
+
+describe('ensureSemanticsActive', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns true immediately when tree has enough nodes', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(10));
+
+    const result = await ensureSemanticsActive('test-device-id');
+
+    expect(result).toBe(true);
+    // Should not call execFile (no activation needed)
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('returns true immediately when tree has exactly minNodes', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(5));
+
+    const result = await ensureSemanticsActive('test-device-id');
+
+    expect(result).toBe(true);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('attempts activation when tree is sparse', async () => {
+    // First call: sparse tree (2 nodes)
+    // Second call after activation: populated tree (10 nodes)
+    mockDumpTree
+      .mockResolvedValueOnce(makeTree(2))
+      .mockResolvedValue(makeTree(10));
+
+    mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+
+    const promise = ensureSemanticsActive('test-device-id');
+
+    // Advance past the poll interval
+    await jest.advanceTimersByTimeAsync(400);
+
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'xcrun',
+      ['simctl', 'spawn', 'test-device-id',
+        'defaults', 'write', 'com.apple.Accessibility',
+        'AccessibilityEnabled', '-bool', 'YES'],
+      expect.objectContaining({ timeout: 5000 }),
+    );
+  });
+
+  it('returns false on timeout when tree never populates', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(2));
+    mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+
+    const promise = ensureSemanticsActive('test-device-id', { timeout: 600 });
+
+    // Advance past timeout
+    await jest.advanceTimersByTimeAsync(1000);
+
+    const result = await promise;
+
+    expect(result).toBe(false);
+  });
+
+  it('handles dumpTree failure gracefully on initial check', async () => {
+    mockDumpTree
+      .mockRejectedValueOnce(new Error('Bridge not found'))
+      .mockResolvedValue(makeTree(10));
+
+    mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+
+    const promise = ensureSemanticsActive('test-device-id');
+    await jest.advanceTimersByTimeAsync(400);
+    const result = await promise;
+
+    expect(result).toBe(true);
+  });
+
+  it('handles execFile failure gracefully', async () => {
+    mockDumpTree
+      .mockResolvedValueOnce(makeTree(2))
+      .mockResolvedValue(makeTree(10));
+
+    mockExecFile.mockRejectedValue(new Error('simctl failed'));
+
+    const promise = ensureSemanticsActive('test-device-id');
+    await jest.advanceTimersByTimeAsync(400);
+    const result = await promise;
+
+    expect(result).toBe(true);
+  });
+
+  it('respects custom minNodes threshold', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(3));
+
+    const result = await ensureSemanticsActive('test-device-id', { minNodes: 3 });
+
+    expect(result).toBe(true);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ensureSemanticsActive()` in `src/native/semantics-activator.ts` that forces Flutter apps to populate their accessibility/semantics tree
- Integrate into `app_tree`, `app_query`, `app_inspect` tools — automatically called before tree reads
- Works by enabling Accessibility flag via `simctl defaults write` without full VoiceOver side effects

## Motivation
Flutter lazily builds its semantics tree — it only populates native `UIAccessibilityElement` objects when an assistive technology (VoiceOver, XCTest) is detected. Without activation, `app_tree` returns an empty tree for Flutter apps, making accessibility-based QA automation impossible.

## Implementation
- **Quick-check**: If tree already has ≥5 nodes, skip activation (no-op for native apps)
- **Activation**: `simctl spawn defaults write com.apple.Accessibility AccessibilityEnabled -bool YES`
- **Polling**: Retries tree dump every 300ms until populated or 3s timeout
- **Graceful degradation**: Returns `false` on timeout, never throws

## Files Changed
| File | Change |
|------|--------|
| `src/native/semantics-activator.ts` | **NEW** — Core activation logic |
| `src/native/index.ts` | Export new module |
| `src/tools/app-tree.ts` | Call `ensureSemanticsActive()` before tree dump |
| `src/tools/app-query.ts` | Call `ensureSemanticsActive()` before query |
| `src/tools/app-inspect.ts` | Call `ensureSemanticsActive()` before inspect |
| `tests/unit/semantics-activator.test.ts` | **NEW** — 10 unit tests |

## Test plan
- [x] 10 unit tests pass (`countNodes`, `ensureSemanticsActive` scenarios)
- [x] 13 existing `app_tree`/`app_query`/`app_inspect` tests pass (no regression)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: Boot simulator → launch Flutter debug app → `app_tree` returns populated tree
- [ ] Manual: Verify no VoiceOver spoken feedback during activation

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)