### PR TITLE
chore: fix 12 pre-existing lint errors blocking CI

### DIFF
--- a/src/flutter/vm-service-client.ts
+++ b/src/flutter/vm-service-client.ts
@@ -9,10 +9,8 @@
 import WebSocket from 'ws';
 import type {
   VMServiceRequest,
-  VMServiceResponse,
   VMServiceEvent,
   VMInfo,
-  VMIsolateRef,
   FlutterConnectionState,
   FlutterConnectOptions,
 } from './flutter-types';

--- a/tests/unit/app-wait-for.test.ts
+++ b/tests/unit/app-wait-for.test.ts
@@ -67,7 +67,7 @@ let assertHandler: ToolHandler;
 
 beforeAll(() => {
   const mockServer = {
-    registerTool: jest.fn((schema: unknown, fn: unknown) => {}),
+    registerTool: jest.fn((_schema: unknown, _fn: unknown) => {}),
   } as unknown as MCPServer;
 
   // Capture wait_for handler

--- a/tests/unit/flutter-vm-service.test.ts
+++ b/tests/unit/flutter-vm-service.test.ts
@@ -50,12 +50,10 @@ describe('vm-service-discovery', () => {
 
 describe('FlutterVMClient', () => {
   let FlutterVMClient: typeof import('../../src/flutter/vm-service-client').FlutterVMClient;
-  let FlutterVMError: typeof import('../../src/flutter/vm-service-client').FlutterVMError;
 
   beforeAll(async () => {
     const mod = await import('../../src/flutter/vm-service-client');
     FlutterVMClient = mod.FlutterVMClient;
-    FlutterVMError = mod.FlutterVMError;
   });
 
   it('starts disconnected', () => {
@@ -104,6 +102,7 @@ describe('FlutterVMClient', () => {
 
 describe('FlutterVMError', () => {
   it('has correct name and code', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { FlutterVMError } = require('../../src/flutter/vm-service-client');
     const err = new FlutterVMError('test error', 'TEST_CODE');
     expect(err.name).toBe('FlutterVMError');
@@ -131,24 +130,28 @@ describe('Flutter tool registration', () => {
   });
 
   it('registers flutter_connect', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { registerFlutterConnectTool } = require('../../src/tools/flutter-connect');
     registerFlutterConnectTool(mockServer);
     expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
   });
 
   it('registers flutter_widget_tree', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { registerFlutterWidgetTreeTool } = require('../../src/tools/flutter-widget-tree');
     registerFlutterWidgetTreeTool(mockServer);
     expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
   });
 
   it('registers flutter_hot_reload', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { registerFlutterHotReloadTool } = require('../../src/tools/flutter-hot-reload');
     registerFlutterHotReloadTool(mockServer);
     expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
   });
 
   it('registers flutter_logs', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { registerFlutterLogsTool } = require('../../src/tools/flutter-logs');
     registerFlutterLogsTool(mockServer);
     expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
@@ -180,6 +183,7 @@ describe('flutter_widget_tree handler', () => {
 
   beforeAll(() => {
     const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { registerFlutterWidgetTreeTool } = require('../../src/tools/flutter-widget-tree');
     registerFlutterWidgetTreeTool(server);
     handler = server.registerTool.mock.calls[0][1];
@@ -223,6 +227,7 @@ describe('flutter_hot_reload handler', () => {
 
   beforeAll(() => {
     const server = { registerTool: jest.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { registerFlutterHotReloadTool } = require('../../src/tools/flutter-hot-reload');
     registerFlutterHotReloadTool(server);
     handler = server.registerTool.mock.calls[0][1];


### PR DESCRIPTION
## Summary

Fixes the pre-existing lint errors that were failing CI on every Flutter feature PR (#443-#451). Zero behavioral change — removes unused imports and adds `eslint-disable-next-line` directives for `require()` calls that match the convention used in newer tests.

## Why

The 9 open PRs (#443-#451) were all red on `lint` despite introducing zero new errors. Root cause: `develop` itself carries 12 lint errors that pre-date this PR chain.

## Files touched

- `src/flutter/vm-service-client.ts` — drop unused `VMServiceResponse`, `VMIsolateRef` type imports
- `tests/unit/app-wait-for.test.ts` — rename unused callback args `schema`/`fn` → `_schema`/`_fn`
- `tests/unit/flutter-vm-service.test.ts` — add `// eslint-disable-next-line @typescript-eslint/no-require-imports` before 7 `require()` calls; remove unused `FlutterVMError` assignment

## Verification

Before: `npm run lint` → 431 problems (12 errors, 419 warnings), exit 1
After:  `npm run lint` → 419 problems (0 errors, 419 warnings), exit 0

Warnings unchanged intentionally — those are `no-explicit-any` noise across the codebase and out of scope for this CI-unblock.

Generated with [Claude Code](https://claude.com/claude-code)