### PR TITLE
feat: app_wait_for and app_assert_element for native app QA

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -113,6 +113,9 @@ export const TOOL_TIERS: Record<string, number> = {
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   app_tap_element: 2,
+  // Tier 2: Native App — Semantic Wait & Assert (Flutter-compatible)
+  app_wait_for_element: 2,
+  app_assert_element: 2,
 
   // Tier 2: Hybrid context switching
   app_webview_connect: 2,

--- a/src/tools/app-assert-element.ts
+++ b/src/tools/app-assert-element.ts
@@ -1,0 +1,186 @@
+/**
+ * app_assert_element — CI-friendly assertions on native UI elements.
+ *
+ * Assert that an element exists, is visible, is enabled, or contains
+ * specific text. Returns structured pass/fail results suitable for
+ * automated QA pipelines.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import { getSessionManager } from '../session-manager';
+
+type AssertCondition = 'exists' | 'not_exists' | 'visible' | 'enabled' | 'disabled' | 'has_text';
+
+export function registerAppAssertElementTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_assert_element',
+      description:
+        'Assert a condition on a native app UI element found by accessibility query. ' +
+        'Returns structured pass/fail result suitable for CI pipelines. ' +
+        'Works with any app including Flutter.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          identifier: {
+            type: 'string',
+            description: 'Accessibility identifier (exact match)',
+          },
+          label: {
+            type: 'string',
+            description: 'Accessibility label (case-insensitive substring)',
+          },
+          text: {
+            type: 'string',
+            description: 'Text content in value or label',
+          },
+          role: {
+            type: 'string',
+            description: 'Accessibility role (e.g. "AXButton")',
+          },
+          assert: {
+            type: 'string',
+            enum: ['exists', 'not_exists', 'visible', 'enabled', 'disabled', 'has_text'],
+            description: 'Condition to assert (default: "exists")',
+          },
+          expected_text: {
+            type: 'string',
+            description: 'Expected text value (required when assert is "has_text")',
+          },
+          message: {
+            type: 'string',
+            description: 'Custom assertion message for CI reports',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      const identifier = params.identifier as string | undefined;
+      const label = params.label as string | undefined;
+      const text = params.text as string | undefined;
+      const role = params.role as string | undefined;
+
+      if (!identifier && !label && !text && !role) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'At least one query parameter (identifier, label, text, or role) is required',
+            }),
+          }],
+          isError: true,
+        };
+      }
+
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error(
+            'No device specified and no active device. Boot a simulator first with device_boot.',
+          );
+        }
+
+        const condition = (params.assert as AssertCondition | undefined) ?? 'exists';
+        const expectedText = params.expected_text as string | undefined;
+        const message = params.message as string | undefined;
+        const query = { identifier, label, text, role };
+
+        if (condition === 'has_text' && !expectedText) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'expected_text is required when assert is "has_text"',
+              }),
+            }],
+            isError: true,
+          };
+        }
+
+        // Ensure Flutter semantics are active
+        await ensureSemanticsActive(deviceId);
+
+        const bridge = getAccessibilityBridge();
+        const result = await bridge.query(query, { deviceId });
+        const matches = result.matches;
+        const match = matches.length > 0 ? matches[0] : null;
+
+        let passed: boolean;
+        let actual: string;
+
+        switch (condition) {
+          case 'exists':
+            passed = matches.length > 0;
+            actual = matches.length > 0 ? `found ${matches.length} element(s)` : 'not found';
+            break;
+          case 'not_exists':
+            passed = matches.length === 0;
+            actual = matches.length === 0 ? 'not found (expected)' : `found ${matches.length} element(s)`;
+            break;
+          case 'visible':
+            passed = match !== null && match.visible;
+            actual = match ? (match.visible ? 'visible' : 'hidden') : 'not found';
+            break;
+          case 'enabled':
+            passed = match !== null && match.enabled;
+            actual = match ? (match.enabled ? 'enabled' : 'disabled') : 'not found';
+            break;
+          case 'disabled':
+            passed = match !== null && !match.enabled;
+            actual = match ? (!match.enabled ? 'disabled' : 'enabled') : 'not found';
+            break;
+          case 'has_text': {
+            const elementText = match?.value ?? match?.label ?? '';
+            passed = elementText.toLowerCase().includes((expectedText ?? '').toLowerCase());
+            actual = elementText || '(empty)';
+            break;
+          }
+          default:
+            passed = false;
+            actual = `unknown condition: ${condition}`;
+        }
+
+        const assertResult = {
+          passed,
+          condition,
+          query,
+          actual,
+          expected: condition === 'has_text' ? expectedText : condition,
+          message: message ?? `Assert ${condition} for element`,
+          element: match ? {
+            role: match.role,
+            label: match.label,
+            identifier: match.identifier,
+            value: match.value,
+            frame: match.frame,
+            visible: match.visible,
+            enabled: match.enabled,
+          } : null,
+        };
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(assertResult, null, 2),
+          }],
+          isError: !passed,
+        };
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        console.error(`[app_assert_element] ${errorMessage}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/app-wait-for.ts
+++ b/src/tools/app-wait-for.ts
@@ -1,0 +1,192 @@
+/**
+ * app_wait_for — Wait for a native UI element to appear in the accessibility tree.
+ *
+ * Polls the accessibility tree at intervals until an element matching the
+ * query appears (or disappears), or timeout is reached. Essential for
+ * reliable automation after navigation, animations, or async data loading.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import type { AXNode } from '../native';
+import { getSessionManager } from '../session-manager';
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_INTERVAL_MS = 500;
+
+type WaitCondition = 'exists' | 'not_exists' | 'visible' | 'enabled';
+
+export function registerAppWaitForNativeTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_wait_for',
+      description:
+        'Wait for a native app UI element matching an accessibility query to appear (or disappear). ' +
+        'Polls the accessibility tree until the condition is met or timeout is reached. ' +
+        'Essential for waiting after navigation, animations, or async data loading in any app including Flutter.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          identifier: {
+            type: 'string',
+            description: 'Accessibility identifier to wait for (exact match)',
+          },
+          label: {
+            type: 'string',
+            description: 'Accessibility label to wait for (case-insensitive substring)',
+          },
+          text: {
+            type: 'string',
+            description: 'Text content to wait for in value or label',
+          },
+          role: {
+            type: 'string',
+            description: 'Accessibility role to wait for (e.g. "AXButton")',
+          },
+          condition: {
+            type: 'string',
+            enum: ['exists', 'not_exists', 'visible', 'enabled'],
+            description: 'What condition to wait for (default: "exists")',
+          },
+          timeout: {
+            type: 'number',
+            description: 'Max wait time in ms (default: 10000)',
+          },
+          interval: {
+            type: 'number',
+            description: 'Poll interval in ms (default: 500)',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      const identifier = params.identifier as string | undefined;
+      const label = params.label as string | undefined;
+      const text = params.text as string | undefined;
+      const role = params.role as string | undefined;
+
+      if (!identifier && !label && !text && !role) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'At least one query parameter (identifier, label, text, or role) is required',
+            }),
+          }],
+          isError: true,
+        };
+      }
+
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error(
+            'No device specified and no active device. Boot a simulator first with device_boot.',
+          );
+        }
+
+        const condition = (params.condition as WaitCondition | undefined) ?? 'exists';
+        const timeout = (params.timeout as number | undefined) ?? DEFAULT_TIMEOUT_MS;
+        const interval = (params.interval as number | undefined) ?? DEFAULT_INTERVAL_MS;
+        const query = { identifier, label, text, role };
+
+        // Ensure Flutter semantics are active
+        await ensureSemanticsActive(deviceId);
+
+        const bridge = getAccessibilityBridge();
+        const startTime = Date.now();
+        const deadline = startTime + timeout;
+        let pollCount = 0;
+
+        while (Date.now() < deadline) {
+          pollCount++;
+          try {
+            const result = await bridge.query(query, { deviceId });
+            const met = checkCondition(result.matches, condition);
+
+            if (met) {
+              const elapsed = Date.now() - startTime;
+              return {
+                content: [{
+                  type: 'text' as const,
+                  text: JSON.stringify({
+                    status: 'found',
+                    condition,
+                    elapsed,
+                    polls: pollCount,
+                    element: condition !== 'not_exists' && result.matches.length > 0
+                      ? {
+                        role: result.matches[0].role,
+                        label: result.matches[0].label,
+                        identifier: result.matches[0].identifier,
+                        frame: result.matches[0].frame,
+                        path: result.matches[0].path,
+                      }
+                      : null,
+                  }),
+                }],
+              };
+            }
+          } catch {
+            // Query error during polling — continue to next attempt
+          }
+
+          // Don't sleep past deadline
+          const remaining = deadline - Date.now();
+          if (remaining <= 0) break;
+          await sleep(Math.min(interval, remaining));
+        }
+
+        // Timeout
+        const elapsed = Date.now() - startTime;
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'Timeout waiting for element',
+              condition,
+              query,
+              timeout,
+              elapsed,
+              polls: pollCount,
+            }),
+          }],
+          isError: true,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[app_wait_for] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function checkCondition(matches: AXNode[], condition: WaitCondition): boolean {
+  switch (condition) {
+    case 'exists':
+      return matches.length > 0;
+    case 'not_exists':
+      return matches.length === 0;
+    case 'visible':
+      return matches.some((m) => m.visible);
+    case 'enabled':
+      return matches.some((m) => m.enabled);
+    default:
+      return matches.length > 0;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -89,6 +89,8 @@ import { registerFlutterHotReloadTool } from './flutter-hot-reload';
 import { registerFlutterLogsTool } from './flutter-logs';
 import { registerFlutterNetworkTool } from './flutter-network';
 import { registerAppTapElementTool } from './app-tap-element';
+import { registerAppWaitForNativeTool } from './app-wait-for';
+import { registerAppAssertElementTool } from './app-assert-element';
 
 export { setWorkflowEngine } from './orchestration-tools';
 export { setBarrier } from './barrier-tools';
@@ -249,4 +251,7 @@ export function registerAllTools(server: MCPServer): void {
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   registerAppTapElementTool(server);
+  // Tier 2: Native App — Semantic Wait & Assert (Flutter-compatible)
+  registerAppWaitForNativeTool(server);
+  registerAppAssertElementTool(server);
 }

--- a/tests/unit/app-wait-for.test.ts
+++ b/tests/unit/app-wait-for.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Unit tests for app_wait_for (native) and app_assert_element tools.
+ */
+
+jest.mock('../../src/mcp-server', () => {
+  const actual = jest.requireActual('../../src/mcp-server');
+  return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };
+});
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerAppWaitForNativeTool } from '../../src/tools/app-wait-for';
+import { registerAppAssertElementTool } from '../../src/tools/app-assert-element';
+import type { AXNode, AXQueryResult } from '../../src/native/ax-types';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockQuery = jest.fn();
+
+jest.mock('../../src/native/accessibility-bridge', () => ({
+  getAccessibilityBridge: () => ({
+    query: mockQuery,
+    dumpTree: jest.fn().mockResolvedValue({ role: 'AXGroup', children: [], traits: [], frame: { x: 0, y: 0, width: 390, height: 844 }, visible: true, enabled: true, focused: false, path: '' }),
+  }),
+}));
+
+jest.mock('../../src/native/semantics-activator', () => ({
+  ensureSemanticsActive: jest.fn().mockResolvedValue(true),
+  countNodes: jest.fn().mockReturnValue(10),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'test-device-id',
+  }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeNode(overrides: Partial<AXNode> = {}): AXNode {
+  return {
+    role: 'AXButton',
+    label: 'Welcome',
+    identifier: 'welcome_label',
+    traits: [],
+    frame: { x: 50, y: 200, width: 300, height: 44 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    path: '0/1',
+    ...overrides,
+  };
+}
+
+function makeQueryResult(matches: AXNode[]): AXQueryResult {
+  return { matches, total: matches.length, query: {}, ambiguous: false };
+}
+
+type ToolHandler = (sessionId: string, params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+let waitHandler: ToolHandler;
+let assertHandler: ToolHandler;
+
+beforeAll(() => {
+  const mockServer = {
+    registerTool: jest.fn((schema: unknown, fn: unknown) => {}),
+  } as unknown as MCPServer;
+
+  // Capture wait_for handler
+  registerAppWaitForNativeTool(mockServer);
+  waitHandler = (mockServer.registerTool as jest.Mock).mock.calls[0][1];
+
+  // Capture assert_element handler
+  registerAppAssertElementTool(mockServer);
+  assertHandler = (mockServer.registerTool as jest.Mock).mock.calls[1][1];
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── app_wait_for Tests ───────────────────────────────────────────────────────
+
+describe('app_wait_for', () => {
+  it('returns immediately when element already exists', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode()]));
+
+    const result = await waitHandler('session', {
+      label: 'Welcome',
+      timeout: 5000,
+      interval: 100,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('found');
+    expect(body.condition).toBe('exists');
+    expect(body.polls).toBe(1);
+    expect(body.element).toBeTruthy();
+    expect(body.element.label).toBe('Welcome');
+  });
+
+  it('polls until element appears', async () => {
+    jest.useFakeTimers();
+
+    mockQuery
+      .mockResolvedValueOnce(makeQueryResult([]))
+      .mockResolvedValueOnce(makeQueryResult([]))
+      .mockResolvedValue(makeQueryResult([makeNode()]));
+
+    const promise = waitHandler('session', {
+      label: 'Welcome',
+      timeout: 5000,
+      interval: 100,
+    });
+
+    await jest.advanceTimersByTimeAsync(300);
+    const result = await promise;
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('found');
+    expect(body.polls).toBeGreaterThanOrEqual(2);
+
+    jest.useRealTimers();
+  });
+
+  it('returns timeout error when element never appears', async () => {
+    jest.useFakeTimers();
+
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+
+    const promise = waitHandler('session', {
+      label: 'Missing',
+      timeout: 500,
+      interval: 100,
+    });
+
+    await jest.advanceTimersByTimeAsync(600);
+    const result = await promise;
+    const body = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(body.error).toBe('Timeout waiting for element');
+    expect(body.timeout).toBe(500);
+
+    jest.useRealTimers();
+  });
+
+  it('waits for condition: not_exists', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+
+    const result = await waitHandler('session', {
+      label: 'Spinner',
+      condition: 'not_exists',
+      timeout: 1000,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('found');
+    expect(body.condition).toBe('not_exists');
+    expect(body.element).toBeNull();
+  });
+
+  it('waits for condition: visible', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode({ visible: true })]));
+
+    const result = await waitHandler('session', {
+      label: 'Welcome',
+      condition: 'visible',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('found');
+    expect(body.condition).toBe('visible');
+  });
+
+  it('waits for condition: enabled', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode({ enabled: true })]));
+
+    const result = await waitHandler('session', {
+      label: 'Submit',
+      condition: 'enabled',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('found');
+    expect(body.condition).toBe('enabled');
+  });
+
+  it('returns error when no query parameters given', async () => {
+    const result = await waitHandler('session', {});
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ── app_assert_element Tests ─────────────────────────────────────────────────
+
+describe('app_assert_element', () => {
+  it('passes when element exists', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode()]));
+
+    const result = await assertHandler('session', {
+      label: 'Welcome',
+      assert: 'exists',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+    expect(body.condition).toBe('exists');
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('fails when element does not exist', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+
+    const result = await assertHandler('session', {
+      label: 'Missing',
+      assert: 'exists',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(false);
+    expect(result.isError).toBe(true);
+  });
+
+  it('passes assert not_exists when element missing', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+
+    const result = await assertHandler('session', {
+      label: 'Spinner',
+      assert: 'not_exists',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+  });
+
+  it('passes assert visible when element visible', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode({ visible: true })]));
+
+    const result = await assertHandler('session', {
+      label: 'Welcome',
+      assert: 'visible',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+  });
+
+  it('fails assert visible when element hidden', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode({ visible: false })]));
+
+    const result = await assertHandler('session', {
+      label: 'Hidden',
+      assert: 'visible',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(false);
+  });
+
+  it('passes assert enabled', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode({ enabled: true })]));
+
+    const result = await assertHandler('session', {
+      label: 'Submit',
+      assert: 'enabled',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+  });
+
+  it('passes assert disabled', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode({ enabled: false })]));
+
+    const result = await assertHandler('session', {
+      label: 'Submit',
+      assert: 'disabled',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+  });
+
+  it('passes assert has_text when text matches', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode({ value: 'Hello World' })]));
+
+    const result = await assertHandler('session', {
+      label: 'Greeting',
+      assert: 'has_text',
+      expected_text: 'Hello',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+  });
+
+  it('fails assert has_text when text does not match', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode({ value: 'Goodbye' })]));
+
+    const result = await assertHandler('session', {
+      label: 'Greeting',
+      assert: 'has_text',
+      expected_text: 'Hello',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(false);
+  });
+
+  it('requires expected_text for has_text condition', async () => {
+    const result = await assertHandler('session', {
+      label: 'Test',
+      assert: 'has_text',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(body.error).toContain('expected_text is required');
+  });
+
+  it('includes custom message in result', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode()]));
+
+    const result = await assertHandler('session', {
+      label: 'Welcome',
+      assert: 'exists',
+      message: 'Welcome screen should appear after login',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.message).toBe('Welcome screen should appear after login');
+  });
+
+  it('returns error when no query parameters given', async () => {
+    const result = await assertHandler('session', {});
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `app_wait_for` tool — polls accessibility tree until element appears/disappears (configurable timeout, interval, conditions)
- Add `app_assert_element` tool — CI-friendly pass/fail assertions on element state (exists, visible, enabled, disabled, has_text)
- Both tools integrated with Flutter semantics activation

## Motivation
After `app_tap_element` triggers navigation, there's no way to wait for the next screen to load. Without `app_wait_for`, QA scripts must use fragile `sleep()` calls. `app_assert_element` provides structured CI-friendly assertions for automated pipelines.

## New Tools

### `app_wait_for`
```json
{ "label": "Welcome", "condition": "exists", "timeout": 10000 }
```
Conditions: `exists`, `not_exists`, `visible`, `enabled`

### `app_assert_element`
```json
{ "label": "Welcome", "assert": "has_text", "expected_text": "Hello", "message": "Greeting shown" }
```
Conditions: `exists`, `not_exists`, `visible`, `enabled`, `disabled`, `has_text`

## Dependencies
- Depends on #428 (Flutter semantics activation) — branched from `feature/flutter-semantics-activation`

## Test plan
- [x] 19 unit tests pass (7 wait_for + 12 assert_element)
- [x] Build succeeds
- [ ] Manual: Tap login → `app_wait_for({ label: "Dashboard" })` → succeeds after transition
- [ ] Manual: `app_assert_element({ label: "Welcome", assert: "exists" })` returns pass

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)