### PR TITLE
feat: Flutter-specific QA detector suite

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -97,6 +97,11 @@ export const TOOL_TIERS: Record<string, number> = {
   compare_devices: 3,
   app_assert: 2,
 
+  // Tier 2: Flutter QA Detectors
+  qa_flutter_touch_targets: 2,
+  qa_flutter_semantics: 2,
+  qa_flutter_dark_mode: 2,
+
   // Tier 2: Hybrid context switching
   app_webview_connect: 2,
   set_active_context: 2,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -80,6 +80,9 @@ import { registerAppAssertTool } from './app-assert';
 import { registerAppWebviewConnectTool } from './app-webview-connect';
 import { registerSetActiveContextTool } from './set-active-context';
 import { registerAppPermissionTools } from './app-permission';
+import { registerQaFlutterTouchTargetsTool } from './qa-flutter-touch-targets';
+import { registerQaFlutterSemanticsTool } from './qa-flutter-semantics';
+import { registerQaFlutterDarkModeTool } from './qa-flutter-dark-mode';
 
 export { setWorkflowEngine } from './orchestration-tools';
 export { setBarrier } from './barrier-tools';
@@ -223,4 +226,9 @@ export function registerAllTools(server: MCPServer): void {
   registerSetActiveContextTool(server);
   // Tier 2: Native App — System Surfaces
   registerAppPermissionTools(server);
+
+  // Tier 2: Flutter QA Detectors
+  registerQaFlutterTouchTargetsTool(server);
+  registerQaFlutterSemanticsTool(server);
+  registerQaFlutterDarkModeTool(server);
 }

--- a/src/tools/qa-flutter-dark-mode.ts
+++ b/src/tools/qa-flutter-dark-mode.ts
@@ -1,0 +1,134 @@
+/**
+ * qa_flutter_dark_mode — Check dark mode rendering for Flutter/native apps.
+ *
+ * Takes screenshots in both light and dark mode, compares them, and reports
+ * the visual difference. Relies on simctl appearance toggle and screenshot.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getSessionManager } from '../session-manager';
+import { SimctlExecutor } from '../simulator/simctl';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+export function registerQaFlutterDarkModeTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'qa_flutter_dark_mode',
+      description:
+        'Check dark mode rendering for a Flutter/native app. Takes screenshots in both light and dark mode, ' +
+        'reports whether the app responds to appearance changes. Restores the original appearance after check.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+          settle_time: {
+            type: 'number',
+            description: 'Time in ms to wait after appearance change for UI to settle (default: 1500)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const settleTime = (params.settle_time as number | undefined) ?? 1500;
+        const simctl = new SimctlExecutor();
+        const tmpDir = os.tmpdir();
+
+        // Get current appearance
+        let originalAppearance: 'light' | 'dark' = 'light';
+        try {
+          const currentAppearance = await simctl.exec([
+            'ui', deviceId, 'appearance',
+          ]);
+          if (currentAppearance.trim().toLowerCase().includes('dark')) {
+            originalAppearance = 'dark';
+          }
+        } catch {
+          // Default to light if can't determine
+        }
+
+        // Set light mode and screenshot
+        await simctl.exec(['ui', deviceId, 'appearance', 'light']);
+        await sleep(settleTime);
+        const lightPath = path.join(tmpDir, `opensafari-qa-light-${deviceId}.png`);
+        await simctl.exec(['io', deviceId, 'screenshot', lightPath]);
+        const lightSize = getFileSize(lightPath);
+
+        // Set dark mode and screenshot
+        await simctl.exec(['ui', deviceId, 'appearance', 'dark']);
+        await sleep(settleTime);
+        const darkPath = path.join(tmpDir, `opensafari-qa-dark-${deviceId}.png`);
+        await simctl.exec(['io', deviceId, 'screenshot', darkPath]);
+        const darkSize = getFileSize(darkPath);
+
+        // Restore original appearance
+        await simctl.exec(['ui', deviceId, 'appearance', originalAppearance]);
+
+        // Compare file sizes as a rough proxy for visual difference
+        // If screenshots are identical in size, the app likely doesn't respond to dark mode
+        const sizeDiff = Math.abs(lightSize - darkSize);
+        const sizeDiffPercent = lightSize > 0
+          ? Math.round((sizeDiff / lightSize) * 100)
+          : 0;
+
+        // The app responds to dark mode if there's meaningful visual difference
+        const respondsToDarkMode = sizeDiffPercent > 2;
+
+        // Clean up temp files
+        try { fs.unlinkSync(lightPath); } catch { /* ignore */ }
+        try { fs.unlinkSync(darkPath); } catch { /* ignore */ }
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              detector: 'qa_flutter_dark_mode',
+              passed: respondsToDarkMode,
+              responds_to_dark_mode: respondsToDarkMode,
+              light_screenshot_size: lightSize,
+              dark_screenshot_size: darkSize,
+              size_diff_percent: sizeDiffPercent,
+              original_appearance: originalAppearance,
+              summary: respondsToDarkMode
+                ? `App responds to dark mode. Screenshot size diff: ${sizeDiffPercent}%.`
+                : `App may not respond to dark mode. Screenshot size diff: ${sizeDiffPercent}% (below 2% threshold). Verify manually.`,
+            }, null, 2),
+          }],
+          isError: !respondsToDarkMode,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[qa_flutter_dark_mode] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function getFileSize(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size;
+  } catch {
+    return 0;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/tools/qa-flutter-semantics.ts
+++ b/src/tools/qa-flutter-semantics.ts
@@ -1,0 +1,174 @@
+/**
+ * qa_flutter_semantics — Check accessibility/semantics coverage for Flutter apps.
+ *
+ * Verifies that interactive elements have proper accessibility labels and
+ * identifiers. Reports coverage percentage and flags unlabeled elements.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getAccessibilityBridge } from '../native';
+import type { AXNode } from '../native';
+import { getSessionManager } from '../session-manager';
+
+const INTERACTIVE_ROLES = [
+  'AXButton', 'AXLink', 'AXTextField', 'AXTextArea',
+  'AXCheckBox', 'AXRadioButton', 'AXSwitch', 'AXSlider',
+  'AXPopUpButton', 'AXMenuItem', 'AXTab', 'AXImage',
+];
+
+interface SemanticsIssue {
+  role: string;
+  path: string;
+  frame: { x: number; y: number; width: number; height: number };
+  issue: string;
+}
+
+export function registerQaFlutterSemanticsTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'qa_flutter_semantics',
+      description:
+        'Check accessibility/semantics coverage for a Flutter/native app. Verifies that interactive ' +
+        'elements have proper accessibility labels and identifiers for screen readers and automation.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          min_coverage: {
+            type: 'number',
+            description: 'Minimum acceptable coverage percentage (default: 80)',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const minCoverage = (params.min_coverage as number | undefined) ?? 80;
+        const bridge = getAccessibilityBridge();
+        const tree = await bridge.dumpTree({ deviceId, maxDepth: 15 });
+
+        const issues: SemanticsIssue[] = [];
+        let totalInteractive = 0;
+        let labeled = 0;
+        let withIdentifier = 0;
+
+        analyzeSemantics(tree, issues, {
+          totalInteractive: 0,
+          labeled: 0,
+          withIdentifier: 0,
+        });
+
+        const stats = countSemantics(tree);
+        totalInteractive = stats.totalInteractive;
+        labeled = stats.labeled;
+        withIdentifier = stats.withIdentifier;
+
+        const coverage = totalInteractive > 0
+          ? Math.round((labeled / totalInteractive) * 100)
+          : 100;
+        const identifierCoverage = totalInteractive > 0
+          ? Math.round((withIdentifier / totalInteractive) * 100)
+          : 100;
+        const passed = coverage >= minCoverage;
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              detector: 'qa_flutter_semantics',
+              passed,
+              coverage_percent: coverage,
+              identifier_coverage_percent: identifierCoverage,
+              min_coverage: minCoverage,
+              total_interactive: totalInteractive,
+              labeled,
+              with_identifier: withIdentifier,
+              issues_count: issues.length,
+              issues: issues.slice(0, 20),
+              summary: passed
+                ? `Semantics coverage: ${coverage}% (${labeled}/${totalInteractive} elements labeled). Meets ${minCoverage}% threshold.`
+                : `Semantics coverage: ${coverage}% (${labeled}/${totalInteractive} elements labeled). Below ${minCoverage}% threshold.`,
+            }, null, 2),
+          }],
+          isError: !passed,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[qa_flutter_semantics] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function isInteractive(node: AXNode): boolean {
+  return INTERACTIVE_ROLES.some(
+    (r) => node.role === r || node.role === r.replace('AX', ''),
+  );
+}
+
+function countSemantics(node: AXNode): { totalInteractive: number; labeled: number; withIdentifier: number } {
+  let totalInteractive = 0;
+  let labeled = 0;
+  let withIdentifier = 0;
+
+  function walk(n: AXNode): void {
+    if (isInteractive(n) && n.visible) {
+      totalInteractive++;
+      if (n.label && n.label.trim().length > 0) labeled++;
+      if (n.identifier && n.identifier.trim().length > 0) withIdentifier++;
+    }
+    if (n.children) {
+      for (const child of n.children) walk(child);
+    }
+  }
+  walk(node);
+  return { totalInteractive, labeled, withIdentifier };
+}
+
+function analyzeSemantics(
+  node: AXNode,
+  issues: SemanticsIssue[],
+  _stats: { totalInteractive: number; labeled: number; withIdentifier: number },
+): void {
+  if (isInteractive(node) && node.visible) {
+    const hasLabel = node.label && node.label.trim().length > 0;
+    const hasIdentifier = node.identifier && node.identifier.trim().length > 0;
+
+    if (!hasLabel && !hasIdentifier) {
+      issues.push({
+        role: node.role,
+        path: node.path,
+        frame: node.frame,
+        issue: 'Missing both accessibility label and identifier',
+      });
+    } else if (!hasLabel) {
+      issues.push({
+        role: node.role,
+        path: node.path,
+        frame: node.frame,
+        issue: 'Missing accessibility label (has identifier only)',
+      });
+    }
+  }
+
+  if (node.children) {
+    for (const child of node.children) {
+      analyzeSemantics(child, issues, _stats);
+    }
+  }
+}

--- a/src/tools/qa-flutter-touch-targets.ts
+++ b/src/tools/qa-flutter-touch-targets.ts
@@ -1,0 +1,162 @@
+/**
+ * qa_flutter_touch_targets — Check minimum tap target sizes for Flutter apps.
+ *
+ * Material Design guidelines require minimum 48x48dp for interactive elements.
+ * This detector reads the accessibility tree and flags elements that are too small.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getAccessibilityBridge } from '../native';
+import type { AXNode } from '../native';
+import { getSessionManager } from '../session-manager';
+
+const DEFAULT_MIN_SIZE = 48;
+const INTERACTIVE_ROLES = [
+  'AXButton', 'AXLink', 'AXTextField', 'AXTextArea',
+  'AXCheckBox', 'AXRadioButton', 'AXSwitch', 'AXSlider',
+  'AXPopUpButton', 'AXMenuItem', 'AXTab',
+];
+
+interface TouchTargetViolation {
+  role: string;
+  label?: string;
+  identifier?: string;
+  path: string;
+  frame: { x: number; y: number; width: number; height: number };
+  issue: string;
+}
+
+export function registerQaFlutterTouchTargetsTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'qa_flutter_touch_targets',
+      description:
+        'Check that all interactive elements in a Flutter/native app meet minimum tap target size ' +
+        '(48x48dp per Material Design / WCAG 2.5.8). Reads the accessibility tree and flags violations.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          min_size: {
+            type: 'number',
+            description: 'Minimum tap target size in points (default: 48 per Material Design)',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const minSize = (params.min_size as number | undefined) ?? DEFAULT_MIN_SIZE;
+        const bridge = getAccessibilityBridge();
+        const tree = await bridge.dumpTree({ deviceId, maxDepth: 15 });
+
+        const violations: TouchTargetViolation[] = [];
+        let totalInteractive = 0;
+
+        findViolations(tree, minSize, violations, { total: 0 });
+        countInteractive(tree, { count: 0 });
+        totalInteractive = countInteractiveNodes(tree);
+
+        const passed = violations.length === 0;
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              detector: 'qa_flutter_touch_targets',
+              passed,
+              min_size: minSize,
+              total_interactive: totalInteractive,
+              violations_count: violations.length,
+              violations: violations.slice(0, 20), // Limit output
+              summary: passed
+                ? `All ${totalInteractive} interactive elements meet ${minSize}dp minimum.`
+                : `${violations.length} of ${totalInteractive} interactive elements are smaller than ${minSize}dp.`,
+            }, null, 2),
+          }],
+          isError: !passed,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[qa_flutter_touch_targets] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function isInteractive(node: AXNode): boolean {
+  return INTERACTIVE_ROLES.some(
+    (r) => node.role === r || node.role === r.replace('AX', ''),
+  );
+}
+
+function countInteractiveNodes(node: AXNode): number {
+  let count = 0;
+  if (isInteractive(node) && node.visible) count++;
+  if (node.children) {
+    for (const child of node.children) {
+      count += countInteractiveNodes(child);
+    }
+  }
+  return count;
+}
+
+function findViolations(
+  node: AXNode,
+  minSize: number,
+  violations: TouchTargetViolation[],
+  _counter: { total: number },
+): void {
+  if (isInteractive(node) && node.visible) {
+    const { width, height } = node.frame;
+    const issues: string[] = [];
+
+    if (width > 0 && width < minSize) {
+      issues.push(`width ${Math.round(width)}dp < ${minSize}dp`);
+    }
+    if (height > 0 && height < minSize) {
+      issues.push(`height ${Math.round(height)}dp < ${minSize}dp`);
+    }
+
+    if (issues.length > 0) {
+      violations.push({
+        role: node.role,
+        label: node.label,
+        identifier: node.identifier,
+        path: node.path,
+        frame: node.frame,
+        issue: issues.join(', '),
+      });
+    }
+  }
+
+  if (node.children) {
+    for (const child of node.children) {
+      findViolations(child, minSize, violations, _counter);
+    }
+  }
+}
+
+function countInteractive(node: AXNode, counter: { count: number }): void {
+  if (isInteractive(node) && node.visible) counter.count++;
+  if (node.children) {
+    for (const child of node.children) {
+      countInteractive(child, counter);
+    }
+  }
+}

--- a/tests/unit/qa-flutter-detectors.test.ts
+++ b/tests/unit/qa-flutter-detectors.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for Flutter QA detectors:
+ *   qa_flutter_touch_targets, qa_flutter_semantics, qa_flutter_dark_mode
+ */
+
+jest.mock('../../src/mcp-server', () => {
+  const actual = jest.requireActual('../../src/mcp-server');
+  return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };
+});
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerQaFlutterTouchTargetsTool } from '../../src/tools/qa-flutter-touch-targets';
+import { registerQaFlutterSemanticsTool } from '../../src/tools/qa-flutter-semantics';
+import type { AXNode } from '../../src/native/ax-types';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockDumpTree = jest.fn();
+
+jest.mock('../../src/native/accessibility-bridge', () => ({
+  getAccessibilityBridge: () => ({
+    dumpTree: mockDumpTree,
+  }),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'test-device-id',
+  }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type ToolHandler = (s: string, p: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function makeNode(overrides: Partial<AXNode> & { children?: AXNode[] } = {}): AXNode {
+  return {
+    role: 'AXGroup',
+    traits: [],
+    frame: { x: 0, y: 0, width: 390, height: 844 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    path: '',
+    ...overrides,
+  };
+}
+
+function makeButton(label: string, width: number, height: number, path: string): AXNode {
+  return makeNode({
+    role: 'AXButton',
+    label,
+    frame: { x: 20, y: 100, width, height },
+    path,
+  });
+}
+
+// ── Touch Targets Tests ──────────────────────────────────────────────────────
+
+describe('qa_flutter_touch_targets', () => {
+  let handler: ToolHandler;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    registerQaFlutterTouchTargetsTool(server as unknown as MCPServer);
+    handler = (server.registerTool as jest.Mock).mock.calls[0][1];
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes when all buttons meet minimum size', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeButton('Login', 200, 48, '0'),
+        makeButton('Register', 300, 50, '1'),
+      ],
+    }));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+    expect(body.violations_count).toBe(0);
+    expect(body.total_interactive).toBe(2);
+  });
+
+  it('detects buttons smaller than 48dp', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeButton('OK', 30, 30, '0'),        // too small
+        makeButton('Login', 200, 48, '1'),     // ok
+        makeButton('X', 20, 20, '2'),          // too small
+      ],
+    }));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(false);
+    expect(body.violations_count).toBe(2);
+    expect(body.violations[0].label).toBe('OK');
+    expect(body.violations[1].label).toBe('X');
+  });
+
+  it('supports custom minimum size', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeButton('OK', 40, 40, '0'), // fails at 48, passes at 40
+      ],
+    }));
+
+    const result = await handler('s', { min_size: 40 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+  });
+
+  it('ignores non-interactive elements', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeNode({ role: 'AXStaticText', label: 'Hello', frame: { x: 0, y: 0, width: 10, height: 10 }, path: '0' }),
+        makeButton('Login', 200, 48, '1'),
+      ],
+    }));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+    expect(body.total_interactive).toBe(1); // only the button
+  });
+
+  it('ignores hidden elements', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeNode({ role: 'AXButton', label: 'Hidden', visible: false, frame: { x: 0, y: 0, width: 10, height: 10 }, path: '0' }),
+      ],
+    }));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+    expect(body.total_interactive).toBe(0);
+  });
+});
+
+// ── Semantics Coverage Tests ─────────────────────────────────────────────────
+
+describe('qa_flutter_semantics', () => {
+  let handler: ToolHandler;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    registerQaFlutterSemanticsTool(server as unknown as MCPServer);
+    handler = (server.registerTool as jest.Mock).mock.calls[0][1];
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes when all elements have labels', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeNode({ role: 'AXButton', label: 'Login', identifier: 'login_btn', path: '0' }),
+        makeNode({ role: 'AXTextField', label: 'Email', identifier: 'email_field', path: '1' }),
+      ],
+    }));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+    expect(body.coverage_percent).toBe(100);
+  });
+
+  it('fails when elements lack labels', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeNode({ role: 'AXButton', label: 'Login', path: '0' }),
+        makeNode({ role: 'AXButton', path: '1' }), // no label or identifier
+        makeNode({ role: 'AXTextField', path: '2' }), // no label or identifier
+      ],
+    }));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(false);
+    expect(body.coverage_percent).toBeLessThan(80);
+    expect(body.issues_count).toBeGreaterThan(0);
+  });
+
+  it('supports custom min_coverage', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeNode({ role: 'AXButton', label: 'A', path: '0' }),
+        makeNode({ role: 'AXButton', path: '1' }), // unlabeled
+      ],
+    }));
+
+    // 50% coverage — fails at 80%, passes at 50%
+    const result = await handler('s', { min_coverage: 50 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+    expect(body.coverage_percent).toBe(50);
+  });
+
+  it('reports identifier coverage separately', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeNode({ role: 'AXButton', label: 'Login', identifier: 'login_btn', path: '0' }),
+        makeNode({ role: 'AXButton', label: 'Register', path: '1' }), // label but no identifier
+      ],
+    }));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.coverage_percent).toBe(100); // all have labels
+    expect(body.identifier_coverage_percent).toBe(50); // only half have identifiers
+  });
+});


### PR DESCRIPTION
## Summary
- Add 3 Flutter QA detectors: touch targets, semantics coverage, dark mode
- All work via accessibility tree + simctl — no Flutter-specific protocol needed
- Registered in Tier 2 with progressive disclosure

## New QA Detectors

| Detector | What It Checks | Method |
|----------|---------------|--------|
| `qa_flutter_touch_targets` | Min 48x48dp tap target size (Material Design / WCAG) | Accessibility tree frame analysis |
| `qa_flutter_semantics` | Label/identifier coverage for interactive elements | Accessibility tree inspection |
| `qa_flutter_dark_mode` | App responds to dark/light appearance changes | Simctl appearance toggle + screenshot comparison |

## Test plan
- [x] 9 unit tests pass (5 touch targets + 4 semantics)
- [x] Build succeeds
- [ ] Manual: Run detectors on Flutter app with small buttons → violations reported
- [ ] Manual: Run dark mode detector → confirms app responds to appearance change

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)