### PR TITLE
feat: Dart VM Service Protocol bridge for Flutter debug inspection

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -102,6 +102,12 @@ export const TOOL_TIERS: Record<string, number> = {
   qa_flutter_semantics: 2,
   qa_flutter_dark_mode: 2,
 
+  // Tier 2: Flutter VM Service (debug/profile builds only)
+  flutter_connect: 2,
+  flutter_widget_tree: 2,
+  flutter_hot_reload: 2,
+  flutter_logs: 2,
+
   // Tier 2: Hybrid context switching
   app_webview_connect: 2,
   set_active_context: 2,

--- a/src/flutter/flutter-types.ts
+++ b/src/flutter/flutter-types.ts
@@ -1,0 +1,92 @@
+/**
+ * Type definitions for the Dart VM Service Protocol and Flutter extensions.
+ */
+
+/** VM Service JSON-RPC request */
+export interface VMServiceRequest {
+  jsonrpc: '2.0';
+  id: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** VM Service JSON-RPC response */
+export interface VMServiceResponse {
+  jsonrpc: '2.0';
+  id: string;
+  result?: Record<string, unknown>;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+/** VM Service event notification */
+export interface VMServiceEvent {
+  jsonrpc: '2.0';
+  method: string;
+  params: {
+    streamId: string;
+    event: {
+      kind: string;
+      message?: string;
+      bytes?: string;
+      timestamp?: number;
+      isolate?: VMIsolateRef;
+      [key: string]: unknown;
+    };
+  };
+}
+
+/** Reference to a Dart isolate */
+export interface VMIsolateRef {
+  type: 'IsolateRef' | '@Isolate';
+  id: string;
+  name: string;
+  number?: string;
+}
+
+/** VM info returned by getVM */
+export interface VMInfo {
+  type: 'VM';
+  name: string;
+  architectureBits: number;
+  hostCPU: string;
+  operatingSystem: string;
+  targetCPU: string;
+  version: string;
+  pid: number;
+  isolates: VMIsolateRef[];
+  isolateGroups?: Array<{ type: string; id: string; name: string }>;
+}
+
+/** Connection state for a Flutter VM Service session */
+export interface FlutterConnectionState {
+  /** The HTTP URL of the Dart VM Service (e.g. http://127.0.0.1:50642/abc=/) */
+  httpUrl: string;
+  /** The WebSocket URL derived from httpUrl */
+  wsUrl: string;
+  /** Whether the connection is currently active */
+  connected: boolean;
+  /** The bundle ID of the connected app (if known) */
+  bundleId?: string;
+  /** The device UDID */
+  deviceId: string;
+  /** VM info from initial handshake */
+  vmInfo?: VMInfo;
+  /** The main isolate ID */
+  mainIsolateId?: string;
+}
+
+/** Options for connecting to a Flutter app */
+export interface FlutterConnectOptions {
+  /** Device UDID */
+  deviceId: string;
+  /** Explicit VM Service URL (skips discovery) */
+  vmServiceUrl?: string;
+  /** Bundle ID to filter logs during discovery */
+  bundleId?: string;
+  /** Discovery timeout in ms (default: 10000) */
+  timeout?: number;
+}

--- a/src/flutter/index.ts
+++ b/src/flutter/index.ts
@@ -1,0 +1,11 @@
+export { FlutterVMClient, FlutterVMError, getFlutterVMClient, removeFlutterVMClient } from './vm-service-client';
+export { discoverVMServiceUrl, httpToWsUrl, isValidVMServiceUrl } from './vm-service-discovery';
+export type {
+  FlutterConnectionState,
+  FlutterConnectOptions,
+  VMInfo,
+  VMIsolateRef,
+  VMServiceRequest,
+  VMServiceResponse,
+  VMServiceEvent,
+} from './flutter-types';

--- a/src/flutter/vm-service-client.ts
+++ b/src/flutter/vm-service-client.ts
@@ -1,0 +1,353 @@
+/**
+ * Dart VM Service Protocol Client
+ *
+ * WebSocket JSON-RPC 2.0 client for communicating with the Dart VM Service.
+ * Provides methods for VM inspection, Flutter service extensions, and
+ * event streaming.
+ */
+
+import WebSocket from 'ws';
+import type {
+  VMServiceRequest,
+  VMServiceResponse,
+  VMServiceEvent,
+  VMInfo,
+  VMIsolateRef,
+  FlutterConnectionState,
+  FlutterConnectOptions,
+} from './flutter-types';
+import { discoverVMServiceUrl, httpToWsUrl, isValidVMServiceUrl } from './vm-service-discovery';
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
+const DEFAULT_CONNECT_TIMEOUT_MS = 5000;
+
+type EventCallback = (event: VMServiceEvent['params']['event']) => void;
+
+export class FlutterVMClient {
+  private ws: WebSocket | null = null;
+  private requestId = 0;
+  private pending = new Map<string, {
+    resolve: (value: Record<string, unknown>) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }>();
+  private eventListeners = new Map<string, Set<EventCallback>>();
+  private state: FlutterConnectionState | null = null;
+
+  /** Get the current connection state */
+  getState(): FlutterConnectionState | null {
+    return this.state;
+  }
+
+  /** Check if connected */
+  isConnected(): boolean {
+    return this.ws !== null && this.ws.readyState === WebSocket.OPEN;
+  }
+
+  /**
+   * Connect to a Flutter app's Dart VM Service.
+   * Auto-discovers the URL if not provided explicitly.
+   */
+  async connect(options: FlutterConnectOptions): Promise<FlutterConnectionState> {
+    // Discover or validate URL
+    let httpUrl = options.vmServiceUrl;
+
+    if (!httpUrl) {
+      const discovered = await discoverVMServiceUrl(options.deviceId, {
+        bundleId: options.bundleId,
+        timeout: options.timeout,
+      });
+      if (!discovered) {
+        throw new FlutterVMError(
+          'Could not discover Dart VM Service URL. Ensure the Flutter app is running in debug or profile mode.',
+          'VM_SERVICE_NOT_FOUND',
+        );
+      }
+      httpUrl = discovered;
+    }
+
+    if (!isValidVMServiceUrl(httpUrl)) {
+      throw new FlutterVMError(
+        `Invalid VM Service URL: ${httpUrl}`,
+        'INVALID_URL',
+      );
+    }
+
+    const wsUrl = httpToWsUrl(httpUrl);
+
+    // Connect via WebSocket
+    await this.connectWebSocket(wsUrl);
+
+    // Get VM info and find main isolate
+    const vmInfo = await this.getVM();
+    const mainIsolate = vmInfo.isolates.find((i) => i.name === 'main') ?? vmInfo.isolates[0];
+
+    this.state = {
+      httpUrl,
+      wsUrl,
+      connected: true,
+      bundleId: options.bundleId,
+      deviceId: options.deviceId,
+      vmInfo,
+      mainIsolateId: mainIsolate?.id,
+    };
+
+    return this.state;
+  }
+
+  /** Disconnect from the VM Service */
+  async disconnect(): Promise<void> {
+    if (this.ws) {
+      // Reject all pending requests
+      for (const [id, entry] of this.pending) {
+        clearTimeout(entry.timer);
+        entry.reject(new FlutterVMError('Connection closed', 'DISCONNECTED'));
+        this.pending.delete(id);
+      }
+
+      this.ws.close();
+      this.ws = null;
+    }
+    if (this.state) {
+      this.state.connected = false;
+    }
+    this.eventListeners.clear();
+  }
+
+  /**
+   * Send a JSON-RPC request and wait for the response.
+   */
+  async callMethod(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (!this.isConnected()) {
+      throw new FlutterVMError('Not connected to VM Service', 'NOT_CONNECTED');
+    }
+
+    const id = String(++this.requestId);
+    const request: VMServiceRequest = {
+      jsonrpc: '2.0',
+      id,
+      method,
+      params,
+    };
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new FlutterVMError(
+          `Request timeout: ${method} (${DEFAULT_REQUEST_TIMEOUT_MS}ms)`,
+          'REQUEST_TIMEOUT',
+        ));
+      }, DEFAULT_REQUEST_TIMEOUT_MS);
+
+      this.pending.set(id, { resolve, reject, timer });
+      this.ws!.send(JSON.stringify(request));
+    });
+  }
+
+  /**
+   * Call a Flutter service extension (ext.flutter.*).
+   * Automatically targets the main isolate.
+   */
+  async callServiceExtension(
+    extension: string,
+    params?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const isolateId = this.state?.mainIsolateId;
+    if (!isolateId) {
+      throw new FlutterVMError('No main isolate found', 'NO_ISOLATE');
+    }
+
+    const fullMethod = extension.startsWith('ext.') ? extension : `ext.flutter.${extension}`;
+    return this.callMethod(fullMethod, { isolateId, ...params });
+  }
+
+  // ── VM Methods ──────────────────────────────────────────────────────────
+
+  /** Get VM information */
+  async getVM(): Promise<VMInfo> {
+    const result = await this.callMethod('getVM');
+    return result as unknown as VMInfo;
+  }
+
+  /** Get isolate details */
+  async getIsolate(isolateId?: string): Promise<Record<string, unknown>> {
+    const id = isolateId ?? this.state?.mainIsolateId;
+    if (!id) throw new FlutterVMError('No isolate ID', 'NO_ISOLATE');
+    return this.callMethod('getIsolate', { isolateId: id });
+  }
+
+  // ── Flutter Extensions ──────────────────────────────────────────────────
+
+  /** Dump the full widget tree */
+  async getWidgetTree(): Promise<string> {
+    const result = await this.callServiceExtension('debugDumpApp');
+    return (result as { result?: string }).result ?? JSON.stringify(result);
+  }
+
+  /** Dump the render object tree */
+  async getRenderTree(): Promise<string> {
+    const result = await this.callServiceExtension('debugDumpRenderTree');
+    return (result as { result?: string }).result ?? JSON.stringify(result);
+  }
+
+  /** Dump the semantics tree in traversal order */
+  async getSemanticsTree(): Promise<string> {
+    const result = await this.callServiceExtension('debugDumpSemanticsTreeInTraversalOrder');
+    return (result as { result?: string }).result ?? JSON.stringify(result);
+  }
+
+  /** Trigger a hot reload */
+  async hotReload(): Promise<Record<string, unknown>> {
+    const isolateId = this.state?.mainIsolateId;
+    if (!isolateId) throw new FlutterVMError('No main isolate', 'NO_ISOLATE');
+    return this.callMethod('reloadSources', { isolateId });
+  }
+
+  /** Trigger a hot restart */
+  async hotRestart(): Promise<Record<string, unknown>> {
+    return this.callServiceExtension('hotRestart');
+  }
+
+  /** Toggle performance overlay */
+  async togglePerformanceOverlay(enabled: boolean): Promise<Record<string, unknown>> {
+    return this.callServiceExtension('showPerformanceOverlay', {
+      enabled: enabled ? 'true' : 'false',
+    });
+  }
+
+  /** Toggle debug banner */
+  async toggleDebugBanner(enabled: boolean): Promise<Record<string, unknown>> {
+    return this.callServiceExtension('debugAllowBanner', {
+      enabled: enabled ? 'true' : 'false',
+    });
+  }
+
+  // ── Event Streaming ─────────────────────────────────────────────────────
+
+  /** Subscribe to a VM Service event stream */
+  async streamListen(streamId: string): Promise<void> {
+    await this.callMethod('streamListen', { streamId });
+  }
+
+  /** Register a callback for events on a stream */
+  onEvent(streamId: string, callback: EventCallback): void {
+    if (!this.eventListeners.has(streamId)) {
+      this.eventListeners.set(streamId, new Set());
+    }
+    this.eventListeners.get(streamId)!.add(callback);
+  }
+
+  /** Remove an event callback */
+  offEvent(streamId: string, callback: EventCallback): void {
+    this.eventListeners.get(streamId)?.delete(callback);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private connectWebSocket(wsUrl: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new FlutterVMError(
+          `WebSocket connection timeout: ${wsUrl}`,
+          'CONNECT_TIMEOUT',
+        ));
+      }, DEFAULT_CONNECT_TIMEOUT_MS);
+
+      this.ws = new WebSocket(wsUrl);
+
+      this.ws.on('open', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+
+      this.ws.on('error', (err) => {
+        clearTimeout(timer);
+        reject(new FlutterVMError(
+          `WebSocket error: ${err.message}`,
+          'CONNECT_ERROR',
+        ));
+      });
+
+      this.ws.on('close', () => {
+        if (this.state) {
+          this.state.connected = false;
+        }
+      });
+
+      this.ws.on('message', (data) => {
+        this.handleMessage(data.toString());
+      });
+    });
+  }
+
+  private handleMessage(raw: string): void {
+    try {
+      const msg = JSON.parse(raw);
+
+      // Check if it's a response to a pending request
+      if (msg.id && this.pending.has(msg.id)) {
+        const entry = this.pending.get(msg.id)!;
+        clearTimeout(entry.timer);
+        this.pending.delete(msg.id);
+
+        if (msg.error) {
+          entry.reject(new FlutterVMError(
+            `VM Service error: ${msg.error.message} (code: ${msg.error.code})`,
+            'RPC_ERROR',
+          ));
+        } else {
+          entry.resolve(msg.result ?? {});
+        }
+        return;
+      }
+
+      // Check if it's an event notification
+      if (msg.method === 'streamNotify' && msg.params) {
+        const event = msg as VMServiceEvent;
+        const streamId = event.params.streamId;
+        const listeners = this.eventListeners.get(streamId);
+        if (listeners) {
+          for (const callback of listeners) {
+            try {
+              callback(event.params.event);
+            } catch {
+              // Don't let listener errors crash the client
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore malformed messages
+    }
+  }
+}
+
+export class FlutterVMError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = 'FlutterVMError';
+  }
+}
+
+// Singleton per device
+const clients = new Map<string, FlutterVMClient>();
+
+export function getFlutterVMClient(deviceId: string): FlutterVMClient {
+  let client = clients.get(deviceId);
+  if (!client) {
+    client = new FlutterVMClient();
+    clients.set(deviceId, client);
+  }
+  return client;
+}
+
+export function removeFlutterVMClient(deviceId: string): void {
+  const client = clients.get(deviceId);
+  if (client) {
+    client.disconnect();
+    clients.delete(deviceId);
+  }
+}

--- a/src/flutter/vm-service-discovery.ts
+++ b/src/flutter/vm-service-discovery.ts
@@ -1,0 +1,88 @@
+/**
+ * Dart VM Service URL Discovery
+ *
+ * Discovers the observatory/VM Service URL of a Flutter app running
+ * in debug or profile mode on an iOS Simulator. The URL is printed
+ * to the system log at launch time.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const VM_SERVICE_URL_PATTERN = /https?:\/\/127\.0\.0\.1:\d+\/[a-zA-Z0-9_-]+=\//;
+const DEFAULT_TIMEOUT_MS = 10000;
+
+/**
+ * Discover the Dart VM Service URL from simulator logs.
+ *
+ * Strategy:
+ * 1. Search recent historical logs for the observatory URL
+ * 2. Return null if not found within timeout
+ *
+ * @param deviceId  Simulator UDID
+ * @param options   Discovery options
+ * @returns The VM Service HTTP URL, or null if not found
+ */
+export async function discoverVMServiceUrl(
+  deviceId: string,
+  options?: { bundleId?: string; timeout?: number },
+): Promise<string | null> {
+  const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS;
+
+  // Strategy: Search recent logs for observatory URL
+  try {
+    const { stdout } = await execFileAsync('xcrun', [
+      'simctl', 'spawn', deviceId,
+      'log', 'show',
+      '--predicate', 'eventMessage CONTAINS "Observatory" OR eventMessage CONTAINS "VM service" OR eventMessage CONTAINS "Dart VM service"',
+      '--last', '5m',
+      '--style', 'compact',
+    ], { timeout, maxBuffer: 5 * 1024 * 1024 });
+
+    // Find all URL matches and return the most recent one
+    const matches = stdout.match(new RegExp(VM_SERVICE_URL_PATTERN.source, 'g'));
+    if (matches && matches.length > 0) {
+      return matches[matches.length - 1]; // Most recent
+    }
+  } catch {
+    // Log search failed — try broader search
+  }
+
+  // Fallback: broader search without predicate
+  try {
+    const { stdout } = await execFileAsync('xcrun', [
+      'simctl', 'spawn', deviceId,
+      'log', 'show',
+      '--last', '2m',
+      '--style', 'compact',
+    ], { timeout, maxBuffer: 10 * 1024 * 1024 });
+
+    const matches = stdout.match(new RegExp(VM_SERVICE_URL_PATTERN.source, 'g'));
+    if (matches && matches.length > 0) {
+      return matches[matches.length - 1];
+    }
+  } catch {
+    // Broad search also failed
+  }
+
+  return null;
+}
+
+/**
+ * Convert an HTTP observatory URL to its WebSocket equivalent.
+ *
+ * http://127.0.0.1:50642/abc=/  →  ws://127.0.0.1:50642/abc=/ws
+ */
+export function httpToWsUrl(httpUrl: string): string {
+  const base = httpUrl.replace(/^http/, 'ws').replace(/\/?$/, '');
+  return `${base}/ws`;
+}
+
+/**
+ * Validate that a URL looks like a Dart VM Service URL.
+ */
+export function isValidVMServiceUrl(url: string): boolean {
+  return VM_SERVICE_URL_PATTERN.test(url);
+}

--- a/src/tools/flutter-connect.ts
+++ b/src/tools/flutter-connect.ts
@@ -1,0 +1,95 @@
+/**
+ * flutter_connect — Connect to a Flutter app's Dart VM Service.
+ *
+ * Auto-discovers the VM Service URL from simulator logs, or accepts
+ * an explicit URL. Required before using other flutter_* tools.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient } from '../flutter';
+import { getSessionManager } from '../session-manager';
+
+export function registerFlutterConnectTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_connect',
+      description:
+        'Connect to a Flutter app\'s Dart VM Service for debug inspection. ' +
+        'Auto-discovers the observatory URL from simulator logs, or accepts an explicit URL. ' +
+        'Required before using flutter_widget_tree, flutter_hot_reload, flutter_logs, etc. ' +
+        'Only works with debug/profile builds (release builds disable VM Service).',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          vm_service_url: {
+            type: 'string',
+            description: 'Explicit VM Service URL (e.g. "http://127.0.0.1:50642/abc=/"). If omitted, auto-discovers from logs.',
+          },
+          bundle_id: {
+            type: 'string',
+            description: 'Bundle ID of the Flutter app (helps disambiguate if multiple apps running)',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+          timeout: {
+            type: 'number',
+            description: 'Discovery timeout in ms (default: 10000)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device. Boot a simulator first.');
+        }
+
+        const client = getFlutterVMClient(deviceId);
+
+        // Disconnect existing connection if any
+        if (client.isConnected()) {
+          await client.disconnect();
+        }
+
+        const state = await client.connect({
+          deviceId,
+          vmServiceUrl: params.vm_service_url as string | undefined,
+          bundleId: params.bundle_id as string | undefined,
+          timeout: params.timeout as number | undefined,
+        });
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'connected',
+              vmServiceUrl: state.httpUrl,
+              wsUrl: state.wsUrl,
+              deviceId: state.deviceId,
+              vm: state.vmInfo ? {
+                name: state.vmInfo.name,
+                version: state.vmInfo.version,
+                pid: state.vmInfo.pid,
+                isolates: state.vmInfo.isolates.map((i) => ({ id: i.id, name: i.name })),
+              } : null,
+              mainIsolateId: state.mainIsolateId,
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_connect] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/flutter-hot-reload.ts
+++ b/src/tools/flutter-hot-reload.ts
@@ -1,0 +1,81 @@
+/**
+ * flutter_hot_reload — Trigger hot reload or hot restart on a connected Flutter app.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient } from '../flutter';
+import { getSessionManager } from '../session-manager';
+
+export function registerFlutterHotReloadTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_hot_reload',
+      description:
+        'Trigger hot reload or hot restart on a connected Flutter app. ' +
+        'Hot reload preserves app state; hot restart resets it. ' +
+        'Requires an active flutter_connect session.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          mode: {
+            type: 'string',
+            enum: ['reload', 'restart'],
+            description: 'Reload mode (default: "reload"). "reload" preserves state, "restart" resets state.',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const client = getFlutterVMClient(deviceId);
+        if (!client.isConnected()) {
+          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+        }
+
+        const mode = (params.mode as string | undefined) ?? 'reload';
+        const startTime = Date.now();
+
+        let result: Record<string, unknown>;
+        if (mode === 'restart') {
+          result = await client.hotRestart();
+        } else {
+          result = await client.hotReload();
+        }
+
+        const elapsed = Date.now() - startTime;
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: mode === 'restart' ? 'restarted' : 'reloaded',
+              mode,
+              elapsed,
+              deviceId,
+              result,
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_hot_reload] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/flutter-logs.ts
+++ b/src/tools/flutter-logs.ts
@@ -1,0 +1,177 @@
+/**
+ * flutter_logs — Capture Dart print()/debugPrint() log output from a Flutter app.
+ *
+ * Subscribes to the Stdout and Stderr VM Service streams and collects
+ * log entries. Returns captured logs on demand.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient } from '../flutter';
+import { getSessionManager } from '../session-manager';
+
+interface LogEntry {
+  timestamp: number;
+  stream: string;
+  message: string;
+}
+
+// Per-device log buffers
+const logBuffers = new Map<string, LogEntry[]>();
+const subscribed = new Set<string>();
+
+const MAX_LOG_ENTRIES = 500;
+
+export function registerFlutterLogsTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_logs',
+      description:
+        'Capture Dart print()/debugPrint() log output from a connected Flutter app. ' +
+        'First call starts capturing; subsequent calls return accumulated logs. ' +
+        'Requires an active flutter_connect session.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          action: {
+            type: 'string',
+            enum: ['start', 'get', 'clear'],
+            description: 'Action: "start" begins capturing, "get" returns logs, "clear" empties buffer (default: "get")',
+          },
+          filter: {
+            type: 'string',
+            description: 'Filter log messages by substring (case-insensitive)',
+          },
+          limit: {
+            type: 'number',
+            description: 'Max number of log entries to return (default: 100)',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const client = getFlutterVMClient(deviceId);
+        if (!client.isConnected()) {
+          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+        }
+
+        const action = (params.action as string | undefined) ?? 'get';
+        const filter = params.filter as string | undefined;
+        const limit = (params.limit as number | undefined) ?? 100;
+
+        if (action === 'start' || !subscribed.has(deviceId)) {
+          // Initialize buffer and subscribe to streams
+          if (!logBuffers.has(deviceId)) {
+            logBuffers.set(deviceId, []);
+          }
+
+          if (!subscribed.has(deviceId)) {
+            // Subscribe to Stdout and Stderr streams
+            try { await client.streamListen('Stdout'); } catch { /* may already be subscribed */ }
+            try { await client.streamListen('Stderr'); } catch { /* may already be subscribed */ }
+
+            // Register event handlers
+            client.onEvent('Stdout', (event) => {
+              const message = event.bytes
+                ? Buffer.from(event.bytes, 'base64').toString('utf8')
+                : event.message ?? '';
+              if (message.trim()) {
+                addLogEntry(deviceId, 'stdout', message.trim());
+              }
+            });
+
+            client.onEvent('Stderr', (event) => {
+              const message = event.bytes
+                ? Buffer.from(event.bytes, 'base64').toString('utf8')
+                : event.message ?? '';
+              if (message.trim()) {
+                addLogEntry(deviceId, 'stderr', message.trim());
+              }
+            });
+
+            subscribed.add(deviceId);
+          }
+
+          if (action === 'start') {
+            return {
+              content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                  status: 'capturing',
+                  deviceId,
+                  message: 'Log capture started. Call flutter_logs with action "get" to retrieve logs.',
+                }),
+              }],
+            };
+          }
+        }
+
+        if (action === 'clear') {
+          logBuffers.set(deviceId, []);
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify({ status: 'cleared', deviceId }),
+            }],
+          };
+        }
+
+        // action === 'get'
+        let entries = logBuffers.get(deviceId) ?? [];
+
+        if (filter) {
+          const filterLower = filter.toLowerCase();
+          entries = entries.filter((e) => e.message.toLowerCase().includes(filterLower));
+        }
+
+        const limited = entries.slice(-limit);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              total: entries.length,
+              returned: limited.length,
+              logs: limited.map((e) => ({
+                time: new Date(e.timestamp).toISOString(),
+                stream: e.stream,
+                message: e.message,
+              })),
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_logs] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function addLogEntry(deviceId: string, stream: string, message: string): void {
+  const buffer = logBuffers.get(deviceId) ?? [];
+  buffer.push({ timestamp: Date.now(), stream, message });
+
+  // Trim buffer if too large
+  while (buffer.length > MAX_LOG_ENTRIES) {
+    buffer.shift();
+  }
+
+  logBuffers.set(deviceId, buffer);
+}

--- a/src/tools/flutter-widget-tree.ts
+++ b/src/tools/flutter-widget-tree.ts
@@ -1,0 +1,87 @@
+/**
+ * flutter_widget_tree — Dump the Flutter widget, render, or semantics tree.
+ *
+ * Requires an active flutter_connect session. Uses Dart VM Service
+ * extensions to dump the full tree structure.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient } from '../flutter';
+import { getSessionManager } from '../session-manager';
+
+export function registerFlutterWidgetTreeTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_widget_tree',
+      description:
+        'Dump the Flutter widget tree, render tree, or semantics tree via Dart VM Service. ' +
+        'Requires an active flutter_connect session. Provides full widget hierarchy not visible ' +
+        'through the macOS accessibility bridge.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          tree_type: {
+            type: 'string',
+            enum: ['widget', 'render', 'semantics'],
+            description: 'Which tree to dump (default: "widget")',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const client = getFlutterVMClient(deviceId);
+        if (!client.isConnected()) {
+          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+        }
+
+        const treeType = (params.tree_type as string | undefined) ?? 'widget';
+
+        let treeDump: string;
+        switch (treeType) {
+          case 'widget':
+            treeDump = await client.getWidgetTree();
+            break;
+          case 'render':
+            treeDump = await client.getRenderTree();
+            break;
+          case 'semantics':
+            treeDump = await client.getSemanticsTree();
+            break;
+          default:
+            throw new Error(`Unknown tree type: ${treeType}. Use "widget", "render", or "semantics".`);
+        }
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              tree_type: treeType,
+              deviceId,
+              dump: treeDump,
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_widget_tree] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -83,6 +83,10 @@ import { registerAppPermissionTools } from './app-permission';
 import { registerQaFlutterTouchTargetsTool } from './qa-flutter-touch-targets';
 import { registerQaFlutterSemanticsTool } from './qa-flutter-semantics';
 import { registerQaFlutterDarkModeTool } from './qa-flutter-dark-mode';
+import { registerFlutterConnectTool } from './flutter-connect';
+import { registerFlutterWidgetTreeTool } from './flutter-widget-tree';
+import { registerFlutterHotReloadTool } from './flutter-hot-reload';
+import { registerFlutterLogsTool } from './flutter-logs';
 
 export { setWorkflowEngine } from './orchestration-tools';
 export { setBarrier } from './barrier-tools';
@@ -231,4 +235,10 @@ export function registerAllTools(server: MCPServer): void {
   registerQaFlutterTouchTargetsTool(server);
   registerQaFlutterSemanticsTool(server);
   registerQaFlutterDarkModeTool(server);
+
+  // Tier 2: Flutter VM Service (debug/profile builds only)
+  registerFlutterConnectTool(server);
+  registerFlutterWidgetTreeTool(server);
+  registerFlutterHotReloadTool(server);
+  registerFlutterLogsTool(server);
 }

--- a/tests/unit/flutter-vm-service.test.ts
+++ b/tests/unit/flutter-vm-service.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for Flutter VM Service module:
+ *   - vm-service-discovery.ts (URL parsing)
+ *   - vm-service-client.ts (client lifecycle)
+ *   - flutter-connect.ts, flutter-widget-tree.ts, flutter-hot-reload.ts, flutter-logs.ts (MCP tools)
+ */
+
+import { httpToWsUrl, isValidVMServiceUrl } from '../../src/flutter/vm-service-discovery';
+
+// ── URL Discovery Tests ──────────────────────────────────────────────────────
+
+describe('vm-service-discovery', () => {
+  describe('httpToWsUrl', () => {
+    it('converts HTTP URL to WebSocket URL', () => {
+      expect(httpToWsUrl('http://127.0.0.1:50642/abc=/'))
+        .toBe('ws://127.0.0.1:50642/abc=/ws');
+    });
+
+    it('converts HTTPS URL to WSS URL', () => {
+      expect(httpToWsUrl('https://127.0.0.1:50642/abc=/'))
+        .toBe('wss://127.0.0.1:50642/abc=/ws');
+    });
+
+    it('handles URL without trailing slash', () => {
+      expect(httpToWsUrl('http://127.0.0.1:50642/abc='))
+        .toBe('ws://127.0.0.1:50642/abc=/ws');
+    });
+
+    it('handles complex auth tokens', () => {
+      expect(httpToWsUrl('http://127.0.0.1:12345/a1b2c3d4e5f6=/'))
+        .toBe('ws://127.0.0.1:12345/a1b2c3d4e5f6=/ws');
+    });
+  });
+
+  describe('isValidVMServiceUrl', () => {
+    it('validates correct VM Service URLs', () => {
+      expect(isValidVMServiceUrl('http://127.0.0.1:50642/abc=/')).toBe(true);
+      expect(isValidVMServiceUrl('http://127.0.0.1:12345/a1b2c3d4e5f6=/')).toBe(true);
+    });
+
+    it('rejects invalid URLs', () => {
+      expect(isValidVMServiceUrl('http://example.com')).toBe(false);
+      expect(isValidVMServiceUrl('not a url')).toBe(false);
+      expect(isValidVMServiceUrl('')).toBe(false);
+    });
+  });
+});
+
+// ── FlutterVMClient Tests ────────────────────────────────────────────────────
+
+describe('FlutterVMClient', () => {
+  let FlutterVMClient: typeof import('../../src/flutter/vm-service-client').FlutterVMClient;
+  let FlutterVMError: typeof import('../../src/flutter/vm-service-client').FlutterVMError;
+
+  beforeAll(async () => {
+    const mod = await import('../../src/flutter/vm-service-client');
+    FlutterVMClient = mod.FlutterVMClient;
+    FlutterVMError = mod.FlutterVMError;
+  });
+
+  it('starts disconnected', () => {
+    const client = new FlutterVMClient();
+    expect(client.isConnected()).toBe(false);
+    expect(client.getState()).toBeNull();
+  });
+
+  it('throws NOT_CONNECTED when calling methods without connection', async () => {
+    const client = new FlutterVMClient();
+    await expect(client.callMethod('getVM')).rejects.toThrow('Not connected');
+  });
+
+  it('throws NO_ISOLATE when calling service extension without isolate', async () => {
+    const client = new FlutterVMClient();
+    // Manually set state without isolate
+    (client as unknown as Record<string, unknown>).state = {
+      connected: true,
+      mainIsolateId: null,
+    };
+    (client as unknown as Record<string, unknown>).ws = { readyState: 1 }; // OPEN
+
+    await expect(client.callServiceExtension('debugDumpApp')).rejects.toThrow('No main isolate');
+  });
+
+  it('disconnect clears state', async () => {
+    const client = new FlutterVMClient();
+    (client as unknown as Record<string, unknown>).state = {
+      connected: true,
+      httpUrl: 'http://127.0.0.1:50642/abc=/',
+      wsUrl: 'ws://127.0.0.1:50642/abc=/ws',
+      deviceId: 'test',
+    };
+    (client as unknown as Record<string, unknown>).ws = {
+      close: jest.fn(),
+      readyState: 1,
+    };
+
+    await client.disconnect();
+
+    expect(client.getState()?.connected).toBe(false);
+  });
+});
+
+// ── FlutterVMError Tests ─────────────────────────────────────────────────────
+
+describe('FlutterVMError', () => {
+  it('has correct name and code', () => {
+    const { FlutterVMError } = require('../../src/flutter/vm-service-client');
+    const err = new FlutterVMError('test error', 'TEST_CODE');
+    expect(err.name).toBe('FlutterVMError');
+    expect(err.code).toBe('TEST_CODE');
+    expect(err.message).toBe('test error');
+    expect(err instanceof Error).toBe(true);
+  });
+});
+
+// ── Tool Registration Tests ──────────────────────────────────────────────────
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'test-device-id',
+  }),
+}));
+
+describe('Flutter tool registration', () => {
+  const mockServer = {
+    registerTool: jest.fn(),
+  };
+
+  beforeEach(() => {
+    mockServer.registerTool.mockClear();
+  });
+
+  it('registers flutter_connect', () => {
+    const { registerFlutterConnectTool } = require('../../src/tools/flutter-connect');
+    registerFlutterConnectTool(mockServer);
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers flutter_widget_tree', () => {
+    const { registerFlutterWidgetTreeTool } = require('../../src/tools/flutter-widget-tree');
+    registerFlutterWidgetTreeTool(mockServer);
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers flutter_hot_reload', () => {
+    const { registerFlutterHotReloadTool } = require('../../src/tools/flutter-hot-reload');
+    registerFlutterHotReloadTool(mockServer);
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers flutter_logs', () => {
+    const { registerFlutterLogsTool } = require('../../src/tools/flutter-logs');
+    registerFlutterLogsTool(mockServer);
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Tool Handler Tests (flutter_widget_tree, flutter_hot_reload) ─────────────
+
+const mockGetWidgetTree = jest.fn();
+const mockGetRenderTree = jest.fn();
+const mockGetSemanticsTree = jest.fn();
+const mockHotReload = jest.fn();
+const mockHotRestart = jest.fn();
+const mockIsConnected = jest.fn();
+
+jest.mock('../../src/flutter', () => ({
+  getFlutterVMClient: () => ({
+    isConnected: mockIsConnected,
+    getWidgetTree: mockGetWidgetTree,
+    getRenderTree: mockGetRenderTree,
+    getSemanticsTree: mockGetSemanticsTree,
+    hotReload: mockHotReload,
+    hotRestart: mockHotRestart,
+  }),
+}));
+
+describe('flutter_widget_tree handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    const { registerFlutterWidgetTreeTool } = require('../../src/tools/flutter-widget-tree');
+    registerFlutterWidgetTreeTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns widget tree when connected', async () => {
+    mockIsConnected.mockReturnValue(true);
+    mockGetWidgetTree.mockResolvedValue('MyApp\n  MaterialApp\n    Scaffold');
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.tree_type).toBe('widget');
+    expect(body.dump).toContain('MyApp');
+  });
+
+  it('returns render tree', async () => {
+    mockIsConnected.mockReturnValue(true);
+    mockGetRenderTree.mockResolvedValue('RenderView\n  RenderBox');
+
+    const result = await handler('s', { tree_type: 'render' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.tree_type).toBe('render');
+    expect(body.dump).toContain('RenderView');
+  });
+
+  it('errors when not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+
+    const result = await handler('s', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Not connected');
+  });
+});
+
+describe('flutter_hot_reload handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    const { registerFlutterHotReloadTool } = require('../../src/tools/flutter-hot-reload');
+    registerFlutterHotReloadTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('triggers hot reload', async () => {
+    mockIsConnected.mockReturnValue(true);
+    mockHotReload.mockResolvedValue({ type: 'ReloadReport', success: true });
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('reloaded');
+    expect(body.mode).toBe('reload');
+    expect(mockHotReload).toHaveBeenCalled();
+  });
+
+  it('triggers hot restart', async () => {
+    mockIsConnected.mockReturnValue(true);
+    mockHotRestart.mockResolvedValue({});
+
+    const result = await handler('s', { mode: 'restart' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('restarted');
+    expect(body.mode).toBe('restart');
+    expect(mockHotRestart).toHaveBeenCalled();
+  });
+
+  it('errors when not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+
+    const result = await handler('s', {});
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/flutter/` module: WebSocket JSON-RPC 2.0 client for the Dart VM Service Protocol
- Add 4 new MCP tools: `flutter_connect`, `flutter_widget_tree`, `flutter_hot_reload`, `flutter_logs`
- Enables deep inspection of Flutter apps in debug/profile builds on iOS Simulator

## New Module: `src/flutter/`

| File | Purpose |
|------|---------|
| `flutter-types.ts` | Type definitions (VMServiceRequest/Response, VMInfo, etc.) |
| `vm-service-discovery.ts` | Auto-discover observatory URL from simulator logs |
| `vm-service-client.ts` | WebSocket JSON-RPC client with request matching and event streaming |
| `index.ts` | Module exports |

## New MCP Tools

| Tool | Description |
|------|-------------|
| `flutter_connect` | Connect to Flutter VM Service (auto-discover or manual URL) |
| `flutter_widget_tree` | Dump widget/render/semantics tree via `ext.flutter.*` extensions |
| `flutter_hot_reload` | Trigger hot reload (preserve state) or hot restart (reset state) |
| `flutter_logs` | Capture Dart `print()`/`debugPrint()` output via Stdout/Stderr streams |

## Architecture
```
MCP Client → flutter_connect → FlutterVMClient (WebSocket) → Dart VM Service
                                                               ├── ext.flutter.debugDumpApp
                                                               ├── ext.flutter.hotRestart
                                                               ├── reloadSources
                                                               └── streamListen(Stdout)
```

## Test plan
- [x] 21 unit tests pass (URL parsing, client lifecycle, tool handlers)
- [x] Build succeeds
- [ ] Manual: `flutter run -d <sim>` → `flutter_connect` → `flutter_widget_tree` returns tree
- [ ] Manual: `flutter_hot_reload` reflects code changes in app
- [ ] Manual: `flutter_logs` captures `print()` output

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)