### PR TITLE
feat(flutter): add qa_flutter_keyboard_overlap detector

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -102,6 +102,7 @@ export const TOOL_TIERS: Record<string, number> = {
   qa_flutter_semantics: 2,
   qa_flutter_dark_mode: 2,
   qa_flutter_orientation: 2,
+  qa_flutter_keyboard_overlap: 2,
 
   // Tier 2: Flutter VM Service (debug/profile builds only)
   flutter_connect: 2,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -84,6 +84,7 @@ import { registerQaFlutterTouchTargetsTool } from './qa-flutter-touch-targets';
 import { registerQaFlutterSemanticsTool } from './qa-flutter-semantics';
 import { registerQaFlutterDarkModeTool } from './qa-flutter-dark-mode';
 import { registerQaFlutterOrientationTool } from './qa-flutter-orientation';
+import { registerQaFlutterKeyboardOverlapTool } from './qa-flutter-keyboard-overlap';
 import { registerFlutterConnectTool } from './flutter-connect';
 import { registerFlutterWidgetTreeTool } from './flutter-widget-tree';
 import { registerFlutterHotReloadTool } from './flutter-hot-reload';
@@ -269,6 +270,7 @@ export function registerAllTools(server: MCPServer): void {
   registerQaFlutterSemanticsTool(server);
   registerQaFlutterDarkModeTool(server);
   registerQaFlutterOrientationTool(server);
+  registerQaFlutterKeyboardOverlapTool(server);
 
   // Tier 2: Flutter VM Service (debug/profile builds only)
   registerFlutterConnectTool(server);

--- a/src/tools/qa-flutter-keyboard-overlap.ts
+++ b/src/tools/qa-flutter-keyboard-overlap.ts
@@ -1,0 +1,196 @@
+/**
+ * qa_flutter_keyboard_overlap — Detect input fields obscured by the software keyboard.
+ *
+ * Taps each text input in a Flutter/native app, waits for the keyboard to appear,
+ * then checks whether the field remains visible above the keyboard boundary.
+ * Handles scrollable forms where the keyboard pushes content up.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getAccessibilityBridge } from '../native';
+import type { AXNode } from '../native';
+import { getSessionManager } from '../session-manager';
+import { SimctlExecutor } from '../simulator/simctl';
+
+const DEFAULT_KEYBOARD_HEIGHT = 300;
+const DEFAULT_SCREEN_HEIGHT = 852; // iPhone 14/15 logical height
+const INPUT_ROLES = ['AXTextField', 'AXTextArea'];
+const KEYBOARD_APPEAR_DELAY = 800;
+const KEYBOARD_DISMISS_DELAY = 500;
+const MAX_VIOLATIONS = 20;
+
+/** HID usage code for Escape key — used to dismiss the keyboard. */
+const ESCAPE_HID_CODE = '41';
+
+interface OverlapViolation {
+  role: string;
+  label?: string;
+  identifier?: string;
+  path: string;
+  original_frame: { x: number; y: number; width: number; height: number };
+  focused_frame: { x: number; y: number; width: number; height: number };
+  overlap_pixels: number;
+  scrolled: boolean;
+  issue: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function findInputFields(node: AXNode): AXNode[] {
+  const inputs: AXNode[] = [];
+  function walk(n: AXNode): void {
+    if (INPUT_ROLES.includes(n.role) && n.visible) {
+      inputs.push(n);
+    }
+    if (n.children) {
+      for (const c of n.children) walk(c);
+    }
+  }
+  walk(node);
+  return inputs;
+}
+
+function findNodeByPath(root: AXNode, targetPath: string): AXNode | undefined {
+  if (root.path === targetPath) return root;
+  if (root.children) {
+    for (const child of root.children) {
+      const found = findNodeByPath(child, targetPath);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+export function registerQaFlutterKeyboardOverlapTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'qa_flutter_keyboard_overlap',
+      description:
+        'Verify input fields are not obscured by the software keyboard in Flutter/native apps. ' +
+        'Taps each text input, checks if it remains visible above the keyboard, and reports overlap.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+          keyboard_height: {
+            type: 'number',
+            description:
+              'Estimated keyboard height in points (default: 300). ' +
+              'Adjust for different keyboard types (number pad ~260, email ~300, default ~300).',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const keyboardHeight =
+          (params.keyboard_height as number | undefined) ?? DEFAULT_KEYBOARD_HEIGHT;
+
+        const bridge = getAccessibilityBridge();
+        const simctl = new SimctlExecutor();
+
+        // Initial tree dump to find all input fields
+        const tree = await bridge.dumpTree({ deviceId, maxDepth: 15 });
+
+        // Derive screen height from root element frame
+        const screenHeight =
+          tree.frame.height > 0 ? tree.frame.height : DEFAULT_SCREEN_HEIGHT;
+        const keyboardTop = screenHeight - keyboardHeight;
+
+        const inputFields = findInputFields(tree);
+        const violations: OverlapViolation[] = [];
+
+        for (const field of inputFields) {
+          const originalFrame = { ...field.frame };
+          const centerX = Math.round(field.frame.x + field.frame.width / 2);
+          const centerY = Math.round(field.frame.y + field.frame.height / 2);
+
+          // Tap the input to bring up the keyboard
+          await simctl.exec(['io', deviceId, 'input', 'tap', String(centerX), String(centerY)]);
+          await sleep(KEYBOARD_APPEAR_DELAY);
+
+          // Re-dump tree to get updated frame (form may have scrolled)
+          const updatedTree = await bridge.dumpTree({ deviceId, maxDepth: 15 });
+          const updatedField = findNodeByPath(updatedTree, field.path);
+
+          if (!updatedField) {
+            // Element disappeared after focus — could be a navigation change; skip
+            await simctl.exec(['io', deviceId, 'sendkey', ESCAPE_HID_CODE]);
+            await sleep(KEYBOARD_DISMISS_DELAY);
+            continue;
+          }
+
+          const focusedFrame = { ...updatedField.frame };
+          const fieldBottom = focusedFrame.y + focusedFrame.height;
+          const scrolled = Math.abs(focusedFrame.y - originalFrame.y) > 1;
+
+          if (fieldBottom > keyboardTop) {
+            const overlapPixels = Math.round(fieldBottom - keyboardTop);
+            violations.push({
+              role: field.role,
+              label: field.label,
+              identifier: field.identifier,
+              path: field.path,
+              original_frame: originalFrame,
+              focused_frame: focusedFrame,
+              overlap_pixels: overlapPixels,
+              scrolled,
+              issue: `Input obscured by keyboard by ${overlapPixels} pixels`,
+            });
+          }
+
+          // Dismiss keyboard before checking next field
+          await simctl.exec(['io', deviceId, 'sendkey', ESCAPE_HID_CODE]);
+          await sleep(KEYBOARD_DISMISS_DELAY);
+        }
+
+        const passed = violations.length === 0;
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  detector: 'qa_flutter_keyboard_overlap',
+                  passed,
+                  total_inputs: inputFields.length,
+                  keyboard_height: keyboardHeight,
+                  screen_height: screenHeight,
+                  violations_count: violations.length,
+                  violations: violations.slice(0, MAX_VIOLATIONS),
+                  summary: passed
+                    ? `All ${inputFields.length} input fields are visible above the keyboard.`
+                    : `${violations.length} of ${inputFields.length} input fields are obscured by keyboard.`,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: !passed,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[qa_flutter_keyboard_overlap] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/tests/unit/qa-flutter-keyboard-overlap.test.ts
+++ b/tests/unit/qa-flutter-keyboard-overlap.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for qa_flutter_keyboard_overlap detector.
+ *
+ * Covers: obscured input detection, overlap pixel reporting,
+ * scrollable form detection, and passing when all inputs are above keyboard.
+ */
+
+jest.mock('../../src/mcp-server', () => {
+  const actual = jest.requireActual('../../src/mcp-server');
+  return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };
+});
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerQaFlutterKeyboardOverlapTool } from '../../src/tools/qa-flutter-keyboard-overlap';
+import type { AXNode } from '../../src/native/ax-types';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockDumpTree = jest.fn();
+const mockExec = jest.fn().mockResolvedValue('');
+
+jest.mock('../../src/native/accessibility-bridge', () => ({
+  getAccessibilityBridge: () => ({
+    dumpTree: mockDumpTree,
+  }),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'test-device-id',
+  }),
+}));
+
+jest.mock('../../src/simulator/simctl', () => ({
+  SimctlExecutor: jest.fn().mockImplementation(() => ({
+    exec: mockExec,
+  })),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type ToolHandler = (s: string, p: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function makeNode(overrides: Partial<AXNode> & { children?: AXNode[] } = {}): AXNode {
+  return {
+    role: 'AXGroup',
+    traits: [],
+    frame: { x: 0, y: 0, width: 390, height: 844 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    path: '',
+    ...overrides,
+  };
+}
+
+function makeInput(
+  label: string,
+  y: number,
+  path: string,
+  role: string = 'AXTextField',
+): AXNode {
+  return makeNode({
+    role,
+    label,
+    frame: { x: 20, y, width: 350, height: 44 },
+    path,
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('qa_flutter_keyboard_overlap', () => {
+  let handler: ToolHandler;
+
+  beforeAll(() => {
+    const server = { registerTool: jest.fn() };
+    registerQaFlutterKeyboardOverlapTool(server as unknown as MCPServer);
+    handler = (server.registerTool as jest.Mock).mock.calls[0][1];
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('detects input obscured by keyboard', async () => {
+    // Screen height 844, keyboard_height 300 => keyboard_top = 544
+    // Input at y=600 with height 44 => bottom = 644, overlaps by 100px
+    const tree = makeNode({
+      children: [
+        makeInput('Email', 600, '0/0'),
+      ],
+    });
+    // First dump returns the initial tree; second dump (after tap) returns same positions
+    mockDumpTree.mockResolvedValue(tree);
+
+    const result = await handler('s', { keyboard_height: 300 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(false);
+    expect(body.violations_count).toBe(1);
+    expect(body.violations[0].label).toBe('Email');
+    expect(body.violations[0].overlap_pixels).toBe(100);
+    expect(body.violations[0].issue).toContain('100 pixels');
+  });
+
+  it('passes when all inputs are above keyboard area', async () => {
+    // Screen height 844, keyboard_height 300 => keyboard_top = 544
+    // Input at y=100 with height 44 => bottom = 144, well above keyboard
+    const tree = makeNode({
+      children: [
+        makeInput('Name', 100, '0/0'),
+        makeInput('Email', 200, '0/1'),
+      ],
+    });
+    mockDumpTree.mockResolvedValue(tree);
+
+    const result = await handler('s', { keyboard_height: 300 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(true);
+    expect(body.violations_count).toBe(0);
+    expect(body.total_inputs).toBe(2);
+  });
+
+  it('reports overlap in pixels correctly', async () => {
+    // Screen height 844, keyboard_height 300 => keyboard_top = 544
+    // Input at y=520, height 44 => bottom = 564 => overlap = 20px
+    const tree = makeNode({
+      children: [
+        makeInput('Phone', 520, '0/0'),
+      ],
+    });
+    mockDumpTree.mockResolvedValue(tree);
+
+    const result = await handler('s', { keyboard_height: 300 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(false);
+    expect(body.violations[0].overlap_pixels).toBe(20);
+    expect(body.violations[0].role).toBe('AXTextField');
+  });
+
+  it('detects when form scrolls (frame.y changes between dumps)', async () => {
+    // Initial tree: input at y=700
+    const initialTree = makeNode({
+      children: [
+        makeInput('Address', 700, '0/0'),
+      ],
+    });
+
+    // After tapping: input scrolled up to y=300 (form scrolled)
+    const scrolledTree = makeNode({
+      children: [
+        makeNode({
+          role: 'AXTextField',
+          label: 'Address',
+          frame: { x: 20, y: 300, width: 350, height: 44 },
+          path: '0/0',
+          traits: [],
+          visible: true,
+          enabled: true,
+          focused: true,
+        }),
+      ],
+    });
+
+    // First call returns initial tree, subsequent calls return scrolled tree
+    mockDumpTree
+      .mockResolvedValueOnce(initialTree)
+      .mockResolvedValueOnce(scrolledTree);
+
+    const result = await handler('s', { keyboard_height: 300 });
+    const body = JSON.parse(result.content[0].text);
+
+    // After scrolling, bottom = 300 + 44 = 344, which is above keyboard_top (544)
+    expect(body.passed).toBe(true);
+    expect(body.violations_count).toBe(0);
+  });
+
+  it('reports scrolled=true when field position changes after focus', async () => {
+    // Initial tree: input at y=600
+    const initialTree = makeNode({
+      children: [
+        makeInput('Notes', 600, '0/0', 'AXTextArea'),
+      ],
+    });
+
+    // After tapping: input scrolled to y=500 but still overlaps
+    // keyboard_top = 544, bottom = 500 + 44 = 544 — exactly at boundary, no overlap
+    // Let's make it still overlap: y=510, bottom = 554 > 544 => overlap 10px
+    const scrolledTree = makeNode({
+      children: [
+        makeNode({
+          role: 'AXTextArea',
+          label: 'Notes',
+          frame: { x: 20, y: 510, width: 350, height: 44 },
+          path: '0/0',
+          traits: [],
+          visible: true,
+          enabled: true,
+          focused: true,
+        }),
+      ],
+    });
+
+    mockDumpTree
+      .mockResolvedValueOnce(initialTree)
+      .mockResolvedValueOnce(scrolledTree);
+
+    const result = await handler('s', { keyboard_height: 300 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.passed).toBe(false);
+    expect(body.violations[0].scrolled).toBe(true);
+    expect(body.violations[0].overlap_pixels).toBe(10);
+    expect(body.violations[0].role).toBe('AXTextArea');
+  });
+
+  it('uses simctl to tap and dismiss keyboard', async () => {
+    const tree = makeNode({
+      children: [
+        makeInput('Email', 100, '0/0'),
+      ],
+    });
+    mockDumpTree.mockResolvedValue(tree);
+
+    await handler('s', { device_id: 'DEV-123', keyboard_height: 300 });
+
+    // Should have called simctl tap on the input center
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.arrayContaining(['io', 'DEV-123', 'input', 'tap']),
+    );
+    // Should have called simctl sendkey to dismiss keyboard
+    expect(mockExec).toHaveBeenCalledWith(
+      ['io', 'DEV-123', 'sendkey', '41'],
+    );
+  });
+
+  it('ignores non-input elements', async () => {
+    const tree = makeNode({
+      children: [
+        makeNode({ role: 'AXButton', label: 'Submit', frame: { x: 20, y: 700, width: 350, height: 44 }, path: '0/0' }),
+        makeNode({ role: 'AXStaticText', label: 'Title', frame: { x: 20, y: 750, width: 350, height: 20 }, path: '0/1' }),
+      ],
+    });
+    mockDumpTree.mockResolvedValue(tree);
+
+    const result = await handler('s', { keyboard_height: 300 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.total_inputs).toBe(0);
+    expect(body.passed).toBe(true);
+  });
+
+  it('ignores hidden input fields', async () => {
+    const tree = makeNode({
+      children: [
+        makeNode({
+          role: 'AXTextField',
+          label: 'Hidden',
+          visible: false,
+          frame: { x: 20, y: 700, width: 350, height: 44 },
+          path: '0/0',
+        }),
+      ],
+    });
+    mockDumpTree.mockResolvedValue(tree);
+
+    const result = await handler('s', { keyboard_height: 300 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.total_inputs).toBe(0);
+    expect(body.passed).toBe(true);
+  });
+
+  it('derives screen height from root node frame', async () => {
+    // Root node with non-default height
+    const tree = makeNode({
+      frame: { x: 0, y: 0, width: 393, height: 852 },
+      children: [
+        makeInput('Email', 600, '0/0'),
+      ],
+    });
+    mockDumpTree.mockResolvedValue(tree);
+
+    const result = await handler('s', { keyboard_height: 300 });
+    const body = JSON.parse(result.content[0].text);
+
+    // keyboard_top = 852 - 300 = 552
+    // bottom = 600 + 44 = 644 > 552 => overlap = 92
+    expect(body.screen_height).toBe(852);
+    expect(body.violations[0].overlap_pixels).toBe(92);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new Tier 2 Flutter/native QA detector, `qa_flutter_keyboard_overlap`, that verifies input fields are not obscured by the software keyboard. Part of issue #426.

The detector walks the accessibility tree, taps each `AXTextField` / `AXTextArea`, waits for the keyboard to appear, re-dumps the tree to capture any scroll adjustments, and reports fields whose bottom edge falls below the keyboard top line.

### Behavior
- Detects input fields obscured by the keyboard, reporting the overlap in pixels
- Handles scrollable forms by comparing `frame.y` before/after focus (reports `scrolled: true`)
- Dismisses the keyboard between field checks via `simctl sendkey 41` (Escape HID code)
- Configurable `keyboard_height` (default: 300) so callers can adjust for number pad, email, default, etc.
- Derives screen height from the root AX node frame, with a safe fallback
- Output is capped at 20 violations for MCP payload safety

### Output shape
```json
{
  "detector": "qa_flutter_keyboard_overlap",
  "passed": false,
  "total_inputs": 5,
  "keyboard_height": 300,
  "screen_height": 852,
  "violations_count": 2,
  "violations": [
    {
      "role": "AXTextField",
      "label": "Email",
      "path": "0/2/1",
      "original_frame": { ... },
      "focused_frame": { ... },
      "overlap_pixels": 45,
      "scrolled": false,
      "issue": "Input obscured by keyboard by 45 pixels"
    }
  ],
  "summary": "2 of 5 input fields are obscured by keyboard."
}
```

### Registration
- `src/tools/index.ts` — imports and registers the tool alongside the other Flutter QA detectors
- `src/config/tool-tiers.ts` — registered as Tier 2

## Test plan
- [x] `npm run build` passes (webpack compiled successfully, no TS errors)
- [x] New unit suite `tests/unit/qa-flutter-keyboard-overlap.test.ts` — 9/9 passing
  - Detects obscured inputs and correct overlap pixel math
  - Passes when all inputs sit above the keyboard top line
  - Detects scrollable forms (y changes between dumps)
  - Reports `scrolled: true` when form scrolls and field still overlaps
  - Issues the correct `simctl` tap and `sendkey 41` commands
  - Ignores non-input and hidden elements
  - Derives screen height from the root AX node frame
- [x] Existing `tests/unit/qa-flutter-detectors.test.ts` still 9/9 passing
- [ ] Manual smoke test on a Flutter simulator build with a scrollable form

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>