### PR TITLE
feat: Network traffic monitoring for Flutter/native apps

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -108,6 +108,9 @@ export const TOOL_TIERS: Record<string, number> = {
   flutter_hot_reload: 2,
   flutter_logs: 2,
 
+  // Tier 2: Flutter Network Monitoring
+  flutter_network: 2,
+
   // Tier 2: Hybrid context switching
   app_webview_connect: 2,
   set_active_context: 2,

--- a/src/tools/flutter-network.ts
+++ b/src/tools/flutter-network.ts
@@ -1,0 +1,407 @@
+/**
+ * flutter_network — HTTP traffic capture for native/Flutter apps.
+ *
+ * Starts a local HTTP proxy, configures the simulator to route traffic
+ * through it, and captures request/response metadata. Provides log
+ * retrieval and HAR export.
+ */
+
+import * as http from 'http';
+import * as https from 'https';
+import * as url from 'url';
+import { MCPServer } from '../mcp-server';
+import { getSessionManager } from '../session-manager';
+import { SimctlExecutor } from '../simulator/simctl';
+
+interface NetworkEntry {
+  id: number;
+  timestamp: number;
+  method: string;
+  url: string;
+  statusCode?: number;
+  requestHeaders: Record<string, string | string[] | undefined>;
+  responseHeaders?: Record<string, string | string[] | undefined>;
+  requestSize: number;
+  responseSize: number;
+  duration?: number;
+  error?: string;
+}
+
+interface ProxyState {
+  server: http.Server;
+  port: number;
+  entries: NetworkEntry[];
+  entryId: number;
+  deviceId: string;
+}
+
+// Per-device proxy state
+const proxies = new Map<string, ProxyState>();
+const MAX_ENTRIES = 1000;
+
+export function registerFlutterNetworkTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_network',
+      description:
+        'Capture HTTP network traffic from Flutter/native apps via a local proxy. ' +
+        'Actions: "start" begins capture, "log" returns captured requests, ' +
+        '"har" exports as HAR format, "stop" stops capture and cleans up.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          action: {
+            type: 'string',
+            enum: ['start', 'log', 'har', 'stop'],
+            description: 'Action to perform (default: "log")',
+          },
+          port: {
+            type: 'number',
+            description: 'Proxy port (default: 8888). Only used with "start" action.',
+          },
+          filter_url: {
+            type: 'string',
+            description: 'Filter entries by URL substring',
+          },
+          filter_status: {
+            type: 'number',
+            description: 'Filter entries by HTTP status code',
+          },
+          limit: {
+            type: 'number',
+            description: 'Max entries to return (default: 50)',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const action = (params.action as string | undefined) ?? 'log';
+
+        switch (action) {
+          case 'start':
+            return await handleStart(deviceId, params);
+          case 'log':
+            return handleLog(deviceId, params);
+          case 'har':
+            return handleHar(deviceId);
+          case 'stop':
+            return await handleStop(deviceId);
+          default:
+            throw new Error(`Unknown action: ${action}`);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_network] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+async function handleStart(
+  deviceId: string,
+  params: Record<string, unknown>,
+) {
+  if (proxies.has(deviceId)) {
+    throw new Error('Proxy already running for this device. Stop it first with action "stop".');
+  }
+
+  const port = (params.port as number | undefined) ?? 8888;
+
+  // Create HTTP proxy server
+  const proxyServer = http.createServer((clientReq, clientRes) => {
+    const state = proxies.get(deviceId);
+    if (!state) return;
+
+    const reqUrl = clientReq.url ?? '/';
+    const entry: NetworkEntry = {
+      id: ++state.entryId,
+      timestamp: Date.now(),
+      method: clientReq.method ?? 'GET',
+      url: reqUrl,
+      requestHeaders: clientReq.headers as Record<string, string | string[] | undefined>,
+      requestSize: 0,
+      responseSize: 0,
+    };
+
+    // Track request size
+    clientReq.on('data', (chunk: Buffer) => {
+      entry.requestSize += chunk.length;
+    });
+
+    // Forward request
+    try {
+      const parsed = url.parse(reqUrl);
+      const isHttps = parsed.protocol === 'https:';
+      const requestModule = isHttps ? https : http;
+
+      const proxyReq = requestModule.request(
+        {
+          hostname: parsed.hostname,
+          port: parsed.port ?? (isHttps ? 443 : 80),
+          path: parsed.path,
+          method: clientReq.method,
+          headers: clientReq.headers,
+        },
+        (proxyRes) => {
+          entry.statusCode = proxyRes.statusCode;
+          entry.responseHeaders = proxyRes.headers as Record<string, string | string[] | undefined>;
+          entry.duration = Date.now() - entry.timestamp;
+
+          proxyRes.on('data', (chunk: Buffer) => {
+            entry.responseSize += chunk.length;
+          });
+
+          proxyRes.on('end', () => {
+            addEntry(state, entry);
+          });
+
+          clientRes.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+          proxyRes.pipe(clientRes, { end: true });
+        },
+      );
+
+      proxyReq.on('error', (err) => {
+        entry.error = err.message;
+        entry.duration = Date.now() - entry.timestamp;
+        addEntry(state, entry);
+        clientRes.writeHead(502);
+        clientRes.end('Proxy Error');
+      });
+
+      clientReq.pipe(proxyReq, { end: true });
+    } catch (err) {
+      entry.error = err instanceof Error ? err.message : String(err);
+      addEntry(state, entry);
+      clientRes.writeHead(502);
+      clientRes.end('Proxy Error');
+    }
+  });
+
+  // Start listening
+  await new Promise<void>((resolve, reject) => {
+    proxyServer.on('error', (err) => {
+      reject(new Error(`Could not start proxy on port ${port}: ${err.message}`));
+    });
+    proxyServer.listen(port, '127.0.0.1', () => resolve());
+  });
+
+  proxies.set(deviceId, {
+    server: proxyServer,
+    port,
+    entries: [],
+    entryId: 0,
+    deviceId,
+  });
+
+  // Configure simulator to use proxy
+  const simctl = new SimctlExecutor();
+  try {
+    await simctl.exec([
+      'spawn', deviceId, 'defaults', 'write',
+      'Apple Global Domain', 'WebKitProxyDefaultsKey',
+      '-dict', 'HTTPEnable', '-int', '1',
+      'HTTPProxy', '-string', '127.0.0.1',
+      'HTTPPort', '-int', String(port),
+    ]);
+  } catch {
+    // Proxy config may not work on all simulator versions — capture still works for explicit proxy clients
+  }
+
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({
+        status: 'started',
+        port,
+        deviceId,
+        message: `HTTP proxy listening on 127.0.0.1:${port}. Configure your Flutter app to use this proxy or set NSGlobalDomain proxy settings.`,
+      }),
+    }],
+  };
+}
+
+function handleLog(
+  deviceId: string,
+  params: Record<string, unknown>,
+) {
+  const state = proxies.get(deviceId);
+  if (!state) {
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({
+          error: 'No proxy running for this device. Start one with action "start".',
+        }),
+      }],
+    };
+  }
+
+  let entries = [...state.entries];
+
+  const filterUrl = params.filter_url as string | undefined;
+  if (filterUrl) {
+    entries = entries.filter((e) =>
+      e.url.toLowerCase().includes(filterUrl.toLowerCase()),
+    );
+  }
+
+  const filterStatus = params.filter_status as number | undefined;
+  if (filterStatus) {
+    entries = entries.filter((e) => e.statusCode === filterStatus);
+  }
+
+  const limit = (params.limit as number | undefined) ?? 50;
+  const limited = entries.slice(-limit);
+
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({
+        total: state.entries.length,
+        filtered: entries.length,
+        returned: limited.length,
+        entries: limited.map((e) => ({
+          id: e.id,
+          time: new Date(e.timestamp).toISOString(),
+          method: e.method,
+          url: e.url,
+          status: e.statusCode,
+          duration_ms: e.duration,
+          request_size: e.requestSize,
+          response_size: e.responseSize,
+          error: e.error,
+        })),
+      }, null, 2),
+    }],
+  };
+}
+
+function handleHar(
+  deviceId: string,
+) {
+  const state = proxies.get(deviceId);
+  if (!state) {
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ error: 'No proxy running.' }),
+      }],
+    };
+  }
+
+  const har = {
+    log: {
+      version: '1.2',
+      creator: { name: 'opensafari', version: '0.2.9' },
+      entries: state.entries.map((e) => ({
+        startedDateTime: new Date(e.timestamp).toISOString(),
+        time: e.duration ?? 0,
+        request: {
+          method: e.method,
+          url: e.url,
+          httpVersion: 'HTTP/1.1',
+          headers: Object.entries(e.requestHeaders ?? {}).map(([k, v]) => ({
+            name: k,
+            value: String(v),
+          })),
+          headersSize: -1,
+          bodySize: e.requestSize,
+        },
+        response: {
+          status: e.statusCode ?? 0,
+          statusText: '',
+          httpVersion: 'HTTP/1.1',
+          headers: Object.entries(e.responseHeaders ?? {}).map(([k, v]) => ({
+            name: k,
+            value: String(v),
+          })),
+          content: { size: e.responseSize, mimeType: '' },
+          headersSize: -1,
+          bodySize: e.responseSize,
+        },
+        cache: {},
+        timings: {
+          send: 0,
+          wait: e.duration ?? 0,
+          receive: 0,
+        },
+      })),
+    },
+  };
+
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify(har, null, 2),
+    }],
+  };
+}
+
+async function handleStop(
+  deviceId: string,
+) {
+  const state = proxies.get(deviceId);
+  if (!state) {
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ status: 'not_running', message: 'No proxy to stop.' }),
+      }],
+    };
+  }
+
+  const entriesCount = state.entries.length;
+
+  // Close server
+  await new Promise<void>((resolve) => {
+    state.server.close(() => resolve());
+  });
+
+  // Clear simulator proxy settings
+  const simctl = new SimctlExecutor();
+  try {
+    await simctl.exec([
+      'spawn', deviceId, 'defaults', 'delete',
+      'Apple Global Domain', 'WebKitProxyDefaultsKey',
+    ]);
+  } catch {
+    // Ignore cleanup errors
+  }
+
+  proxies.delete(deviceId);
+
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({
+        status: 'stopped',
+        deviceId,
+        entries_captured: entriesCount,
+      }),
+    }],
+  };
+}
+
+function addEntry(state: ProxyState, entry: NetworkEntry): void {
+  state.entries.push(entry);
+  while (state.entries.length > MAX_ENTRIES) {
+    state.entries.shift();
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -87,6 +87,7 @@ import { registerFlutterConnectTool } from './flutter-connect';
 import { registerFlutterWidgetTreeTool } from './flutter-widget-tree';
 import { registerFlutterHotReloadTool } from './flutter-hot-reload';
 import { registerFlutterLogsTool } from './flutter-logs';
+import { registerFlutterNetworkTool } from './flutter-network';
 
 export { setWorkflowEngine } from './orchestration-tools';
 export { setBarrier } from './barrier-tools';
@@ -241,4 +242,7 @@ export function registerAllTools(server: MCPServer): void {
   registerFlutterWidgetTreeTool(server);
   registerFlutterHotReloadTool(server);
   registerFlutterLogsTool(server);
+
+  // Tier 2: Flutter Network Monitoring
+  registerFlutterNetworkTool(server);
 }

--- a/tests/unit/flutter-network.test.ts
+++ b/tests/unit/flutter-network.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for flutter_network tool (proxy-based HTTP capture).
+ */
+
+jest.mock('../../src/mcp-server', () => {
+  const actual = jest.requireActual('../../src/mcp-server');
+  return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };
+});
+
+const mockExec = jest.fn().mockResolvedValue('');
+
+jest.mock('../../src/simulator/simctl', () => ({
+  SimctlExecutor: jest.fn().mockImplementation(() => ({
+    exec: mockExec,
+  })),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'test-device-id',
+  }),
+}));
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerFlutterNetworkTool } from '../../src/tools/flutter-network';
+
+type ToolHandler = (s: string, p: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+let handler: ToolHandler;
+
+beforeAll(() => {
+  const server = { registerTool: jest.fn() };
+  registerFlutterNetworkTool(server as unknown as MCPServer);
+  handler = (server.registerTool as jest.Mock).mock.calls[0][1];
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('flutter_network', () => {
+  it('returns error when getting log without active proxy', async () => {
+    const result = await handler('s', { action: 'log' });
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toContain('No proxy running');
+  });
+
+  it('returns not_running when stopping without active proxy', async () => {
+    const result = await handler('s', { action: 'stop' });
+    const body = JSON.parse(result.content[0].text);
+    expect(body.status).toBe('not_running');
+  });
+
+  it('starts proxy on specified port', async () => {
+    const result = await handler('s', { action: 'start', port: 18888 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('started');
+    expect(body.port).toBe(18888);
+
+    // Clean up
+    await handler('s', { action: 'stop' });
+  });
+
+  it('returns empty log when no traffic captured', async () => {
+    await handler('s', { action: 'start', port: 18889 });
+
+    const result = await handler('s', { action: 'log' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.total).toBe(0);
+    expect(body.entries).toEqual([]);
+
+    await handler('s', { action: 'stop' });
+  });
+
+  it('exports empty HAR format', async () => {
+    await handler('s', { action: 'start', port: 18890 });
+
+    const result = await handler('s', { action: 'har' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.log).toBeDefined();
+    expect(body.log.version).toBe('1.2');
+    expect(body.log.creator.name).toBe('opensafari');
+    expect(body.log.entries).toEqual([]);
+
+    await handler('s', { action: 'stop' });
+  });
+
+  it('stops proxy and reports entries captured', async () => {
+    await handler('s', { action: 'start', port: 18891 });
+
+    const result = await handler('s', { action: 'stop' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('stopped');
+    expect(body.entries_captured).toBe(0);
+  });
+
+  it('prevents starting duplicate proxy', async () => {
+    await handler('s', { action: 'start', port: 18892 });
+
+    const result = await handler('s', { action: 'start', port: 18893 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.error).toContain('already running');
+
+    await handler('s', { action: 'stop' });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `flutter_network` tool with HTTP proxy-based traffic capture
- Actions: start, log, har, stop — full lifecycle management
- HAR 1.2 export for Chrome DevTools / HAR Viewer compatibility

## How It Works
```
flutter_network({ action: "start", port: 8888 })
  → Local HTTP proxy starts on 127.0.0.1:8888
  → Simulator proxy settings configured via simctl

flutter_network({ action: "log", filter_url: "api.example.com" })
  → Returns captured requests matching filter

flutter_network({ action: "har" })
  → Exports all captured traffic as HAR 1.2 JSON

flutter_network({ action: "stop" })
  → Stops proxy, restores simulator settings
```

## Features
- URL and status code filtering for log retrieval
- Request/response size and timing tracking
- Per-device proxy isolation (multi-simulator safe)
- Auto-cleanup of simulator proxy settings on stop
- 1000 entry buffer with FIFO eviction

## Test plan
- [x] 7 unit tests pass (start, log, har, stop, duplicate prevention)
- [x] Build succeeds
- [ ] Manual: Start proxy → make requests from Flutter app → log shows entries
- [ ] Manual: HAR export viewable in Chrome DevTools Network tab

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)