### PR TITLE
feat(flutter): add flutter_cpu_profile and flutter_timeline_capture (#439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - **`flutter_root_widget`** (#436): Dumps the running Flutter app's widget summary tree via `ext.flutter.inspector.getRootWidgetSummaryTreeWithPreviews`. Each node includes `type`, `description`, and `creationLocation` (file:line:column) so callers can jump straight to the source.
 - **`flutter_inspect_selection`** (#436): Returns the currently selected widget via `ext.flutter.inspector.getSelectedSummaryWidget`, with an optional `show` flag that toggles the in-app inspector overlay (`ext.flutter.inspector.show`) to arm coordinate-based selection. Empty selection returns `status: "empty"` with a usage hint.
 - **`FlutterVMClient.getRootWidgetSummaryTree` / `getSelectedWidget` / `setInspectorShow`**: New VM-client helpers wrapping the Flutter Inspector service extensions. The coordinate→widget tool (`flutter_widget_at_point`) is deferred to a follow-up issue — it requires a toggle/tap/read sequence coupled to `app_tap`.
+- **`flutter_cpu_profile`** (#439): Samples the Dart VM CPU profiler via `getCpuSamples` for a configurable window (max 120s) and returns a top-N list of `{function, self_us, total_us, samples}`. Pure `aggregateCpuSamples` helper is exported for independent unit testing — it counts self-samples (top-of-stack only) vs total-samples (anywhere in stack) and converts both to microseconds via the payload's `samplePeriod`.
+- **`flutter_timeline_capture`** (#439): Enables VM timeline streams (default `["Dart", "GC", "Embedder"]`), waits a window, fetches `getVMTimeline`, and writes the result to `output_path` as Chrome Trace Event JSON — loadable in `chrome://tracing` or Perfetto. Unknown stream names are rejected before any VM call.
 
 ## [0.2.1] - 2026-04-05
 

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -124,6 +124,9 @@ export const TOOL_TIERS: Record<string, number> = {
   // Tier 2: Flutter Inspector (issue #436)
   flutter_root_widget: 2,
   flutter_inspect_selection: 2,
+  // Tier 2: Flutter Performance Profiling (issue #439)
+  flutter_cpu_profile: 2,
+  flutter_timeline_capture: 2,
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   app_tap_element: 2,

--- a/src/tools/flutter-cpu-profile.ts
+++ b/src/tools/flutter-cpu-profile.ts
@@ -283,34 +283,47 @@ export function registerFlutterTimelineCaptureTool(server: MCPServer): void {
         await client.callMethod('setVMTimelineFlags', { recordedStreams: streams });
 
         const started = Date.now();
-        await sleep(durationMs);
 
-        const raw = await client.callMethod('getVMTimeline');
-        const traceEvents = (raw as { traceEvents?: unknown[] }).traceEvents ?? [];
+        // Anything past this point must restore timeline flags before returning —
+        // a disk-full / permission-denied / RPC failure after enabling would
+        // otherwise leave the VM recording streams indefinitely, growing its
+        // internal timeline buffer and skewing every subsequent capture.
+        try {
+          await sleep(durationMs);
 
-        // Chrome Trace Format: top-level object with traceEvents array.
-        const chromeTrace = JSON.stringify({ traceEvents, displayTimeUnit: 'ms' });
+          const raw = await client.callMethod('getVMTimeline');
+          const traceEvents = (raw as { traceEvents?: unknown[] }).traceEvents ?? [];
 
-        const absolute = path.isAbsolute(outputPath) ? outputPath : path.resolve(process.cwd(), outputPath);
-        await fs.mkdir(path.dirname(absolute), { recursive: true });
-        await fs.writeFile(absolute, chromeTrace, 'utf8');
+          // Chrome Trace Format: top-level object with traceEvents array.
+          const chromeTrace = JSON.stringify({ traceEvents, displayTimeUnit: 'ms' });
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              status: 'ok',
-              deviceId,
-              duration_ms: durationMs,
-              streams,
-              output_path: absolute,
-              size_bytes: Buffer.byteLength(chromeTrace, 'utf8'),
-              event_count: Array.isArray(traceEvents) ? traceEvents.length : 0,
-              elapsed_ms: Date.now() - started,
-              hint: 'Open this file in chrome://tracing or import into Perfetto.',
-            }, null, 2),
-          }],
-        };
+          const absolute = path.isAbsolute(outputPath) ? outputPath : path.resolve(process.cwd(), outputPath);
+          await fs.mkdir(path.dirname(absolute), { recursive: true });
+          await fs.writeFile(absolute, chromeTrace, 'utf8');
+
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify({
+                status: 'ok',
+                deviceId,
+                duration_ms: durationMs,
+                streams,
+                output_path: absolute,
+                size_bytes: Buffer.byteLength(chromeTrace, 'utf8'),
+                event_count: Array.isArray(traceEvents) ? traceEvents.length : 0,
+                elapsed_ms: Date.now() - started,
+                hint: 'Open this file in chrome://tracing or import into Perfetto.',
+              }, null, 2),
+            }],
+          };
+        } finally {
+          try {
+            await client.callMethod('setVMTimelineFlags', { recordedStreams: [] });
+          } catch (resetErr) {
+            console.error(`[flutter_timeline_capture] failed to reset timeline flags: ${resetErr instanceof Error ? resetErr.message : String(resetErr)}`);
+          }
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         console.error(`[flutter_timeline_capture] ${message}`);

--- a/src/tools/flutter-cpu-profile.ts
+++ b/src/tools/flutter-cpu-profile.ts
@@ -1,0 +1,324 @@
+/**
+ * flutter_cpu_profile + flutter_timeline_capture (issue #439).
+ *
+ * Two MCP tools for performance investigation:
+ *
+ *   - flutter_cpu_profile: samples the Dart VM's CPU profiler for a time
+ *     window via getCpuSamples, aggregates per-function self_us / total_us,
+ *     returns a top-N list ready for LLM reading.
+ *
+ *   - flutter_timeline_capture: enables the requested timeline streams,
+ *     waits a window, reads getVMTimeline, and writes the result to disk
+ *     as Chrome Trace Event JSON loadable in chrome://tracing or Perfetto.
+ *
+ * Profile builds give the most accurate results (debug has overhead that
+ * skews the flamegraph). Both tools require an active flutter_connect
+ * session and are deliberately gated to reasonable durations.
+ */
+
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient, FlutterVMError } from '../flutter';
+import { getSessionManager } from '../session-manager';
+
+const MAX_DURATION_MS = 120_000; // 2 minutes — longer windows balloon response size
+
+async function resolveClient(paramDeviceId: unknown) {
+  const deviceId =
+    (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
+    getSessionManager().getSoleDeviceId();
+  if (!deviceId) {
+    throw new Error('No device specified and no active device. Boot a simulator first.');
+  }
+  const client = getFlutterVMClient(deviceId);
+  if (!client.isConnected()) {
+    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+  }
+  return { deviceId, client };
+}
+
+function validateDuration(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) {
+    throw new Error('duration_ms must be a positive number');
+  }
+  if (raw > MAX_DURATION_MS) {
+    throw new Error(`duration_ms must be <= ${MAX_DURATION_MS} (got ${raw})`);
+  }
+  return Math.floor(raw);
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => {
+  const t = setTimeout(resolve, ms);
+  t.unref?.();
+});
+
+// ── CPU profile aggregation ─────────────────────────────────────────────────
+
+export interface FunctionStat {
+  function: string;
+  resolved_url?: string;
+  self_us: number;
+  total_us: number;
+  self_samples: number;
+  total_samples: number;
+}
+
+interface CpuSamplesPayload {
+  samples?: Array<{
+    stack?: number[];
+    tid?: number;
+    timestamp?: number;
+  }>;
+  functions?: Array<{
+    function?: { name?: string; type?: string };
+    resolvedUrl?: string;
+    kind?: string;
+    [k: string]: unknown;
+  }>;
+  samplePeriod?: number; // microseconds per sample
+  timeSpan?: number;
+  [k: string]: unknown;
+}
+
+/**
+ * Aggregate a `getCpuSamples` payload into a per-function statistics map.
+ * `self_us` counts only samples where the function appears at the top of
+ * the stack; `total_us` counts samples where it appears anywhere. Both
+ * are expressed in microseconds using the payload's `samplePeriod`.
+ */
+export function aggregateCpuSamples(payload: CpuSamplesPayload): FunctionStat[] {
+  const functions = Array.isArray(payload.functions) ? payload.functions : [];
+  const samples = Array.isArray(payload.samples) ? payload.samples : [];
+  const samplePeriod = typeof payload.samplePeriod === 'number' && payload.samplePeriod > 0
+    ? payload.samplePeriod
+    : 1; // fallback: treat each sample as 1us so ratios are still meaningful
+
+  const selfCounts = new Map<number, number>();
+  const totalCounts = new Map<number, number>();
+
+  for (const sample of samples) {
+    const stack = Array.isArray(sample.stack) ? sample.stack : [];
+    if (stack.length === 0) continue;
+    const top = stack[0];
+    if (typeof top === 'number') {
+      selfCounts.set(top, (selfCounts.get(top) ?? 0) + 1);
+    }
+    const unique = new Set<number>();
+    for (const fn of stack) {
+      if (typeof fn === 'number') unique.add(fn);
+    }
+    for (const fn of unique) {
+      totalCounts.set(fn, (totalCounts.get(fn) ?? 0) + 1);
+    }
+  }
+
+  const stats: FunctionStat[] = [];
+  for (let i = 0; i < functions.length; i += 1) {
+    const entry = functions[i];
+    if (!entry) continue;
+    const selfSamples = selfCounts.get(i) ?? 0;
+    const totalSamples = totalCounts.get(i) ?? 0;
+    if (selfSamples === 0 && totalSamples === 0) continue;
+    stats.push({
+      function: entry.function?.name ?? `fn#${i}`,
+      resolved_url: typeof entry.resolvedUrl === 'string' ? entry.resolvedUrl : undefined,
+      self_us: selfSamples * samplePeriod,
+      total_us: totalSamples * samplePeriod,
+      self_samples: selfSamples,
+      total_samples: totalSamples,
+    });
+  }
+
+  stats.sort((a, b) => b.self_us - a.self_us);
+  return stats;
+}
+
+export function registerFlutterCpuProfileTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_cpu_profile',
+      description:
+        'Sample the Dart VM CPU profiler for a time window and return a ' +
+        'top-N list of {function, self_us, total_us, samples}. Wraps ' +
+        'getCpuSamples. Profile builds produce the most accurate data; ' +
+        'debug builds work but include framework overhead. Max duration 120s.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          duration_ms: {
+            type: 'number',
+            description: 'Sampling window in milliseconds (max 120000).',
+          },
+          top_n: {
+            type: 'number',
+            description: 'Maximum rows to return sorted by self_us (default: 20).',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: ['duration_ms'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const durationMs = validateDuration(params.duration_ms);
+        const topN = typeof params.top_n === 'number' && params.top_n > 0
+          ? Math.min(Math.floor(params.top_n), 500)
+          : 20;
+
+        const { deviceId, client } = await resolveClient(params.device_id);
+        const isolateId = client.getState()?.mainIsolateId;
+        if (!isolateId) throw new FlutterVMError('No main isolate found', 'NO_ISOLATE');
+
+        const startMicros = Date.now() * 1000;
+        await sleep(durationMs);
+        const extentMicros = durationMs * 1000;
+
+        const raw = await client.callMethod('getCpuSamples', {
+          isolateId,
+          timeOriginMicros: startMicros,
+          timeExtentMicros: extentMicros,
+        });
+        const stats = aggregateCpuSamples(raw as CpuSamplesPayload);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'ok',
+              deviceId,
+              duration_ms: durationMs,
+              sample_count: Array.isArray((raw as CpuSamplesPayload).samples)
+                ? ((raw as CpuSamplesPayload).samples as unknown[]).length
+                : 0,
+              total_functions: stats.length,
+              top_functions: stats.slice(0, topN),
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_cpu_profile] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+// ── Timeline capture ────────────────────────────────────────────────────────
+
+const DEFAULT_TIMELINE_STREAMS = ['Dart', 'GC', 'Embedder'] as const;
+const ALLOWED_TIMELINE_STREAMS = new Set([
+  'Dart', 'GC', 'Embedder', 'Compiler', 'CompilerVerbose', 'Debugger',
+  'Isolate', 'VM', 'API', 'Microtask',
+]);
+
+export function validateTimelineStreams(raw: unknown): string[] {
+  if (raw === undefined) return [...DEFAULT_TIMELINE_STREAMS];
+  if (!Array.isArray(raw)) {
+    throw new Error('streams must be an array of strings');
+  }
+  const seen = new Set<string>();
+  for (const s of raw) {
+    if (typeof s !== 'string') throw new Error('streams must be an array of strings');
+    if (!ALLOWED_TIMELINE_STREAMS.has(s)) {
+      throw new Error(`unknown timeline stream "${s}" (allowed: ${[...ALLOWED_TIMELINE_STREAMS].join(', ')})`);
+    }
+    seen.add(s);
+  }
+  return [...seen];
+}
+
+export function registerFlutterTimelineCaptureTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_timeline_capture',
+      description:
+        'Enable VM timeline streams for a window, then export the captured ' +
+        'events as Chrome Trace JSON (loadable in chrome://tracing or Perfetto). ' +
+        'Default streams are Dart + GC + Embedder; pass "streams" to override. ' +
+        'Output is written to output_path so large traces do not balloon the MCP response. ' +
+        'Max duration 120s.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          duration_ms: {
+            type: 'number',
+            description: 'Capture window in milliseconds (max 120000).',
+          },
+          output_path: {
+            type: 'string',
+            description: 'File path to write the Chrome Trace JSON output.',
+          },
+          streams: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Timeline streams to record. Default: ["Dart", "GC", "Embedder"].',
+          },
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: ['duration_ms', 'output_path'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const durationMs = validateDuration(params.duration_ms);
+        const outputPath = params.output_path;
+        if (typeof outputPath !== 'string' || outputPath.trim().length === 0) {
+          throw new Error('output_path is required (non-empty string)');
+        }
+        const streams = validateTimelineStreams(params.streams);
+
+        const { deviceId, client } = await resolveClient(params.device_id);
+
+        await client.callMethod('setVMTimelineFlags', { recordedStreams: streams });
+
+        const started = Date.now();
+        await sleep(durationMs);
+
+        const raw = await client.callMethod('getVMTimeline');
+        const traceEvents = (raw as { traceEvents?: unknown[] }).traceEvents ?? [];
+
+        // Chrome Trace Format: top-level object with traceEvents array.
+        const chromeTrace = JSON.stringify({ traceEvents, displayTimeUnit: 'ms' });
+
+        const absolute = path.isAbsolute(outputPath) ? outputPath : path.resolve(process.cwd(), outputPath);
+        await fs.mkdir(path.dirname(absolute), { recursive: true });
+        await fs.writeFile(absolute, chromeTrace, 'utf8');
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'ok',
+              deviceId,
+              duration_ms: durationMs,
+              streams,
+              output_path: absolute,
+              size_bytes: Buffer.byteLength(chromeTrace, 'utf8'),
+              event_count: Array.isArray(traceEvents) ? traceEvents.length : 0,
+              elapsed_ms: Date.now() - started,
+              hint: 'Open this file in chrome://tracing or import into Perfetto.',
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_timeline_capture] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -99,6 +99,10 @@ import {
   registerFlutterRootWidgetTool,
   registerFlutterInspectSelectionTool,
 } from './flutter-inspector';
+import {
+  registerFlutterCpuProfileTool,
+  registerFlutterTimelineCaptureTool,
+} from './flutter-cpu-profile';
 import { registerAppTapElementTool } from './app-tap-element';
 import { registerAppWaitForNativeTool } from './app-wait-for';
 import { registerAppAssertElementTool } from './app-assert-element';
@@ -273,6 +277,9 @@ export function registerAllTools(server: MCPServer): void {
   // Tier 2: Flutter Inspector (issue #436)
   registerFlutterRootWidgetTool(server);
   registerFlutterInspectSelectionTool(server);
+  // Tier 2: Flutter Performance Profiling (issue #439)
+  registerFlutterCpuProfileTool(server);
+  registerFlutterTimelineCaptureTool(server);
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   registerAppTapElementTool(server);

--- a/tests/unit/flutter-cpu-profile.test.ts
+++ b/tests/unit/flutter-cpu-profile.test.ts
@@ -308,3 +308,5 @@ describe('flutter_timeline_capture handler', () => {
     expect(setCalls[1].params).toEqual({ recordedStreams: [] });
   });
 });
+
+export {};

--- a/tests/unit/flutter-cpu-profile.test.ts
+++ b/tests/unit/flutter-cpu-profile.test.ts
@@ -287,4 +287,24 @@ describe('flutter_timeline_capture handler', () => {
     const result = await handler('s', { duration_ms: 10, output_path: '/tmp/x.json' });
     expect(result.isError).toBe(true);
   });
+
+  it('resets timeline flags when writeFile fails (P1 regression)', async () => {
+    const unwritable = '/proc/0/should-not-work/trace.json';
+
+    const calls: Array<{ method: string; params: Record<string, unknown> | undefined }> = [];
+    mockCallMethod.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (method === 'getVMTimeline') return { traceEvents: [] };
+      return {};
+    });
+
+    const result = await handler('s', { duration_ms: 10, output_path: unwritable });
+    expect(result.isError).toBe(true);
+
+    // setVMTimelineFlags must have been called twice: once to enable, once to reset.
+    const setCalls = calls.filter((c) => c.method === 'setVMTimelineFlags');
+    expect(setCalls.length).toBe(2);
+    expect(setCalls[0].params).toEqual({ recordedStreams: ['Dart', 'GC', 'Embedder'] });
+    expect(setCalls[1].params).toEqual({ recordedStreams: [] });
+  });
 });

--- a/tests/unit/flutter-cpu-profile.test.ts
+++ b/tests/unit/flutter-cpu-profile.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for flutter_cpu_profile + flutter_timeline_capture (issue #439).
+ */
+
+import {
+  aggregateCpuSamples,
+  validateTimelineStreams,
+} from '../../src/tools/flutter-cpu-profile';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({ getSoleDeviceId: () => 'test-device-id' }),
+}));
+
+const mockIsConnected = jest.fn();
+const mockCallMethod = jest.fn();
+const mockGetState = jest.fn();
+
+jest.mock('../../src/flutter', () => ({
+  getFlutterVMClient: () => ({
+    isConnected: mockIsConnected,
+    callMethod: mockCallMethod,
+    getState: mockGetState,
+  }),
+  FlutterVMError: class extends Error {
+    constructor(msg: string, public readonly code: string) { super(msg); }
+  },
+}));
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+// ── aggregateCpuSamples ─────────────────────────────────────────────────────
+
+describe('aggregateCpuSamples', () => {
+  const payload = {
+    samplePeriod: 1000, // 1000us per sample
+    functions: [
+      { function: { name: 'main' }, resolvedUrl: 'package:app/main.dart' },
+      { function: { name: 'build' }, resolvedUrl: 'package:flutter/src/widgets/framework.dart' },
+      { function: { name: 'paint' } },
+    ],
+    samples: [
+      { stack: [1, 0] },        // build (top), main
+      { stack: [2, 1, 0] },     // paint (top), build, main
+      { stack: [1, 0] },        // build (top), main
+      { stack: [0] },           // main (top)
+    ],
+  };
+
+  it('counts self and total samples per function', () => {
+    const stats = aggregateCpuSamples(payload);
+
+    const main = stats.find((s) => s.function === 'main')!;
+    const build = stats.find((s) => s.function === 'build')!;
+    const paint = stats.find((s) => s.function === 'paint')!;
+
+    // self: main at top once; build at top twice; paint at top once
+    expect(main.self_samples).toBe(1);
+    expect(build.self_samples).toBe(2);
+    expect(paint.self_samples).toBe(1);
+
+    // total: main appears in all 4 stacks; build in 3; paint in 1
+    expect(main.total_samples).toBe(4);
+    expect(build.total_samples).toBe(3);
+    expect(paint.total_samples).toBe(1);
+  });
+
+  it('converts sample counts to microseconds via samplePeriod', () => {
+    const stats = aggregateCpuSamples(payload);
+    const build = stats.find((s) => s.function === 'build')!;
+    expect(build.self_us).toBe(2 * 1000);
+    expect(build.total_us).toBe(3 * 1000);
+  });
+
+  it('sorts descending by self_us', () => {
+    const stats = aggregateCpuSamples(payload);
+    expect(stats[0].function).toBe('build');
+    expect(stats[0].self_us).toBeGreaterThanOrEqual(stats[1].self_us);
+  });
+
+  it('drops functions that never appear in any sample', () => {
+    const stats = aggregateCpuSamples({
+      samplePeriod: 1,
+      functions: [
+        { function: { name: 'used' } },
+        { function: { name: 'never-called' } },
+      ],
+      samples: [{ stack: [0] }],
+    });
+    expect(stats.map((s) => s.function)).toEqual(['used']);
+  });
+
+  it('tolerates malformed samples', () => {
+    const stats = aggregateCpuSamples({
+      samplePeriod: 1,
+      functions: [{ function: { name: 'ok' } }],
+      samples: [{}, { stack: 'oops' } as unknown as { stack: number[] }, { stack: [0] }],
+    });
+    expect(stats[0].function).toBe('ok');
+    expect(stats[0].self_samples).toBe(1);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(aggregateCpuSamples({})).toEqual([]);
+  });
+
+  it('falls back to samplePeriod=1 when missing', () => {
+    const stats = aggregateCpuSamples({
+      functions: [{ function: { name: 'a' } }],
+      samples: [{ stack: [0] }],
+    });
+    expect(stats[0].self_us).toBe(1);
+  });
+});
+
+// ── validateTimelineStreams ─────────────────────────────────────────────────
+
+describe('validateTimelineStreams', () => {
+  it('returns defaults when undefined', () => {
+    expect(validateTimelineStreams(undefined)).toEqual(['Dart', 'GC', 'Embedder']);
+  });
+
+  it('accepts the default set', () => {
+    expect(validateTimelineStreams(['Dart', 'GC'])).toEqual(['Dart', 'GC']);
+  });
+
+  it('dedupes', () => {
+    expect(validateTimelineStreams(['Dart', 'Dart', 'GC'])).toEqual(['Dart', 'GC']);
+  });
+
+  it('rejects non-array', () => {
+    expect(() => validateTimelineStreams('Dart')).toThrow('array of strings');
+  });
+
+  it('rejects non-string element', () => {
+    expect(() => validateTimelineStreams(['Dart', 42])).toThrow('array of strings');
+  });
+
+  it('rejects unknown stream', () => {
+    expect(() => validateTimelineStreams(['NotAStream'])).toThrow('unknown timeline stream');
+  });
+});
+
+// ── flutter_cpu_profile handler ─────────────────────────────────────────────
+
+describe('flutter_cpu_profile handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterCpuProfileTool } = require('../../src/tools/flutter-cpu-profile');
+    registerFlutterCpuProfileTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+  });
+
+  it('rejects missing duration_ms', async () => {
+    const result = await handler('s', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('duration_ms must be a positive number');
+  });
+
+  it('rejects duration_ms above the 120s cap', async () => {
+    const result = await handler('s', { duration_ms: 200_000 });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('must be <=');
+  });
+
+  it('forwards isolate and time window to getCpuSamples', async () => {
+    mockCallMethod.mockResolvedValue({
+      samplePeriod: 1000,
+      functions: [{ function: { name: 'main' } }],
+      samples: [{ stack: [0] }],
+    });
+
+    const result = await handler('s', { duration_ms: 10 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockCallMethod).toHaveBeenCalledWith('getCpuSamples', expect.objectContaining({
+      isolateId: 'iso-1',
+      timeExtentMicros: 10_000,
+    }));
+    expect(body.status).toBe('ok');
+    expect(body.top_functions[0].function).toBe('main');
+    expect(body.sample_count).toBe(1);
+  });
+
+  it('errors when not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+    const result = await handler('s', { duration_ms: 10 });
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ── flutter_timeline_capture handler ────────────────────────────────────────
+
+describe('flutter_timeline_capture handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterTimelineCaptureTool } = require('../../src/tools/flutter-cpu-profile');
+    registerFlutterTimelineCaptureTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+  });
+
+  it('rejects missing required fields', async () => {
+    const r1 = await handler('s', {});
+    expect(r1.isError).toBe(true);
+    const r2 = await handler('s', { duration_ms: 10 });
+    expect(r2.isError).toBe(true);
+    expect(r2.content[0].text).toContain('output_path');
+  });
+
+  it('sets timeline streams, waits, fetches timeline, writes file', async () => {
+    mockCallMethod.mockImplementation(async (method: string) => {
+      if (method === 'setVMTimelineFlags') return {};
+      if (method === 'getVMTimeline') {
+        return { traceEvents: [{ name: 'frame', ph: 'X', pid: 1, tid: 2, ts: 100, dur: 500 }] };
+      }
+      return {};
+    });
+
+    const outPath = path.join(os.tmpdir(), `opensafari-timeline-${Date.now()}.json`);
+    try {
+      const result = await handler('s', { duration_ms: 10, output_path: outPath });
+      expect(result.isError).toBeUndefined();
+      const body = JSON.parse(result.content[0].text);
+
+      expect(body.status).toBe('ok');
+      expect(body.event_count).toBe(1);
+      expect(body.streams).toEqual(['Dart', 'GC', 'Embedder']);
+
+      // Verify setVMTimelineFlags got the defaults.
+      const setCall = mockCallMethod.mock.calls.find((c) => c[0] === 'setVMTimelineFlags');
+      expect(setCall?.[1]).toEqual({ recordedStreams: ['Dart', 'GC', 'Embedder'] });
+
+      // Verify file written with Chrome Trace shape.
+      const written = JSON.parse(await fs.readFile(outPath, 'utf8'));
+      expect(Array.isArray(written.traceEvents)).toBe(true);
+      expect(written.traceEvents[0].name).toBe('frame');
+      expect(written.displayTimeUnit).toBe('ms');
+    } finally {
+      await fs.unlink(outPath).catch(() => {});
+    }
+  });
+
+  it('forwards custom streams', async () => {
+    mockCallMethod.mockResolvedValue({ traceEvents: [] });
+    const outPath = path.join(os.tmpdir(), `opensafari-timeline-${Date.now()}-custom.json`);
+    try {
+      await handler('s', { duration_ms: 10, output_path: outPath, streams: ['Dart', 'Compiler'] });
+      const setCall = mockCallMethod.mock.calls.find((c) => c[0] === 'setVMTimelineFlags');
+      expect(setCall?.[1]).toEqual({ recordedStreams: ['Dart', 'Compiler'] });
+    } finally {
+      await fs.unlink(outPath).catch(() => {});
+    }
+  });
+
+  it('rejects unknown stream name without touching the VM', async () => {
+    const result = await handler('s', {
+      duration_ms: 10,
+      output_path: '/tmp/should-not-write.json',
+      streams: ['NotReal'],
+    });
+    expect(result.isError).toBe(true);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it('errors when not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+    const result = await handler('s', { duration_ms: 10, output_path: '/tmp/x.json' });
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two MCP tools for CPU/frame-performance investigation:

- `flutter_cpu_profile({ duration_ms, top_n? })` — samples the Dart VM CPU profiler over a window and returns a top-N list of `{function, self_us, total_us, samples}`.
- `flutter_timeline_capture({ duration_ms, output_path, streams? })` — records VM timeline streams to a Chrome Trace JSON file for flame-chart analysis in `chrome://tracing` or Perfetto.

Closes #439.

## Design

**cpu_profile**: waits `duration_ms`, reads `getCpuSamples(isolateId, timeOriginMicros, timeExtentMicros)` for that window, aggregates per-function samples. `self_samples` = top-of-stack occurrences, `total_samples` = stack-membership occurrences (dedup'd per sample). Conversion to microseconds uses the payload's `samplePeriod` (fallback 1 if absent).

**timeline_capture**: enables streams via `setVMTimelineFlags({ recordedStreams })`, waits, reads `getVMTimeline`. Writes `{ traceEvents, displayTimeUnit: "ms" }` — the Chrome Trace Event envelope — to `output_path`. Unknown stream names rejected up-front so the VM is never left with garbage flags.

Both tools cap `duration_ms` at 120s (longer windows balloon response size and risk connection timeouts).

## Files touched

- `src/tools/flutter-cpu-profile.ts` (new) — two tools + exported `aggregateCpuSamples`, `validateTimelineStreams`
- `tests/unit/flutter-cpu-profile.test.ts` (new) — 22 tests
- `src/tools/index.ts` — register both tools
- `src/config/tool-tiers.ts` — Tier 2
- `CHANGELOG.md` — Unreleased

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest tests/unit/flutter-cpu-profile.test.ts` → **22/22 passing**
  - `aggregateCpuSamples`: self/total counts, microsecond conversion, sort order, dropping never-called functions, malformed samples, empty input, samplePeriod fallback
  - `validateTimelineStreams`: defaults, dedup, reject non-array / non-string / unknown names
  - `cpu_profile` handler: missing/over-cap duration, RPC forwarding, disconnected error
  - `timeline_capture` handler: missing required fields, setFlags + getTimeline + file write, custom streams, unknown-stream rejection (no VM call), disconnected error
- [ ] Manual integration (profile build): drive a known-hot loop during `flutter_cpu_profile` → expect that function at top of the list. Pending simulator access.
- [ ] Manual: load resulting Chrome Trace JSON in `chrome://tracing`. Pending simulator.

## Batch

Batch 3 PR 3/4. Pairs with #441, #440. Next: breakpoints (#435).

Generated with [Claude Code](https://claude.com/claude-code)