### PR TITLE
feat(flutter): add generic service-extension caller (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - **`flutter_build_mode`** (#442): New MCP tool that detects the Flutter build mode (debug / profile / release) of the running app and reports which opensafari tools are usable in that mode. Use it when `flutter_connect` fails to distinguish between a release build (VM Service disabled by design) and a configuration issue. Returns a `capabilities` map plus a `fallback_tools` list for release builds.
 - **`flutter_toggle_debug_paint`** (#437): New MCP tool that flips Flutter's debug paint overlays (`size`, `baseline`, `repaint_rainbow`) and `time_dilation`, plus an `all_off` reset mode. Backed by `ext.flutter.debugPaint` / `ext.flutter.debugPaintBaselinesEnabled` / `ext.flutter.repaintRainbow` / `ext.flutter.timeDilation`. Useful for diagnosing overflow, padding, and repaint issues via `app_screenshot_native`.
+- **`flutter_list_service_extensions`** (#441): Enumerates every VM Service extension registered by the running Flutter app — including third-party ones (`ext.riverpod.*`, `ext.isar.*`, BLoC observers) — with an optional `prefix` filter. Groups results by namespace for easy LLM consumption.
+- **`flutter_call_service_extension`** (#441): Generic invoker for any service extension. Auto-injects `isolateId`, enforces an `ext.` prefix, validates `args` is an object, audit-logs every call to stderr. Covers Riverpod / BLoC / Isar / etc. without shipping per-library wrappers (Option B from the issue).
 
 ## [0.2.1] - 2026-04-05
 

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -116,6 +116,9 @@ export const TOOL_TIERS: Record<string, number> = {
 
   // Tier 2: Flutter Debug Paint Overlays (issue #437)
   flutter_toggle_debug_paint: 2,
+  // Tier 2: Flutter Service Extensions (issue #441)
+  flutter_list_service_extensions: 2,
+  flutter_call_service_extension: 2,
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   app_tap_element: 2,

--- a/src/tools/flutter-service-extensions.ts
+++ b/src/tools/flutter-service-extensions.ts
@@ -162,9 +162,19 @@ export function registerFlutterCallServiceExtensionTool(server: MCPServer): void
           throw new Error('No main isolate available.');
         }
 
+        // Defensive: strip any caller-supplied `isolateId` before spreading,
+        // then add the auto-injected one. This guarantees the tool's promised
+        // "isolateId is injected for you" contract — a caller that passes
+        // {args: {isolateId: "other"}} cannot silently retarget the RPC.
+        const callerArgs = (args as Record<string, unknown> | undefined) ?? {};
+        if (Object.prototype.hasOwnProperty.call(callerArgs, 'isolateId')) {
+          console.error(`[flutter_call_service_extension] warning: caller-supplied isolateId ignored (auto-injected ${isolateId})`);
+        }
+        const { isolateId: _ignored, ...safeArgs } = callerArgs;
+        void _ignored;
         const result = await client.callMethod(extension, {
+          ...safeArgs,
           isolateId,
-          ...(args as Record<string, unknown> | undefined ?? {}),
         });
 
         return {

--- a/src/tools/flutter-service-extensions.ts
+++ b/src/tools/flutter-service-extensions.ts
@@ -1,0 +1,191 @@
+/**
+ * Generic Flutter service-extension access (issue #441).
+ *
+ * Two MCP tools that let callers enumerate and invoke any VM Service
+ * extension registered by the running app — including third-party ones
+ * like riverpod_devtools (`ext.riverpod.*`), Isar, BLoC observer, etc.
+ *
+ * Keeping this generic (Option B in the issue) avoids shipping a
+ * dedicated tool per library. Library-specific wrappers (e.g. a
+ * `flutter_riverpod_read` convenience) can be layered on top in a
+ * follow-up if a specific ecosystem proves valuable enough.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient } from '../flutter';
+import { getSessionManager } from '../session-manager';
+
+async function resolveClient(paramDeviceId: unknown) {
+  const deviceId =
+    (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
+    getSessionManager().getSoleDeviceId();
+  if (!deviceId) {
+    throw new Error('No device specified and no active device. Boot a simulator first.');
+  }
+  const client = getFlutterVMClient(deviceId);
+  if (!client.isConnected()) {
+    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+  }
+  return { deviceId, client };
+}
+
+// ── flutter_list_service_extensions ─────────────────────────────────────────
+
+export function registerFlutterListServiceExtensionsTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_list_service_extensions',
+      description:
+        'List all service extensions registered by the running Flutter app ' +
+        '(framework ext.flutter.*, dart dev extensions, and third-party ' +
+        'extensions such as ext.riverpod.* from the riverpod_devtools package). ' +
+        'Pair with flutter_call_service_extension to invoke any of them. ' +
+        'Requires an active flutter_connect session.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          prefix: {
+            type: 'string',
+            description: 'Optional prefix filter (e.g. "ext.riverpod." to see only Riverpod extensions).',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const { deviceId, client } = await resolveClient(params.device_id);
+        const isolate = await client.getIsolate();
+        const raw = (isolate as Record<string, unknown>).extensionRPCs;
+        const all = Array.isArray(raw) ? raw.filter((x): x is string => typeof x === 'string') : [];
+
+        const prefix = typeof params.prefix === 'string' ? params.prefix : undefined;
+        const filtered = prefix ? all.filter((ext) => ext.startsWith(prefix)) : all;
+
+        // Group by namespace for easier LLM consumption.
+        const namespaces: Record<string, string[]> = {};
+        for (const ext of filtered) {
+          const parts = ext.split('.');
+          // "ext.flutter.inspector.show" → "ext.flutter.inspector"
+          const ns = parts.slice(0, Math.min(3, parts.length - 1)).join('.') || ext;
+          if (!namespaces[ns]) namespaces[ns] = [];
+          namespaces[ns].push(ext);
+        }
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'ok',
+              deviceId,
+              count: filtered.length,
+              total_registered: all.length,
+              extensions: filtered.sort(),
+              namespaces,
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_list_service_extensions] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+// ── flutter_call_service_extension ──────────────────────────────────────────
+
+export function registerFlutterCallServiceExtensionTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_call_service_extension',
+      description:
+        'Invoke any VM Service extension registered by the running Flutter app. ' +
+        'The isolate id is injected automatically. Use flutter_list_service_extensions ' +
+        'first to discover what is available. Example: ' +
+        '{ extension: "ext.riverpod.providers", args: {} } returns the Riverpod provider map ' +
+        'when the riverpod_devtools package is installed. ' +
+        'SECURITY: invoking arbitrary extensions runs code inside the connected app process — ' +
+        'treat `extension` and `args` with the same care as flutter_evaluate.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          extension: {
+            type: 'string',
+            description: 'Fully-qualified service extension name, e.g. "ext.flutter.debugPaint" or "ext.riverpod.providers".',
+          },
+          args: {
+            type: 'object',
+            description: 'Arguments to forward to the extension (excluding isolateId, which is injected).',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: ['extension'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const extension = params.extension;
+        if (typeof extension !== 'string' || extension.trim().length === 0) {
+          throw new Error('extension is required (non-empty string)');
+        }
+        if (!extension.startsWith('ext.')) {
+          throw new Error(`extension must start with "ext." (got "${extension}")`);
+        }
+
+        const args = params.args;
+        if (args !== undefined && (typeof args !== 'object' || args === null || Array.isArray(args))) {
+          throw new Error('args must be an object or omitted');
+        }
+
+        const { deviceId, client } = await resolveClient(params.device_id);
+
+        // Audit: every call is logged so the threat model matches flutter_evaluate.
+        console.error(`[flutter_call_service_extension] audit: invoking ${extension} on ${deviceId}`);
+
+        // callServiceExtension auto-prefixes "ext.flutter." for bare names — we
+        // want full-name passthrough here, so call callMethod directly with the
+        // fully qualified extension and inject isolateId.
+        const isolateId = client.getState()?.mainIsolateId;
+        if (!isolateId) {
+          throw new Error('No main isolate available.');
+        }
+
+        const result = await client.callMethod(extension, {
+          isolateId,
+          ...(args as Record<string, unknown> | undefined ?? {}),
+        });
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'ok',
+              deviceId,
+              extension,
+              result,
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_call_service_extension] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -90,6 +90,10 @@ import { registerFlutterLogsTool } from './flutter-logs';
 import { registerFlutterNetworkTool } from './flutter-network';
 import { registerFlutterBuildModeTool } from './flutter-build-mode';
 import { registerFlutterDebugPaintTool } from './flutter-debug-paint';
+import {
+  registerFlutterListServiceExtensionsTool,
+  registerFlutterCallServiceExtensionTool,
+} from './flutter-service-extensions';
 import { registerAppTapElementTool } from './app-tap-element';
 import { registerAppWaitForNativeTool } from './app-wait-for';
 import { registerAppAssertElementTool } from './app-assert-element';
@@ -256,6 +260,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Tier 2: Flutter Debug Paint Overlays (issue #437)
   registerFlutterDebugPaintTool(server);
+  // Tier 2: Flutter Service Extensions (issue #441)
+  registerFlutterListServiceExtensionsTool(server);
+  registerFlutterCallServiceExtensionTool(server);
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   registerAppTapElementTool(server);

--- a/tests/unit/flutter-service-extensions.test.ts
+++ b/tests/unit/flutter-service-extensions.test.ts
@@ -231,3 +231,5 @@ describe('flutter_call_service_extension', () => {
     expect(result.content[0].text).toContain('not registered');
   });
 });
+
+export {};

--- a/tests/unit/flutter-service-extensions.test.ts
+++ b/tests/unit/flutter-service-extensions.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for flutter_list_service_extensions + flutter_call_service_extension (issue #441).
+ */
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({ getSoleDeviceId: () => 'test-device-id' }),
+}));
+
+const mockIsConnected = jest.fn();
+const mockGetIsolate = jest.fn();
+const mockCallMethod = jest.fn();
+const mockGetState = jest.fn();
+
+jest.mock('../../src/flutter', () => ({
+  getFlutterVMClient: () => ({
+    isConnected: mockIsConnected,
+    getIsolate: mockGetIsolate,
+    callMethod: mockCallMethod,
+    getState: mockGetState,
+  }),
+}));
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+describe('flutter_list_service_extensions', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterListServiceExtensionsTool } = require('../../src/tools/flutter-service-extensions');
+    registerFlutterListServiceExtensionsTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+  });
+
+  it('registers with the expected name', () => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterListServiceExtensionsTool } = require('../../src/tools/flutter-service-extensions');
+    registerFlutterListServiceExtensionsTool(server);
+    expect(server.registerTool.mock.calls[0][0].name).toBe('flutter_list_service_extensions');
+  });
+
+  it('returns all extensions and groups by namespace', async () => {
+    mockGetIsolate.mockResolvedValue({
+      extensionRPCs: [
+        'ext.flutter.debugPaint',
+        'ext.flutter.inspector.show',
+        'ext.riverpod.providers',
+      ],
+    });
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.count).toBe(3);
+    expect(body.total_registered).toBe(3);
+    expect(body.extensions).toEqual([
+      'ext.flutter.debugPaint',
+      'ext.flutter.inspector.show',
+      'ext.riverpod.providers',
+    ]);
+    expect(body.namespaces['ext.flutter']).toContain('ext.flutter.debugPaint');
+    expect(body.namespaces['ext.flutter.inspector']).toContain('ext.flutter.inspector.show');
+    expect(body.namespaces['ext.riverpod']).toContain('ext.riverpod.providers');
+  });
+
+  it('filters by prefix', async () => {
+    mockGetIsolate.mockResolvedValue({
+      extensionRPCs: [
+        'ext.flutter.debugPaint',
+        'ext.flutter.inspector.show',
+        'ext.riverpod.providers',
+      ],
+    });
+
+    const result = await handler('s', { prefix: 'ext.riverpod.' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.count).toBe(1);
+    expect(body.total_registered).toBe(3);
+    expect(body.extensions).toEqual(['ext.riverpod.providers']);
+  });
+
+  it('handles isolate with no extensionRPCs array', async () => {
+    mockGetIsolate.mockResolvedValue({}); // missing field
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+    expect(body.count).toBe(0);
+    expect(body.extensions).toEqual([]);
+  });
+
+  it('errors when not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+    const result = await handler('s', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Not connected');
+  });
+});
+
+describe('flutter_call_service_extension', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterCallServiceExtensionTool } = require('../../src/tools/flutter-service-extensions');
+    registerFlutterCallServiceExtensionTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+  });
+
+  it('registers with the expected name and required field', () => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterCallServiceExtensionTool } = require('../../src/tools/flutter-service-extensions');
+    registerFlutterCallServiceExtensionTool(server);
+    const def = server.registerTool.mock.calls[0][0];
+    expect(def.name).toBe('flutter_call_service_extension');
+    expect(def.inputSchema.required).toEqual(['extension']);
+  });
+
+  it('invokes the extension with isolateId auto-injected', async () => {
+    mockCallMethod.mockResolvedValue({ providers: [] });
+
+    const result = await handler('s', {
+      extension: 'ext.riverpod.providers',
+      args: { scope: 'global' },
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockCallMethod).toHaveBeenCalledWith('ext.riverpod.providers', {
+      isolateId: 'iso-1',
+      scope: 'global',
+    });
+    expect(body.status).toBe('ok');
+    expect(body.result).toEqual({ providers: [] });
+  });
+
+  it('works without args', async () => {
+    mockCallMethod.mockResolvedValue({});
+    await handler('s', { extension: 'ext.flutter.debugPaint' });
+    expect(mockCallMethod).toHaveBeenCalledWith('ext.flutter.debugPaint', {
+      isolateId: 'iso-1',
+    });
+  });
+
+  it('rejects missing extension', async () => {
+    const result = await handler('s', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('extension is required');
+  });
+
+  it('rejects empty or whitespace extension', async () => {
+    const r1 = await handler('s', { extension: '' });
+    const r2 = await handler('s', { extension: '   ' });
+    expect(r1.isError).toBe(true);
+    expect(r2.isError).toBe(true);
+  });
+
+  it('rejects extension without ext. prefix', async () => {
+    const result = await handler('s', { extension: 'flutter.debugPaint' });
+    expect(result.isError).toBe(true);
+    // The message survives JSON.stringify, which escapes the inner quotes.
+    expect(result.content[0].text).toContain('must start with');
+    expect(result.content[0].text).toContain('flutter.debugPaint');
+  });
+
+  it('rejects non-object args', async () => {
+    const result = await handler('s', { extension: 'ext.foo', args: 'oops' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('args must be an object');
+  });
+
+  it('rejects array args', async () => {
+    const result = await handler('s', { extension: 'ext.foo', args: [1, 2] });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('args must be an object');
+  });
+
+  it('errors when not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+    const result = await handler('s', { extension: 'ext.foo' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Not connected');
+  });
+
+  it('logs an audit message for every call', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockCallMethod.mockResolvedValue({});
+    await handler('s', { extension: 'ext.riverpod.providers' });
+    const auditCall = spy.mock.calls.find((c) => String(c[0]).includes('audit'));
+    expect(auditCall).toBeDefined();
+    expect(String(auditCall?.[0])).toContain('ext.riverpod.providers');
+    spy.mockRestore();
+  });
+
+  it('propagates RPC errors as tool errors', async () => {
+    mockCallMethod.mockRejectedValue(new Error('RPC_ERROR: extension not registered'));
+    const result = await handler('s', { extension: 'ext.unknown' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not registered');
+  });
+});

--- a/tests/unit/flutter-service-extensions.test.ts
+++ b/tests/unit/flutter-service-extensions.test.ts
@@ -205,6 +205,25 @@ describe('flutter_call_service_extension', () => {
     spy.mockRestore();
   });
 
+  it('ignores caller-supplied isolateId in args and warns', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockCallMethod.mockResolvedValue({});
+
+    await handler('s', {
+      extension: 'ext.foo',
+      args: { isolateId: 'attacker-chosen', scope: 'global' },
+    });
+
+    // Auto-injected isolateId must win, and scope must still be forwarded.
+    expect(mockCallMethod).toHaveBeenCalledWith('ext.foo', {
+      scope: 'global',
+      isolateId: 'iso-1',
+    });
+    const warning = spy.mock.calls.find((c) => String(c[0]).includes('isolateId ignored'));
+    expect(warning).toBeDefined();
+    spy.mockRestore();
+  });
+
   it('propagates RPC errors as tool errors', async () => {
     mockCallMethod.mockRejectedValue(new Error('RPC_ERROR: extension not registered'));
     const result = await handler('s', { extension: 'ext.unknown' });


### PR DESCRIPTION
## Summary

Two MCP tools that cover Riverpod, BLoC, Isar, and any other VM-Service-registered extension in one shot.

- `flutter_list_service_extensions({ prefix? })` — enumerates `extensionRPCs` on the main isolate, groups by namespace
- `flutter_call_service_extension({ extension, args? })` — invokes any `ext.*` RPC with auto-injected `isolateId`

Closes #441. Ships the generic path (Option B) rather than library-specific wrappers.

## Why generic over Riverpod-specific

- Shipping `flutter_riverpod_*` wrappers would require tracking API changes in a third-party package.
- Same code path already works for BLoC observers, Isar, logger extensions, and the framework's own `ext.flutter.*`.
- LLM-friendly workflow: `list` → find the extension → `call` — no prior knowledge of which package is in use.

Riverpod usage example is documented in the PR description so the value is obvious without a separate tool.

## Design

```
flutter_list_service_extensions({
  prefix?: string,       // e.g. "ext.riverpod." to filter
  device_id?: string,
})
// → { extensions: string[], namespaces: Record<string, string[]>, count, total_registered }

flutter_call_service_extension({
  extension: string,     // must start with "ext."
  args?: object,         // not string, not array
  device_id?: string,
})
// → { status: "ok", extension, result }
```

**Security**: same threat model as `flutter_evaluate` — arbitrary extension invocation runs in the app process. Tool description calls this out and every call is audit-logged via `console.error`.

## Files touched

- `src/tools/flutter-service-extensions.ts` (new)
- `tests/unit/flutter-service-extensions.test.ts` (new) — 16 tests
- `src/tools/index.ts` — register both tools
- `src/config/tool-tiers.ts` — Tier 2
- `CHANGELOG.md` — Unreleased

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest tests/unit/flutter-service-extensions.test.ts` → **16/16 passing**
  - `list`: all extensions returned, namespace grouping, prefix filter, missing extensionRPCs, disconnected error
  - `call`: happy path with args, no-args case, missing/empty/whitespace extension rejected, non-`ext.*` prefix rejected, non-object and array args rejected, disconnected error, audit log present, RPC error propagation
- [ ] Manual integration: connect to an app with `riverpod_devtools` installed, call `list({prefix:"ext.riverpod."})`, then `call({extension:"ext.riverpod.providers"})`. Pending simulator access.

## Batch

Batch 3 PR 1/4. Next up: memory (#440), CPU/timeline (#439), breakpoints (#435).

Generated with [Claude Code](https://claude.com/claude-code)