### PR TITLE
feat(flutter): add breakpoint / step debugging (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to this project will be documented in this file.
 - **`flutter_track_rebuilds`** (#438): New MCP tool that drives the Flutter framework's dirty-widget rebuild tracker. `action: "start"` enables `ext.flutter.inspector.trackRebuildDirtyWidgets` and subscribes to `Flutter.RebuildWidgets` events on the `Extension` stream; `action: "report"` returns a top-N list of `{widget, file:line, rebuild_count}`; `action: "stop"` disables tracking and cleans up. Optional `duration_ms` on `start` arms an auto-stop. Aggregation is capped at 10,000 events per tracker to prevent memory growth.
 - **`flutter_allocation_profile`** (#440): Captures a per-class allocation profile via VM Service `getAllocationProfile`. Supports `gc_before` to force a major GC before sampling, and `diff_against_previous` to return `delta_instances` / `delta_bytes` against the prior call on the same device — the standard leak-hunt pattern (baseline → action → diff). Drops zero-instance rows, sorts descending by live bytes (or absolute delta in diff mode).
 - **`flutter_heap_snapshot`** (#440): Requests a full Dart heap snapshot via `requestHeapSnapshot`, drains `HeapSnapshot` stream chunks to a Buffer, and writes the result to `output_path` as a binary file importable by Flutter DevTools' Memory tab. Configurable `timeout_ms` (default 60s, max 10min).
+- **Breakpoint / step debugging** (#435): Five new MCP tools that drive the Dart VM Service debugger end-to-end.
+  - `flutter_set_breakpoint({ script_uri, line, column? })` — wraps `addBreakpointWithScriptUri`
+  - `flutter_remove_breakpoint({ breakpoint_id })` — wraps `removeBreakpoint`
+  - `flutter_resume({ mode: "continue" | "step_into" | "step_over" | "step_out" })` — wraps `resume` with the matching `step` token
+  - `flutter_get_stack({ limit? })` — wraps `getStack` with a compact per-frame summary (`function`, `location: {script_uri, line}`, `vars`)
+  - `flutter_wait_for_pause({ timeout_ms?, poll_interval_ms? })` — polls for pause state, mirroring `app_wait_for`; returns `{timeout: true}` on timeout
+- Per-device `BreakpointManager` lazily subscribes to the `Debug` stream and tracks pause state + active breakpoints. Pure helpers `resumeModeToStep`, `summariseFrame`, `_resetBreakpointManagers` exported for testability.
 
 ## [0.2.1] - 2026-04-05
 

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -132,6 +132,12 @@ export const TOOL_TIERS: Record<string, number> = {
   // Tier 2: Flutter Memory Profiling (issue #440)
   flutter_allocation_profile: 2,
   flutter_heap_snapshot: 2,
+  // Tier 2: Flutter Breakpoint / Step Debugging (issue #435)
+  flutter_set_breakpoint: 2,
+  flutter_remove_breakpoint: 2,
+  flutter_resume: 2,
+  flutter_get_stack: 2,
+  flutter_wait_for_pause: 2,
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   app_tap_element: 2,

--- a/src/tools/flutter-breakpoints.ts
+++ b/src/tools/flutter-breakpoints.ts
@@ -52,14 +52,52 @@ export interface DeviceBreakpointState {
   deviceId: string;
   subscribed: boolean;
   listener?: (ev: FlutterEvent) => void;
+  /**
+   * mainIsolateId at the time the Debug stream was subscribed. A changed
+   * isolateId between calls signals a VM reconnect (flutter_connect after
+   * disconnect, or hot restart with a fresh isolate); we then tear down
+   * and re-subscribe.
+   */
+  subscribedForIsolateId?: string;
   pause: PauseState;
   breakpoints: Map<string, BreakpointInfo>;
 }
 
 const managers = new Map<string, DeviceBreakpointState>();
 
+function unsubscribeIfSubscribed(state: DeviceBreakpointState): void {
+  if (state.subscribed && state.listener) {
+    try {
+      // Use the singleton client for this device; offEvent is a no-op if the
+      // client has already been torn down.
+      getFlutterVMClient(state.deviceId).offEvent('Debug', state.listener);
+    } catch {
+      // ignore — the client may be disconnected or reinitialised.
+    }
+  }
+  state.subscribed = false;
+  state.listener = undefined;
+  state.subscribedForIsolateId = undefined;
+}
+
+/**
+ * Test / diagnostic helper — drop every manager AND offEvent their live
+ * Debug listeners so repeated setup/teardown cannot leak handlers on the
+ * shared VM client.
+ */
 export function _resetBreakpointManagers(): void {
+  for (const state of managers.values()) {
+    unsubscribeIfSubscribed(state);
+  }
   managers.clear();
+}
+
+/** Public: drop the manager for a specific device (e.g. on flutter_connect). */
+export function forgetBreakpointManager(deviceId: string): void {
+  const state = managers.get(deviceId);
+  if (!state) return;
+  unsubscribeIfSubscribed(state);
+  managers.delete(deviceId);
 }
 
 function ensureManager(deviceId: string): DeviceBreakpointState {
@@ -85,9 +123,26 @@ async function ensureDebugSubscription(
   client: {
     streamListen: (streamId: string) => Promise<void>;
     onEvent: (streamId: string, cb: (ev: FlutterEvent) => void) => void;
+    offEvent?: (streamId: string, cb: (ev: FlutterEvent) => void) => void;
+    getState?: () => { mainIsolateId?: string } | null;
   },
   state: DeviceBreakpointState,
 ): Promise<void> {
+  // Detect reconnect: if the live isolate id no longer matches the one we
+  // subscribed against, the VM session has restarted and the underlying
+  // client has cleared its event listeners in disconnect(). Tear down and
+  // re-subscribe so we do not leak "dead" subscribed=true state.
+  const currentIsolateId = client.getState?.()?.mainIsolateId;
+  if (state.subscribed && state.subscribedForIsolateId && currentIsolateId && state.subscribedForIsolateId !== currentIsolateId) {
+    if (state.listener && client.offEvent) {
+      try { client.offEvent('Debug', state.listener); } catch { /* ignore */ }
+    }
+    state.subscribed = false;
+    state.listener = undefined;
+    state.subscribedForIsolateId = undefined;
+    state.pause = { paused: false };
+  }
+
   if (state.subscribed) return;
 
   const listener = (ev: FlutterEvent) => {
@@ -110,6 +165,7 @@ async function ensureDebugSubscription(
     client.onEvent('Debug', listener);
     state.listener = listener;
     state.subscribed = true;
+    state.subscribedForIsolateId = currentIsolateId;
   } catch (err) {
     // Keep subscribed=false so next call retries.
     throw err;

--- a/src/tools/flutter-breakpoints.ts
+++ b/src/tools/flutter-breakpoints.ts
@@ -1,0 +1,532 @@
+/**
+ * Flutter breakpoint / step debugging (issue #435).
+ *
+ * Five MCP tools that let an LLM drive the Dart VM Service debugger:
+ *
+ *   - flutter_set_breakpoint({ script_uri, line })
+ *   - flutter_remove_breakpoint({ breakpoint_id })
+ *   - flutter_resume({ mode: "continue" | "step_into" | "step_over" | "step_out" })
+ *   - flutter_get_stack({ limit? })
+ *   - flutter_wait_for_pause({ timeout_ms? })
+ *
+ * Implementation strategy
+ * -----------------------
+ * We keep a per-device BreakpointManager that (a) lazily subscribes to
+ * the `Debug` event stream the first time any breakpoint-related tool
+ * runs for that device, (b) tracks the current pause state, and (c)
+ * remembers active breakpoint ids. Tools read/mutate that state; the
+ * Debug stream listener updates it from VM events.
+ *
+ * wait_for_pause polls this state with a bounded interval (matching the
+ * app_wait_for / flutter_logs pattern) instead of creating MCP pushes,
+ * so the contract stays request/response.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient, FlutterVMError } from '../flutter';
+import { getSessionManager } from '../session-manager';
+import type { VMServiceEvent } from '../flutter/flutter-types';
+
+type FlutterEvent = VMServiceEvent['params']['event'];
+
+type ResumeMode = 'continue' | 'step_into' | 'step_over' | 'step_out';
+
+// ── Per-device manager ──────────────────────────────────────────────────────
+
+export interface PauseState {
+  paused: boolean;
+  reason?: string;         // e.g. 'PauseBreakpoint' / 'PauseInterrupted'
+  pausedAt?: number;       // Date.now()
+  pauseEvent?: FlutterEvent;
+}
+
+export interface BreakpointInfo {
+  id: string;
+  scriptUri: string;
+  line: number;
+  column?: number;
+  resolved: boolean;
+}
+
+export interface DeviceBreakpointState {
+  deviceId: string;
+  subscribed: boolean;
+  listener?: (ev: FlutterEvent) => void;
+  pause: PauseState;
+  breakpoints: Map<string, BreakpointInfo>;
+}
+
+const managers = new Map<string, DeviceBreakpointState>();
+
+export function _resetBreakpointManagers(): void {
+  managers.clear();
+}
+
+function ensureManager(deviceId: string): DeviceBreakpointState {
+  let state = managers.get(deviceId);
+  if (!state) {
+    state = {
+      deviceId,
+      subscribed: false,
+      pause: { paused: false },
+      breakpoints: new Map(),
+    };
+    managers.set(deviceId, state);
+  }
+  return state;
+}
+
+/**
+ * Lazily subscribe to the `Debug` event stream on first use. Subsequent
+ * calls are no-ops. If the VM stream subscription fails, state.subscribed
+ * stays false so we retry next time.
+ */
+async function ensureDebugSubscription(
+  client: {
+    streamListen: (streamId: string) => Promise<void>;
+    onEvent: (streamId: string, cb: (ev: FlutterEvent) => void) => void;
+  },
+  state: DeviceBreakpointState,
+): Promise<void> {
+  if (state.subscribed) return;
+
+  const listener = (ev: FlutterEvent) => {
+    const kind = (ev as unknown as Record<string, unknown>).kind;
+    if (typeof kind !== 'string') return;
+    if (kind === 'PauseBreakpoint' || kind === 'PauseInterrupted' || kind === 'PauseException' || kind === 'PausePostRequest' || kind === 'PauseStart' || kind === 'PauseExit') {
+      state.pause = {
+        paused: true,
+        reason: kind,
+        pausedAt: Date.now(),
+        pauseEvent: ev,
+      };
+    } else if (kind === 'Resume') {
+      state.pause = { paused: false };
+    }
+  };
+
+  try {
+    await client.streamListen('Debug');
+    client.onEvent('Debug', listener);
+    state.listener = listener;
+    state.subscribed = true;
+  } catch (err) {
+    // Keep subscribed=false so next call retries.
+    throw err;
+  }
+}
+
+// ── Shared resolveClient helper ─────────────────────────────────────────────
+
+async function resolveClient(paramDeviceId: unknown) {
+  const deviceId =
+    (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
+    getSessionManager().getSoleDeviceId();
+  if (!deviceId) {
+    throw new Error('No device specified and no active device. Boot a simulator first.');
+  }
+  const client = getFlutterVMClient(deviceId);
+  if (!client.isConnected()) {
+    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+  }
+  return { deviceId, client };
+}
+
+function requireIsolateId(client: { getState: () => { mainIsolateId?: string } | null }): string {
+  const id = client.getState()?.mainIsolateId;
+  if (!id) throw new FlutterVMError('No main isolate found', 'NO_ISOLATE');
+  return id;
+}
+
+function stripPackagePrefix(uri: string): string {
+  // Leave package: URIs intact; strip leading "./" if present.
+  if (uri.startsWith('./')) return uri.slice(2);
+  return uri;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => { const t = setTimeout(r, ms); t.unref?.(); });
+
+// ── Resume-mode mapping ─────────────────────────────────────────────────────
+
+export function resumeModeToStep(mode: ResumeMode): string | undefined {
+  switch (mode) {
+    case 'continue': return undefined;
+    case 'step_into': return 'Into';
+    case 'step_over': return 'Over';
+    case 'step_out': return 'Out';
+    default: throw new Error(`Unknown resume mode: ${String(mode)}`);
+  }
+}
+
+// ── Public tool registrations ───────────────────────────────────────────────
+
+export function registerFlutterSetBreakpointTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_set_breakpoint',
+      description:
+        'Set a breakpoint in the running Flutter app at script_uri:line via ' +
+        'the VM Service addBreakpointWithScriptUri RPC. script_uri must be a ' +
+        'Dart-resolvable URI — typically "package:<app>/<file>.dart". Pair with ' +
+        'flutter_wait_for_pause + flutter_get_stack to inspect the pause, and ' +
+        'flutter_resume to continue. Debug builds only.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          script_uri: {
+            type: 'string',
+            description: 'Resolvable Dart script URI, e.g. "package:myapp/login_page.dart".',
+          },
+          line: {
+            type: 'number',
+            description: '1-based line number in the script.',
+          },
+          column: {
+            type: 'number',
+            description: 'Optional 1-based column number.',
+          },
+          device_id: { type: 'string', description: 'Simulator UDID (uses active device if omitted)' },
+        },
+        required: ['script_uri', 'line'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const scriptUri = params.script_uri;
+        if (typeof scriptUri !== 'string' || scriptUri.trim().length === 0) {
+          throw new Error('script_uri is required (non-empty string)');
+        }
+        const line = params.line;
+        if (typeof line !== 'number' || !Number.isInteger(line) || line <= 0) {
+          throw new Error('line must be a positive integer');
+        }
+        const column = params.column;
+        if (column !== undefined && (typeof column !== 'number' || !Number.isInteger(column) || column < 0)) {
+          throw new Error('column, if provided, must be a non-negative integer');
+        }
+
+        const { deviceId, client } = await resolveClient(params.device_id);
+        const state = ensureManager(deviceId);
+        await ensureDebugSubscription(client, state);
+
+        const isolateId = requireIsolateId(client);
+        const rpcParams: Record<string, unknown> = {
+          isolateId,
+          scriptUri: stripPackagePrefix(scriptUri),
+          line,
+        };
+        if (column !== undefined) rpcParams.column = column;
+
+        const raw = await client.callMethod('addBreakpointWithScriptUri', rpcParams);
+        const bp = (raw as { id?: string; resolved?: boolean; location?: Record<string, unknown> });
+        const id = typeof bp.id === 'string' ? bp.id : `bp-${Date.now()}`;
+
+        const info: BreakpointInfo = {
+          id,
+          scriptUri,
+          line,
+          column: typeof column === 'number' ? column : undefined,
+          resolved: bp.resolved === true,
+        };
+        state.breakpoints.set(id, info);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'ok',
+              deviceId,
+              breakpoint: info,
+              raw_location: bp.location,
+              hint: 'Call flutter_wait_for_pause to block until the breakpoint fires.',
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_set_breakpoint] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+export function registerFlutterRemoveBreakpointTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_remove_breakpoint',
+      description:
+        'Remove a previously-set breakpoint by id (from flutter_set_breakpoint).',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          breakpoint_id: { type: 'string', description: 'Breakpoint id returned from flutter_set_breakpoint.' },
+          device_id: { type: 'string', description: 'Simulator UDID (uses active device if omitted)' },
+        },
+        required: ['breakpoint_id'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const bpId = params.breakpoint_id;
+        if (typeof bpId !== 'string' || bpId.trim().length === 0) {
+          throw new Error('breakpoint_id is required (non-empty string)');
+        }
+
+        const { deviceId, client } = await resolveClient(params.device_id);
+        const state = ensureManager(deviceId);
+        const isolateId = requireIsolateId(client);
+
+        await client.callMethod('removeBreakpoint', { isolateId, breakpointId: bpId });
+        state.breakpoints.delete(bpId);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({ status: 'ok', deviceId, removed: bpId }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_remove_breakpoint] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+export function registerFlutterResumeTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_resume',
+      description:
+        'Resume a paused Flutter isolate. mode="continue" runs until the next ' +
+        'pause event; mode="step_into" / "step_over" / "step_out" take a single ' +
+        'step. Must be called on a currently-paused isolate (see flutter_wait_for_pause).',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          mode: {
+            type: 'string',
+            enum: ['continue', 'step_into', 'step_over', 'step_out'],
+            description: 'Resume mode (default: "continue").',
+          },
+          device_id: { type: 'string', description: 'Simulator UDID (uses active device if omitted)' },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const modeRaw = params.mode;
+        const mode: ResumeMode =
+          typeof modeRaw === 'string' && ['continue', 'step_into', 'step_over', 'step_out'].includes(modeRaw)
+            ? (modeRaw as ResumeMode)
+            : 'continue';
+
+        const { deviceId, client } = await resolveClient(params.device_id);
+        const state = ensureManager(deviceId);
+        const isolateId = requireIsolateId(client);
+
+        const step = resumeModeToStep(mode);
+        const rpcParams: Record<string, unknown> = { isolateId };
+        if (step !== undefined) rpcParams.step = step;
+
+        await client.callMethod('resume', rpcParams);
+        // The Debug stream Resume event normally clears state; set it eagerly
+        // in case the stream subscription has not yet fired.
+        state.pause = { paused: false };
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({ status: 'ok', deviceId, mode, step }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_resume] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+export function registerFlutterGetStackTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_get_stack',
+      description:
+        'Return the current call stack of the (paused) main isolate via getStack. ' +
+        'Each frame includes function name, script URI, line, and locals scope. ' +
+        'Most useful while the isolate is paused at a breakpoint.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          limit: { type: 'number', description: 'Maximum frames to return from the VM.' },
+          device_id: { type: 'string', description: 'Simulator UDID (uses active device if omitted)' },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const limitRaw = params.limit;
+        if (limitRaw !== undefined && (typeof limitRaw !== 'number' || !Number.isInteger(limitRaw) || limitRaw <= 0)) {
+          throw new Error('limit, if provided, must be a positive integer');
+        }
+
+        const { deviceId, client } = await resolveClient(params.device_id);
+        const isolateId = requireIsolateId(client);
+
+        const rpcParams: Record<string, unknown> = { isolateId };
+        if (typeof limitRaw === 'number') rpcParams.limit = limitRaw;
+
+        const raw = await client.callMethod('getStack', rpcParams);
+        const frames = Array.isArray((raw as { frames?: unknown[] }).frames)
+          ? ((raw as { frames: Array<Record<string, unknown>> }).frames).map((f) => summariseFrame(f))
+          : [];
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'ok',
+              deviceId,
+              truncated: Boolean((raw as { truncated?: boolean }).truncated),
+              frame_count: frames.length,
+              frames,
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_get_stack] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+export interface StackFrameSummary {
+  index: number;
+  function?: string;
+  kind?: string;
+  location?: { script_uri?: string; token_pos?: number; line?: number; column?: number };
+  vars?: string[];
+}
+
+/**
+ * Keep the raw VM frame shape at arm's length — we only expose what LLMs
+ * tend to use. Exported for unit coverage.
+ */
+export function summariseFrame(frame: Record<string, unknown>): StackFrameSummary {
+  const index = typeof frame.index === 'number' ? frame.index : 0;
+  const fn = frame.function as Record<string, unknown> | undefined;
+  const functionName = typeof fn?.name === 'string' ? fn.name : undefined;
+  const kind = typeof frame.kind === 'string' ? frame.kind : undefined;
+  const loc = frame.location as Record<string, unknown> | undefined;
+  const locScript = loc?.script as Record<string, unknown> | undefined;
+
+  const location = loc ? {
+    script_uri: typeof locScript?.uri === 'string' ? locScript.uri : undefined,
+    token_pos: typeof loc.tokenPos === 'number' ? loc.tokenPos : undefined,
+    line: typeof loc.line === 'number' ? loc.line : undefined,
+    column: typeof loc.column === 'number' ? loc.column : undefined,
+  } : undefined;
+
+  const vars = Array.isArray(frame.vars)
+    ? (frame.vars as Array<Record<string, unknown>>)
+        .map((v) => typeof v.name === 'string' ? v.name : null)
+        .filter((n): n is string => n !== null)
+    : undefined;
+
+  return { index, function: functionName, kind, location, vars };
+}
+
+export function registerFlutterWaitForPauseTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'flutter_wait_for_pause',
+      description:
+        'Block (by polling) until the main isolate reports a pause event ' +
+        '(breakpoint hit, paused-on-start, or exception). Returns the pause ' +
+        'reason and timestamp on success, or {timeout: true} after timeout_ms. ' +
+        'Mirrors the app_wait_for pattern.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          timeout_ms: { type: 'number', description: 'Maximum wait in ms (default: 10000, max: 120000).' },
+          poll_interval_ms: { type: 'number', description: 'Polling interval (default 50ms).' },
+          device_id: { type: 'string', description: 'Simulator UDID (uses active device if omitted)' },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const timeoutMs = typeof params.timeout_ms === 'number' && params.timeout_ms > 0
+          ? Math.min(Math.floor(params.timeout_ms), 120_000)
+          : 10_000;
+        const pollInterval = typeof params.poll_interval_ms === 'number' && params.poll_interval_ms > 0
+          ? Math.min(Math.floor(params.poll_interval_ms), 1_000)
+          : 50;
+
+        const { deviceId, client } = await resolveClient(params.device_id);
+        const state = ensureManager(deviceId);
+        await ensureDebugSubscription(client, state);
+
+        const started = Date.now();
+        while (!state.pause.paused) {
+          if (Date.now() - started >= timeoutMs) {
+            return {
+              content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                  status: 'timeout',
+                  timeout: true,
+                  deviceId,
+                  waited_ms: Date.now() - started,
+                }, null, 2),
+              }],
+            };
+          }
+          await sleep(pollInterval);
+        }
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              status: 'paused',
+              deviceId,
+              reason: state.pause.reason,
+              paused_at: state.pause.pausedAt,
+              waited_ms: Date.now() - started,
+              hint: 'Call flutter_get_stack to read the frames, then flutter_resume to continue.',
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[flutter_wait_for_pause] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -108,6 +108,13 @@ import {
   registerFlutterAllocationProfileTool,
   registerFlutterHeapSnapshotTool,
 } from './flutter-memory-profile';
+import {
+  registerFlutterSetBreakpointTool,
+  registerFlutterRemoveBreakpointTool,
+  registerFlutterResumeTool,
+  registerFlutterGetStackTool,
+  registerFlutterWaitForPauseTool,
+} from './flutter-breakpoints';
 import { registerAppTapElementTool } from './app-tap-element';
 import { registerAppWaitForNativeTool } from './app-wait-for';
 import { registerAppAssertElementTool } from './app-assert-element';
@@ -290,6 +297,12 @@ export function registerAllTools(server: MCPServer): void {
   // Tier 2: Flutter Memory Profiling (issue #440)
   registerFlutterAllocationProfileTool(server);
   registerFlutterHeapSnapshotTool(server);
+  // Tier 2: Flutter Breakpoint / Step Debugging (issue #435)
+  registerFlutterSetBreakpointTool(server);
+  registerFlutterRemoveBreakpointTool(server);
+  registerFlutterResumeTool(server);
+  registerFlutterGetStackTool(server);
+  registerFlutterWaitForPauseTool(server);
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   registerAppTapElementTool(server);

--- a/tests/unit/flutter-breakpoints.test.ts
+++ b/tests/unit/flutter-breakpoints.test.ts
@@ -413,3 +413,5 @@ describe('BreakpointManager lifecycle', () => {
     expect(mockOffEvent).toHaveBeenCalledWith('Debug', expect.any(Function));
   });
 });
+
+export {};

--- a/tests/unit/flutter-breakpoints.test.ts
+++ b/tests/unit/flutter-breakpoints.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for the breakpoint / step-debugging tool suite (issue #435).
+ */
+
+import {
+  resumeModeToStep,
+  summariseFrame,
+  _resetBreakpointManagers,
+} from '../../src/tools/flutter-breakpoints';
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({ getSoleDeviceId: () => 'test-device-id' }),
+}));
+
+const mockIsConnected = jest.fn();
+const mockCallMethod = jest.fn();
+const mockGetState = jest.fn();
+const mockStreamListen = jest.fn();
+const mockOnEvent = jest.fn();
+const mockOffEvent = jest.fn();
+
+jest.mock('../../src/flutter', () => ({
+  getFlutterVMClient: () => ({
+    isConnected: mockIsConnected,
+    callMethod: mockCallMethod,
+    getState: mockGetState,
+    streamListen: mockStreamListen,
+    onEvent: mockOnEvent,
+    offEvent: mockOffEvent,
+  }),
+  FlutterVMError: class extends Error {
+    constructor(msg: string, public readonly code: string) { super(msg); }
+  },
+}));
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+// ── resumeModeToStep ────────────────────────────────────────────────────────
+
+describe('resumeModeToStep', () => {
+  it('maps each mode to the expected VM step token', () => {
+    expect(resumeModeToStep('continue')).toBeUndefined();
+    expect(resumeModeToStep('step_into')).toBe('Into');
+    expect(resumeModeToStep('step_over')).toBe('Over');
+    expect(resumeModeToStep('step_out')).toBe('Out');
+  });
+
+  it('throws on unknown mode', () => {
+    // @ts-expect-error — runtime check
+    expect(() => resumeModeToStep('warp')).toThrow('Unknown resume mode');
+  });
+});
+
+// ── summariseFrame ──────────────────────────────────────────────────────────
+
+describe('summariseFrame', () => {
+  it('extracts index, function, kind, location, vars', () => {
+    const s = summariseFrame({
+      index: 0,
+      kind: 'Regular',
+      function: { name: 'build' },
+      location: {
+        script: { uri: 'package:app/home.dart' },
+        tokenPos: 123,
+        line: 47,
+        column: 12,
+      },
+      vars: [{ name: 'context' }, { name: 'widget' }, { noName: true }],
+    });
+
+    expect(s.index).toBe(0);
+    expect(s.function).toBe('build');
+    expect(s.kind).toBe('Regular');
+    expect(s.location).toEqual({
+      script_uri: 'package:app/home.dart',
+      token_pos: 123,
+      line: 47,
+      column: 12,
+    });
+    expect(s.vars).toEqual(['context', 'widget']);
+  });
+
+  it('tolerates missing fields', () => {
+    const s = summariseFrame({});
+    expect(s.index).toBe(0);
+    expect(s.function).toBeUndefined();
+    expect(s.location).toBeUndefined();
+    expect(s.vars).toBeUndefined();
+  });
+});
+
+// ── flutter_set_breakpoint ──────────────────────────────────────────────────
+
+describe('flutter_set_breakpoint handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterSetBreakpointTool } = require('../../src/tools/flutter-breakpoints');
+    registerFlutterSetBreakpointTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetBreakpointManagers();
+    mockIsConnected.mockReturnValue(true);
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+    mockStreamListen.mockResolvedValue(undefined);
+  });
+
+  it('rejects missing script_uri', async () => {
+    const result = await handler('s', { line: 42 });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects non-integer / non-positive line', async () => {
+    const r1 = await handler('s', { script_uri: 'package:a/b.dart', line: 0 });
+    const r2 = await handler('s', { script_uri: 'package:a/b.dart', line: 1.5 });
+    expect(r1.isError).toBe(true);
+    expect(r2.isError).toBe(true);
+  });
+
+  it('subscribes to Debug stream and calls addBreakpointWithScriptUri with isolate and line', async () => {
+    mockCallMethod.mockResolvedValue({
+      id: 'breakpoints/7',
+      resolved: true,
+      location: { script: { uri: 'package:a/b.dart' }, line: 42 },
+    });
+
+    const result = await handler('s', { script_uri: 'package:a/b.dart', line: 42 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockStreamListen).toHaveBeenCalledWith('Debug');
+    expect(mockOnEvent).toHaveBeenCalledWith('Debug', expect.any(Function));
+    expect(mockCallMethod).toHaveBeenCalledWith('addBreakpointWithScriptUri', {
+      isolateId: 'iso-1',
+      scriptUri: 'package:a/b.dart',
+      line: 42,
+    });
+    expect(body.status).toBe('ok');
+    expect(body.breakpoint.id).toBe('breakpoints/7');
+    expect(body.breakpoint.resolved).toBe(true);
+  });
+
+  it('forwards optional column', async () => {
+    mockCallMethod.mockResolvedValue({ id: 'bp-1' });
+    await handler('s', { script_uri: 'package:a/b.dart', line: 10, column: 3 });
+    expect(mockCallMethod).toHaveBeenCalledWith('addBreakpointWithScriptUri', expect.objectContaining({ column: 3 }));
+  });
+
+  it('errors when not connected', async () => {
+    mockIsConnected.mockReturnValue(false);
+    const result = await handler('s', { script_uri: 'package:a/b.dart', line: 1 });
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ── flutter_remove_breakpoint ───────────────────────────────────────────────
+
+describe('flutter_remove_breakpoint handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterRemoveBreakpointTool } = require('../../src/tools/flutter-breakpoints');
+    registerFlutterRemoveBreakpointTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetBreakpointManagers();
+    mockIsConnected.mockReturnValue(true);
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+  });
+
+  it('rejects missing id', async () => {
+    const r = await handler('s', {});
+    expect(r.isError).toBe(true);
+  });
+
+  it('calls removeBreakpoint RPC', async () => {
+    mockCallMethod.mockResolvedValue({ type: 'Success' });
+    const result = await handler('s', { breakpoint_id: 'breakpoints/7' });
+    const body = JSON.parse(result.content[0].text);
+    expect(mockCallMethod).toHaveBeenCalledWith('removeBreakpoint', {
+      isolateId: 'iso-1',
+      breakpointId: 'breakpoints/7',
+    });
+    expect(body.status).toBe('ok');
+  });
+});
+
+// ── flutter_resume ──────────────────────────────────────────────────────────
+
+describe('flutter_resume handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterResumeTool } = require('../../src/tools/flutter-breakpoints');
+    registerFlutterResumeTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetBreakpointManagers();
+    mockIsConnected.mockReturnValue(true);
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+    mockCallMethod.mockResolvedValue({});
+  });
+
+  it('resumes without step when mode is "continue" (default)', async () => {
+    await handler('s', {});
+    expect(mockCallMethod).toHaveBeenCalledWith('resume', { isolateId: 'iso-1' });
+  });
+
+  it('passes the correct step for each mode', async () => {
+    await handler('s', { mode: 'step_into' });
+    await handler('s', { mode: 'step_over' });
+    await handler('s', { mode: 'step_out' });
+
+    const calls = mockCallMethod.mock.calls.filter((c) => c[0] === 'resume').map((c) => c[1]);
+    expect(calls).toEqual([
+      { isolateId: 'iso-1', step: 'Into' },
+      { isolateId: 'iso-1', step: 'Over' },
+      { isolateId: 'iso-1', step: 'Out' },
+    ]);
+  });
+
+  it('falls back to "continue" on unknown mode value', async () => {
+    const result = await handler('s', { mode: 'warp' });
+    expect(result.isError).toBeUndefined();
+    expect(mockCallMethod).toHaveBeenCalledWith('resume', { isolateId: 'iso-1' });
+  });
+});
+
+// ── flutter_get_stack ───────────────────────────────────────────────────────
+
+describe('flutter_get_stack handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterGetStackTool } = require('../../src/tools/flutter-breakpoints');
+    registerFlutterGetStackTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+  });
+
+  it('returns summarised frames', async () => {
+    mockCallMethod.mockResolvedValue({
+      frames: [
+        {
+          index: 0,
+          kind: 'Regular',
+          function: { name: 'build' },
+          location: { script: { uri: 'package:a/b.dart' }, line: 47 },
+          vars: [{ name: 'x' }],
+        },
+      ],
+    });
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+    expect(body.frames[0].function).toBe('build');
+    expect(body.frames[0].location.line).toBe(47);
+    expect(body.frames[0].vars).toEqual(['x']);
+  });
+
+  it('forwards limit', async () => {
+    mockCallMethod.mockResolvedValue({ frames: [] });
+    await handler('s', { limit: 5 });
+    expect(mockCallMethod).toHaveBeenCalledWith('getStack', { isolateId: 'iso-1', limit: 5 });
+  });
+
+  it('rejects non-positive limit', async () => {
+    const result = await handler('s', { limit: 0 });
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ── flutter_wait_for_pause ──────────────────────────────────────────────────
+
+describe('flutter_wait_for_pause handler', () => {
+  let handler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { registerFlutterWaitForPauseTool } = require('../../src/tools/flutter-breakpoints');
+    registerFlutterWaitForPauseTool(server);
+    handler = server.registerTool.mock.calls[0][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetBreakpointManagers();
+    mockIsConnected.mockReturnValue(true);
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+    mockStreamListen.mockResolvedValue(undefined);
+  });
+
+  it('returns timeout when no pause arrives', async () => {
+    const result = await handler('s', { timeout_ms: 60, poll_interval_ms: 20 });
+    const body = JSON.parse(result.content[0].text);
+    expect(body.timeout).toBe(true);
+    expect(body.status).toBe('timeout');
+  });
+
+  it('returns paused when the Debug listener reports PauseBreakpoint', async () => {
+    // Capture the listener the manager registered when we subscribe lazily.
+    let capturedListener: ((ev: unknown) => void) | null = null;
+    mockOnEvent.mockImplementation((_stream: string, cb: (ev: unknown) => void) => {
+      capturedListener = cb;
+    });
+
+    // Fire the pause event shortly after we start waiting.
+    const p = handler('s', { timeout_ms: 2000, poll_interval_ms: 10 });
+    setTimeout(() => {
+      capturedListener?.({ kind: 'PauseBreakpoint' });
+    }, 30);
+
+    const result = await p;
+    const body = JSON.parse(result.content[0].text);
+    expect(body.status).toBe('paused');
+    expect(body.reason).toBe('PauseBreakpoint');
+  });
+});

--- a/tests/unit/flutter-breakpoints.test.ts
+++ b/tests/unit/flutter-breakpoints.test.ts
@@ -5,6 +5,7 @@
 import {
   resumeModeToStep,
   summariseFrame,
+  forgetBreakpointManager,
   _resetBreakpointManagers,
 } from '../../src/tools/flutter-breakpoints';
 
@@ -335,5 +336,80 @@ describe('flutter_wait_for_pause handler', () => {
     const body = JSON.parse(result.content[0].text);
     expect(body.status).toBe('paused');
     expect(body.reason).toBe('PauseBreakpoint');
+  });
+});
+
+// ── BreakpointManager lifecycle regressions ─────────────────────────────────
+
+describe('BreakpointManager lifecycle', () => {
+  // Shared handler for these lifecycle tests.
+  let waitHandler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+  let setBpHandler: (s: string, p: Record<string, unknown>) => Promise<ToolResult>;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('../../src/tools/flutter-breakpoints');
+    mod.registerFlutterWaitForPauseTool(server);
+    mod.registerFlutterSetBreakpointTool(server);
+    waitHandler = server.registerTool.mock.calls[0][1];
+    setBpHandler = server.registerTool.mock.calls[1][1];
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetBreakpointManagers();
+    mockIsConnected.mockReturnValue(true);
+    mockStreamListen.mockResolvedValue(undefined);
+  });
+
+  it('_resetBreakpointManagers calls offEvent on active Debug listeners (P1)', async () => {
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+    mockCallMethod.mockResolvedValue({ id: 'bp/1' });
+
+    // Subscribe by setting a breakpoint (which calls ensureDebugSubscription).
+    await setBpHandler('s', { script_uri: 'package:a/b.dart', line: 1 });
+    expect(mockOnEvent).toHaveBeenCalledWith('Debug', expect.any(Function));
+
+    // _resetBreakpointManagers must tear down the listener, not just drop state.
+    _resetBreakpointManagers();
+    expect(mockOffEvent).toHaveBeenCalledWith('Debug', expect.any(Function));
+  });
+
+  it('forgetBreakpointManager tears down and re-subscribes cleanly on next call', async () => {
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+    mockCallMethod.mockResolvedValue({ id: 'bp/1' });
+
+    await setBpHandler('s', { script_uri: 'package:a/b.dart', line: 1 });
+    const offCallsBefore = mockOffEvent.mock.calls.length;
+
+    forgetBreakpointManager('test-device-id');
+    expect(mockOffEvent.mock.calls.length).toBeGreaterThan(offCallsBefore);
+
+    // A follow-up wait should cleanly re-subscribe — no "already subscribed" short-circuit.
+    const waitPromise = waitHandler('s', { timeout_ms: 30, poll_interval_ms: 10 });
+    const result = await waitPromise;
+    expect(JSON.parse(result.content[0].text).status).toBe('timeout');
+    // streamListen called at least twice: original subscribe + post-forget re-subscribe.
+    expect(mockStreamListen.mock.calls.filter((c) => c[0] === 'Debug').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('auto-resubscribes when mainIsolateId changes (reconnect / hot restart)', async () => {
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-1' });
+    mockCallMethod.mockResolvedValue({ id: 'bp/1' });
+
+    await setBpHandler('s', { script_uri: 'package:a/b.dart', line: 1 });
+    const firstOnEventCount = mockOnEvent.mock.calls.filter((c) => c[0] === 'Debug').length;
+
+    // Simulate a reconnect: VM client now reports a different isolate id.
+    mockGetState.mockReturnValue({ mainIsolateId: 'iso-2' });
+
+    await setBpHandler('s', { script_uri: 'package:a/b.dart', line: 2 });
+
+    // onEvent must have been called a second time with the new listener.
+    const newOnEventCount = mockOnEvent.mock.calls.filter((c) => c[0] === 'Debug').length;
+    expect(newOnEventCount).toBe(firstOnEventCount + 1);
+    // offEvent should have been called to detach the stale listener.
+    expect(mockOffEvent).toHaveBeenCalledWith('Debug', expect.any(Function));
   });
 });


### PR DESCRIPTION
## Summary

Five MCP tools that let an LLM drive the Dart VM Service debugger end-to-end:

| Tool | RPC it wraps |
|---|---|
| `flutter_set_breakpoint` | `addBreakpointWithScriptUri` |
| `flutter_remove_breakpoint` | `removeBreakpoint` |
| `flutter_resume` | `resume` (with `step` mapping) |
| `flutter_get_stack` | `getStack` (summarised frames) |
| `flutter_wait_for_pause` | polling on the Debug stream |

Closes #435.

## Design

**Per-device `BreakpointManager`** — lazily subscribes to the `Debug` event stream on first use, tracks current pause state and active breakpoints. Pause events (`PauseBreakpoint`, `PauseInterrupted`, `PauseException`, `PauseStart`, `PausePostRequest`, `PauseExit`) flip `paused: true`; `Resume` events flip it back. `flutter_resume` also clears the state eagerly so the caller does not race the stream.

**`flutter_wait_for_pause`** — polls `state.pause.paused` with a bounded interval (default 50ms, max 1s). Returns `{status: "paused", reason, paused_at, waited_ms}` or `{status: "timeout", timeout: true, waited_ms}` on deadline. Pattern mirrors `app_wait_for`.

**Frame summarisation** — `summariseFrame` is exported as a pure function and unit-tested. Output keeps only what LLMs use: `index`, `function`, `kind`, `location: { script_uri, line, column, token_pos }`, `vars` (names only).

**Resume-mode mapping** — `continue` → no step; `step_into` → `"Into"`; `step_over` → `"Over"`; `step_out` → `"Out"`. Unknown mode values silently fall back to `continue` (and the tool description lists the valid set). `resumeModeToStep` is exported and unit-tested.

## Files touched

- `src/tools/flutter-breakpoints.ts` (new, ~400 LoC)
- `tests/unit/flutter-breakpoints.test.ts` (new) — 19 tests
- `src/tools/index.ts` — register five tools
- `src/config/tool-tiers.ts` — Tier 2
- `CHANGELOG.md` — Unreleased

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest tests/unit/flutter-breakpoints.test.ts` → **19/19 passing**
  - `resumeModeToStep`: each mode + unknown-mode throw
  - `summariseFrame`: full payload, missing fields, vars filtering
  - `flutter_set_breakpoint`: missing script_uri, non-integer line, zero line, Debug stream subscription + RPC shape, optional column forwarding, disconnected error
  - `flutter_remove_breakpoint`: missing id, RPC shape
  - `flutter_resume`: default continue, three step modes, unknown-mode fallback
  - `flutter_get_stack`: summarised frames, limit forwarding, non-positive limit rejection
  - `flutter_wait_for_pause`: timeout path, real pause via simulated Debug listener event
- [ ] Manual integration: set a breakpoint, tap the triggering control in the app, `flutter_wait_for_pause` hits within 1s, `flutter_get_stack` shows correct file:line, `flutter_resume({mode: "step_over"})` lands on the next line. Pending simulator access.

## Batch

Batch 3 PR 4/4 — completes Flutter VM-Service parity with DevTools across issues #434–#442 (minus the coordinate→widget follow-up from #436).

Generated with [Claude Code](https://claude.com/claude-code)