### PR TITLE
fix(flutter): flutter_root_widget WithPreviews fallback

### DIFF
--- a/src/flutter/vm-service-client.ts
+++ b/src/flutter/vm-service-client.ts
@@ -203,13 +203,26 @@ export class FlutterVMClient {
    * a Flutter-Inspector lifetime scope — a stable group name is fine for
    * LLM-driven introspection; DevTools rotates groups per request to
    * manage memory but for one-shot MCP calls the default is safe.
+   *
+   * Falls back to `getRootWidgetSummaryTree` (without previews) if the
+   * WithPreviews variant fails (e.g. VM Service error -32000 on older
+   * Flutter versions). If both fail, the original error is rethrown.
    */
   async getRootWidgetSummaryTree(
     options?: { objectGroup?: string },
   ): Promise<Record<string, unknown>> {
-    return this.callServiceExtension('inspector.getRootWidgetSummaryTreeWithPreviews', {
-      objectGroup: options?.objectGroup ?? 'opensafari-root',
-    });
+    const params = { objectGroup: options?.objectGroup ?? 'opensafari-root' };
+    let originalError: unknown;
+    try {
+      return await this.callServiceExtension('inspector.getRootWidgetSummaryTreeWithPreviews', params);
+    } catch (err) {
+      originalError = err;
+    }
+    try {
+      return await this.callServiceExtension('inspector.getRootWidgetSummaryTree', params);
+    } catch {
+      throw originalError;
+    }
   }
 
   /**

--- a/tests/unit/flutter-vm-client-inspector.test.ts
+++ b/tests/unit/flutter-vm-client-inspector.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for FlutterVMClient.getRootWidgetSummaryTree fallback logic.
+ */
+
+import { FlutterVMClient } from '../../src/flutter/vm-service-client';
+
+describe('FlutterVMClient.getRootWidgetSummaryTree', () => {
+  let client: FlutterVMClient;
+  let callServiceExtensionSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    client = new FlutterVMClient();
+    // Inject a minimal connected state so callServiceExtension doesn't throw NO_ISOLATE
+    (client as unknown as Record<string, unknown>)['state'] = { mainIsolateId: 'isolate-1' };
+    callServiceExtensionSpy = jest.spyOn(client as unknown as { callServiceExtension: () => unknown }, 'callServiceExtension');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns WithPreviews result when it succeeds (no fallback)', async () => {
+    const tree = { type: 'MaterialApp' };
+    callServiceExtensionSpy.mockResolvedValue(tree);
+
+    const result = await client.getRootWidgetSummaryTree();
+
+    expect(result).toBe(tree);
+    expect(callServiceExtensionSpy).toHaveBeenCalledTimes(1);
+    expect(callServiceExtensionSpy).toHaveBeenCalledWith(
+      'inspector.getRootWidgetSummaryTreeWithPreviews',
+      { objectGroup: 'opensafari-root' },
+    );
+  });
+
+  it('falls back to non-Previews when WithPreviews throws', async () => {
+    const fallbackTree = { type: 'Scaffold' };
+    callServiceExtensionSpy
+      .mockRejectedValueOnce(new Error('VM Service error: Server error (code: -32000)'))
+      .mockResolvedValueOnce(fallbackTree);
+
+    const result = await client.getRootWidgetSummaryTree();
+
+    expect(result).toBe(fallbackTree);
+    expect(callServiceExtensionSpy).toHaveBeenCalledTimes(2);
+    expect(callServiceExtensionSpy).toHaveBeenNthCalledWith(
+      1,
+      'inspector.getRootWidgetSummaryTreeWithPreviews',
+      { objectGroup: 'opensafari-root' },
+    );
+    expect(callServiceExtensionSpy).toHaveBeenNthCalledWith(
+      2,
+      'inspector.getRootWidgetSummaryTree',
+      { objectGroup: 'opensafari-root' },
+    );
+  });
+
+  it('rethrows the original WithPreviews error when both fail', async () => {
+    const originalError = new Error('VM Service error: Server error (code: -32000)');
+    const fallbackError = new Error('fallback also failed');
+    callServiceExtensionSpy
+      .mockRejectedValueOnce(originalError)
+      .mockRejectedValueOnce(fallbackError);
+
+    await expect(client.getRootWidgetSummaryTree()).rejects.toThrow(originalError);
+  });
+
+  it('forwards a custom objectGroup to both calls', async () => {
+    callServiceExtensionSpy
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({ type: 'Text' });
+
+    await client.getRootWidgetSummaryTree({ objectGroup: 'my-group' });
+
+    expect(callServiceExtensionSpy).toHaveBeenNthCalledWith(
+      1,
+      'inspector.getRootWidgetSummaryTreeWithPreviews',
+      { objectGroup: 'my-group' },
+    );
+    expect(callServiceExtensionSpy).toHaveBeenNthCalledWith(
+      2,
+      'inspector.getRootWidgetSummaryTree',
+      { objectGroup: 'my-group' },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `getRootWidgetSummaryTreeWithPreviews` returns VM Service error -32000 on some Flutter versions (verified on Flutter 3.11.3 + rebuild_test_app)
- `getRootWidgetSummaryTree` (without previews) works correctly on the same versions
- `FlutterVMClient.getRootWidgetSummaryTree` now tries the `WithPreviews` variant first and transparently falls back to the non-Previews variant on any error
- If both calls fail, the original `WithPreviews` error is rethrown so the caller sees the upstream cause
- Closes #436

## Test plan

- [ ] Happy path: `WithPreviews` succeeds → fallback never called, result returned as-is
- [ ] Fallback path: `WithPreviews` throws → `getRootWidgetSummaryTree` called with same params, its result returned
- [ ] Both fail: original `WithPreviews` error rethrown (not the fallback error)
- [ ] Custom `objectGroup` forwarded correctly to both calls
- [ ] `npm run build` passes with no new errors
- [ ] `npm test` passes (1314 tests, 92 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)