### PR TITLE
feat(flutter): add flutter_toggle_debug_paint tool (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **`flutter_build_mode`** (#442): New MCP tool that detects the Flutter build mode (debug / profile / release) of the running app and reports which opensafari tools are usable in that mode. Use it when `flutter_connect` fails to distinguish between a release build (VM Service disabled by design) and a configuration issue. Returns a `capabilities` map plus a `fallback_tools` list for release builds.
+- **`flutter_toggle_debug_paint`** (#437): New MCP tool that flips Flutter's debug paint overlays (`size`, `baseline`, `repaint_rainbow`) and `time_dilation`, plus an `all_off` reset mode. Backed by `ext.flutter.debugPaint` / `ext.flutter.debugPaintBaselinesEnabled` / `ext.flutter.repaintRainbow` / `ext.flutter.timeDilation`. Useful for diagnosing overflow, padding, and repaint issues via `app_screenshot_native`.
 
 ## [0.2.1] - 2026-04-05
 

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -114,6 +114,9 @@ export const TOOL_TIERS: Record<string, number> = {
   // Tier 2: Flutter Build Mode Detector (issue #442)
   flutter_build_mode: 2,
 
+  // Tier 2: Flutter Debug Paint Overlays (issue #437)
+  flutter_toggle_debug_paint: 2,
+
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   app_tap_element: 2,
   // Tier 2: Native App — Semantic Wait & Assert (Flutter-compatible)

--- a/src/tools/flutter-debug-paint.ts
+++ b/src/tools/flutter-debug-paint.ts
@@ -1,0 +1,143 @@
+/**
+ * flutter_toggle_debug_paint — Toggle Flutter's built-in debug paint flags
+ * (layout bounds, baselines, repaint rainbow) and time dilation.
+ *
+ * Motivation (issue #437): overflow, bad padding, and unintended Expanded
+ * behaviour are hard to diagnose from screenshots alone. The Flutter
+ * framework exposes debug overlays that are trivial to toggle through the
+ * VM Service but have not been exposed as an MCP tool yet.
+ *
+ * Modes:
+ *   - "size"             → ext.flutter.debugPaint                  (layout bounds)
+ *   - "baseline"         → ext.flutter.debugPaintBaselinesEnabled  (text baselines)
+ *   - "repaint_rainbow"  → ext.flutter.repaintRainbow              (repaint regions)
+ *   - "time_dilation"    → ext.flutter.timeDilation                (slow-motion)
+ *   - "all_off"          → resets all of the above                 (sanity / restore)
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient } from '../flutter';
+import { getSessionManager } from '../session-manager';
+
+export type DebugPaintMode =
+  | 'size'
+  | 'baseline'
+  | 'repaint_rainbow'
+  | 'time_dilation'
+  | 'all_off';
+
+const MODE_TO_EXTENSION: Record<Exclude<DebugPaintMode, 'time_dilation' | 'all_off'>, string> = {
+  size: 'debugPaint',
+  baseline: 'debugPaintBaselinesEnabled',
+  repaint_rainbow: 'repaintRainbow',
+};
+
+export function registerFlutterDebugPaintTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_toggle_debug_paint',
+      description:
+        'Toggle Flutter debug overlays (layout bounds, baselines, repaint rainbow) ' +
+        'or time dilation on a connected Flutter app. Use size/baseline/repaint_rainbow ' +
+        'with enable=true/false to flip flags; use time_dilation with dilation_factor ' +
+        'to slow animations (1.0 = normal, 2.0 = half speed); use all_off to reset ' +
+        'every flag. Requires an active flutter_connect session (debug/profile builds).',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          mode: {
+            type: 'string',
+            enum: ['size', 'baseline', 'repaint_rainbow', 'time_dilation', 'all_off'],
+            description: 'Which debug overlay to toggle.',
+          },
+          enable: {
+            type: 'boolean',
+            description: 'For size / baseline / repaint_rainbow: turn the overlay on or off.',
+          },
+          dilation_factor: {
+            type: 'number',
+            description: 'For time_dilation: multiplier (1.0 = normal speed, 2.0 = half speed).',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: ['mode'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const mode = params.mode as DebugPaintMode | undefined;
+        if (!mode) {
+          throw new Error('mode is required (size | baseline | repaint_rainbow | time_dilation | all_off)');
+        }
+
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device. Boot a simulator first.');
+        }
+
+        const client = getFlutterVMClient(deviceId);
+        if (!client.isConnected()) {
+          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+        }
+
+        const results: Array<{ extension: string; params: Record<string, unknown> }> = [];
+
+        if (mode === 'all_off') {
+          // Reset every flag we know about.
+          await client.callServiceExtension('debugPaint', { enabled: 'false' });
+          results.push({ extension: 'ext.flutter.debugPaint', params: { enabled: 'false' } });
+
+          await client.callServiceExtension('debugPaintBaselinesEnabled', { enabled: 'false' });
+          results.push({ extension: 'ext.flutter.debugPaintBaselinesEnabled', params: { enabled: 'false' } });
+
+          await client.callServiceExtension('repaintRainbow', { enabled: 'false' });
+          results.push({ extension: 'ext.flutter.repaintRainbow', params: { enabled: 'false' } });
+
+          await client.callServiceExtension('timeDilation', { timeDilation: '1.0' });
+          results.push({ extension: 'ext.flutter.timeDilation', params: { timeDilation: '1.0' } });
+        } else if (mode === 'time_dilation') {
+          const factor = params.dilation_factor;
+          if (typeof factor !== 'number' || !Number.isFinite(factor) || factor <= 0) {
+            throw new Error('dilation_factor must be a positive number (1.0 = normal)');
+          }
+          await client.callServiceExtension('timeDilation', { timeDilation: String(factor) });
+          results.push({ extension: 'ext.flutter.timeDilation', params: { timeDilation: String(factor) } });
+        } else {
+          const enable = params.enable;
+          if (typeof enable !== 'boolean') {
+            throw new Error(`mode "${mode}" requires enable (boolean)`);
+          }
+          const extensionName = MODE_TO_EXTENSION[mode];
+          const payload = { enabled: enable ? 'true' : 'false' };
+          await client.callServiceExtension(extensionName, payload);
+          results.push({ extension: `ext.flutter.${extensionName}`, params: payload });
+        }
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'ok',
+              mode,
+              applied: results,
+              deviceId,
+              hint: 'Call app_screenshot_native to capture the updated overlay, then all_off to restore.',
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_toggle_debug_paint] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/flutter-debug-paint.ts
+++ b/src/tools/flutter-debug-paint.ts
@@ -85,28 +85,46 @@ export function registerFlutterDebugPaintTool(server: MCPServer): void {
           throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
         }
 
-        const results: Array<{ extension: string; params: Record<string, unknown> }> = [];
+        type Applied = { extension: string; params: Record<string, unknown>; ok: true };
+        type Failure = { extension: string; params: Record<string, unknown>; ok: false; error: string };
+        const applied: Array<Applied | Failure> = [];
 
         if (mode === 'all_off') {
-          // Reset every flag we know about.
-          await client.callServiceExtension('debugPaint', { enabled: 'false' });
-          results.push({ extension: 'ext.flutter.debugPaint', params: { enabled: 'false' } });
+          // Reset every known flag. Use Promise.allSettled so one broken
+          // extension does not leave the app in a half-toggled state —
+          // the caller sees exactly which resets succeeded.
+          const resets: Array<{ ext: string; payload: Record<string, unknown> }> = [
+            { ext: 'debugPaint',                 payload: { enabled: 'false' } },
+            { ext: 'debugPaintBaselinesEnabled', payload: { enabled: 'false' } },
+            { ext: 'repaintRainbow',             payload: { enabled: 'false' } },
+            { ext: 'timeDilation',               payload: { timeDilation: '1.0' } },
+          ];
 
-          await client.callServiceExtension('debugPaintBaselinesEnabled', { enabled: 'false' });
-          results.push({ extension: 'ext.flutter.debugPaintBaselinesEnabled', params: { enabled: 'false' } });
+          const settled = await Promise.allSettled(
+            resets.map((r) => client.callServiceExtension(r.ext, r.payload)),
+          );
 
-          await client.callServiceExtension('repaintRainbow', { enabled: 'false' });
-          results.push({ extension: 'ext.flutter.repaintRainbow', params: { enabled: 'false' } });
-
-          await client.callServiceExtension('timeDilation', { timeDilation: '1.0' });
-          results.push({ extension: 'ext.flutter.timeDilation', params: { timeDilation: '1.0' } });
+          settled.forEach((s, idx) => {
+            const { ext, payload } = resets[idx];
+            if (s.status === 'fulfilled') {
+              applied.push({ extension: `ext.flutter.${ext}`, params: payload, ok: true });
+            } else {
+              const message = s.reason instanceof Error ? s.reason.message : String(s.reason);
+              applied.push({ extension: `ext.flutter.${ext}`, params: payload, ok: false, error: message });
+            }
+          });
         } else if (mode === 'time_dilation') {
           const factor = params.dilation_factor;
           if (typeof factor !== 'number' || !Number.isFinite(factor) || factor <= 0) {
             throw new Error('dilation_factor must be a positive number (1.0 = normal)');
           }
+          if (factor > 1000) {
+            // Upper bound: very large dilation effectively freezes animations
+            // and makes the UI unusable without benefit.
+            throw new Error('dilation_factor must be <= 1000 (larger values freeze the UI)');
+          }
           await client.callServiceExtension('timeDilation', { timeDilation: String(factor) });
-          results.push({ extension: 'ext.flutter.timeDilation', params: { timeDilation: String(factor) } });
+          applied.push({ extension: 'ext.flutter.timeDilation', params: { timeDilation: String(factor) }, ok: true });
         } else {
           const enable = params.enable;
           if (typeof enable !== 'boolean') {
@@ -115,16 +133,19 @@ export function registerFlutterDebugPaintTool(server: MCPServer): void {
           const extensionName = MODE_TO_EXTENSION[mode];
           const payload = { enabled: enable ? 'true' : 'false' };
           await client.callServiceExtension(extensionName, payload);
-          results.push({ extension: `ext.flutter.${extensionName}`, params: payload });
+          applied.push({ extension: `ext.flutter.${extensionName}`, params: payload, ok: true });
         }
+
+        const failures = applied.filter((a): a is Failure => a.ok === false);
 
         return {
           content: [{
             type: 'text' as const,
             text: JSON.stringify({
-              status: 'ok',
+              status: failures.length === 0 ? 'ok' : 'partial',
               mode,
-              applied: results,
+              applied,
+              failures: failures.length === 0 ? undefined : failures.length,
               deviceId,
               hint: 'Call app_screenshot_native to capture the updated overlay, then all_off to restore.',
             }, null, 2),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -89,6 +89,7 @@ import { registerFlutterHotReloadTool } from './flutter-hot-reload';
 import { registerFlutterLogsTool } from './flutter-logs';
 import { registerFlutterNetworkTool } from './flutter-network';
 import { registerFlutterBuildModeTool } from './flutter-build-mode';
+import { registerFlutterDebugPaintTool } from './flutter-debug-paint';
 import { registerAppTapElementTool } from './app-tap-element';
 import { registerAppWaitForNativeTool } from './app-wait-for';
 import { registerAppAssertElementTool } from './app-assert-element';
@@ -252,6 +253,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Tier 2: Flutter Build Mode Detector (issue #442)
   registerFlutterBuildModeTool(server);
+
+  // Tier 2: Flutter Debug Paint Overlays (issue #437)
+  registerFlutterDebugPaintTool(server);
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   registerAppTapElementTool(server);

--- a/tests/unit/flutter-debug-paint.test.ts
+++ b/tests/unit/flutter-debug-paint.test.ts
@@ -83,6 +83,13 @@ describe('flutter_toggle_debug_paint', () => {
     expect(result.isError).toBe(true);
   });
 
+  it('rejects dilation_factor above upper bound (> 1000)', async () => {
+    const result = await handler('s', { mode: 'time_dilation', dilation_factor: 5000 });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('<= 1000');
+    expect(mockCallServiceExtension).not.toHaveBeenCalled();
+  });
+
   it('rejects missing enable flag for size/baseline/repaint_rainbow', async () => {
     const result = await handler('s', { mode: 'size' });
     expect(result.isError).toBe(true);
@@ -103,6 +110,35 @@ describe('flutter_toggle_debug_paint', () => {
     const timeDilationCall = mockCallServiceExtension.mock.calls.find((c) => c[0] === 'timeDilation');
     expect(timeDilationCall?.[1]).toEqual({ timeDilation: '1.0' });
     expect(body.applied).toHaveLength(4);
+    expect(body.status).toBe('ok');
+    expect(body.failures).toBeUndefined();
+    expect(body.applied.every((a: { ok: boolean }) => a.ok === true)).toBe(true);
+  });
+
+  it('all_off tolerates partial failure and reports status="partial" with per-extension errors', async () => {
+    // Third call (repaintRainbow) rejects; the other three must still execute
+    // and the tool must return status: "partial" with one ok:false entry.
+    let call = 0;
+    mockCallServiceExtension.mockImplementation(async () => {
+      call += 1;
+      if (call === 3) throw new Error('extension not registered');
+      return {};
+    });
+
+    const result = await handler('s', { mode: 'all_off' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeUndefined();
+    expect(body.status).toBe('partial');
+    expect(body.failures).toBe(1);
+    expect(body.applied).toHaveLength(4);
+
+    const ok = body.applied.filter((a: { ok: boolean }) => a.ok);
+    const failed = body.applied.filter((a: { ok: boolean }) => !a.ok);
+    expect(ok).toHaveLength(3);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].extension).toBe('ext.flutter.repaintRainbow');
+    expect(failed[0].error).toContain('extension not registered');
   });
 
   it('errors when not connected', async () => {

--- a/tests/unit/flutter-debug-paint.test.ts
+++ b/tests/unit/flutter-debug-paint.test.ts
@@ -155,3 +155,5 @@ describe('flutter_toggle_debug_paint', () => {
     expect(result.content[0].text).toContain('mode is required');
   });
 });
+
+export {};

--- a/tests/unit/flutter-debug-paint.test.ts
+++ b/tests/unit/flutter-debug-paint.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for flutter_toggle_debug_paint (issue #437).
+ */
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({ getSoleDeviceId: () => 'test-device-id' }),
+}));
+
+const mockIsConnected = jest.fn();
+const mockCallServiceExtension = jest.fn();
+
+jest.mock('../../src/flutter', () => ({
+  getFlutterVMClient: () => ({
+    isConnected: mockIsConnected,
+    callServiceExtension: mockCallServiceExtension,
+  }),
+}));
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+describe('flutter_toggle_debug_paint', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterDebugPaintTool } = require('../../src/tools/flutter-debug-paint');
+    registerFlutterDebugPaintTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockCallServiceExtension.mockResolvedValue({});
+  });
+
+  it('registers with the expected name and required field', () => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterDebugPaintTool } = require('../../src/tools/flutter-debug-paint');
+    registerFlutterDebugPaintTool(server);
+    const def = server.registerTool.mock.calls[0][0];
+    expect(def.name).toBe('flutter_toggle_debug_paint');
+    expect(def.inputSchema.required).toEqual(['mode']);
+  });
+
+  it('toggles layout bounds (size mode, enable=true)', async () => {
+    const result = await handler('s', { mode: 'size', enable: true });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockCallServiceExtension).toHaveBeenCalledWith('debugPaint', { enabled: 'true' });
+    expect(body.status).toBe('ok');
+    expect(body.mode).toBe('size');
+    expect(body.applied[0].extension).toBe('ext.flutter.debugPaint');
+  });
+
+  it('disables baseline paint (enable=false)', async () => {
+    const result = await handler('s', { mode: 'baseline', enable: false });
+    expect(result.isError).toBeUndefined();
+    expect(mockCallServiceExtension).toHaveBeenCalledWith('debugPaintBaselinesEnabled', { enabled: 'false' });
+  });
+
+  it('toggles repaint rainbow', async () => {
+    await handler('s', { mode: 'repaint_rainbow', enable: true });
+    expect(mockCallServiceExtension).toHaveBeenCalledWith('repaintRainbow', { enabled: 'true' });
+  });
+
+  it('applies time dilation', async () => {
+    await handler('s', { mode: 'time_dilation', dilation_factor: 2.5 });
+    expect(mockCallServiceExtension).toHaveBeenCalledWith('timeDilation', { timeDilation: '2.5' });
+  });
+
+  it('rejects invalid dilation_factor (negative)', async () => {
+    const result = await handler('s', { mode: 'time_dilation', dilation_factor: -1 });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('positive number');
+    expect(mockCallServiceExtension).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing dilation_factor', async () => {
+    const result = await handler('s', { mode: 'time_dilation' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects missing enable flag for size/baseline/repaint_rainbow', async () => {
+    const result = await handler('s', { mode: 'size' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('requires enable');
+  });
+
+  it('all_off resets every flag including time dilation', async () => {
+    const result = await handler('s', { mode: 'all_off' });
+    const body = JSON.parse(result.content[0].text);
+
+    const extCalls = mockCallServiceExtension.mock.calls.map((c) => c[0]);
+    expect(extCalls).toEqual(expect.arrayContaining([
+      'debugPaint',
+      'debugPaintBaselinesEnabled',
+      'repaintRainbow',
+      'timeDilation',
+    ]));
+    const timeDilationCall = mockCallServiceExtension.mock.calls.find((c) => c[0] === 'timeDilation');
+    expect(timeDilationCall?.[1]).toEqual({ timeDilation: '1.0' });
+    expect(body.applied).toHaveLength(4);
+  });
+
+  it('errors when not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+    const result = await handler('s', { mode: 'size', enable: true });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Not connected');
+    expect(mockCallServiceExtension).not.toHaveBeenCalled();
+  });
+
+  it('errors when mode is missing', async () => {
+    const result = await handler('s', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('mode is required');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `flutter_toggle_debug_paint` MCP tool with 5 modes: `size`, `baseline`, `repaint_rainbow`, `time_dilation`, `all_off`
- Wraps Flutter's built-in debug paint service extensions (`ext.flutter.debugPaint`, `ext.flutter.debugPaintBaselinesEnabled`, `ext.flutter.repaintRainbow`, `ext.flutter.timeDilation`)
- `all_off` resets every flag including `timeDilation: 1.0` — handy for restoring clean screenshots

Closes #437.

## Design

Single-tool-with-`mode` over multiple tools — keeps the registered-tool count down. Input validation:
- `size` / `baseline` / `repaint_rainbow` require `enable` (bool)
- `time_dilation` requires `dilation_factor` (positive number; rejects `0`, negatives, and `NaN`)
- `all_off` needs no other params

## Files touched

- `src/tools/flutter-debug-paint.ts` (new)
- `tests/unit/flutter-debug-paint.test.ts` (new) — 11 tests
- `src/tools/index.ts` — register tool
- `src/config/tool-tiers.ts` — Tier 2
- `CHANGELOG.md` — Unreleased entry

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest tests/unit/flutter-debug-paint.test.ts` → **11/11 passing**
  - size/baseline/repaint_rainbow toggle correct extensions with `enabled: "true"|"false"`
  - time_dilation forwards numeric factor as string payload
  - invalid dilation (negative, missing) → structured error, no RPC call
  - missing `enable` for bool modes → structured error
  - `all_off` fires 4 RPCs (size + baseline + repaint + timeDilation reset)
  - Disconnected client → structured error
- [ ] Manual integration: connect a sample Flutter app, toggle `size` + `app_screenshot_native` shows widget bounds; `all_off` restores original. Pending simulator access.

## Batch

Batch 1 PR 2/3 of Flutter VM-Service parity work (tracked by #434–#442). Sibling PRs: #443 (build_mode). Next up: #434 (evaluate).

Generated with [Claude Code](https://claude.com/claude-code)