### PR TITLE
fix(flutter): flutter_inspect_selection filters _extensionType

### DIFF
--- a/src/tools/flutter-inspector.ts
+++ b/src/tools/flutter-inspector.ts
@@ -218,7 +218,16 @@ export function registerFlutterInspectSelectionTool(server: MCPServer): void {
         });
 
         const node = (raw.result ?? raw) as Record<string, unknown>;
-        const hasSelection = !!(node.type || node.valueId || node.description);
+        // isWidgetSelection rejects VM Service metadata-only responses (e.g. type="_extensionType"
+        // or "Sentinel") that the VM returns when no widget is actually selected.
+        const isWidgetSelection = (n: Record<string, unknown>): boolean => {
+          if (typeof n.valueId === 'string' && n.valueId.length > 0) return true;
+          const t = typeof n.type === 'string' ? n.type : '';
+          // Reject VM Service metadata-only responses
+          if (t.startsWith('_extension') || t === 'Sentinel') return false;
+          return !!(t || n.description);
+        };
+        const hasSelection = isWidgetSelection(node);
         const selection = hasSelection ? summariseNode(node, 0) : null;
 
         return {

--- a/tests/unit/flutter-inspector.test.ts
+++ b/tests/unit/flutter-inspector.test.ts
@@ -252,6 +252,27 @@ describe('flutter_inspect_selection', () => {
     }));
   });
 
+  it('returns status=empty when VM responds with _extensionType only (no real selection)', async () => {
+    // VM Service returns {type: "_extensionType"} when getSelectedSummaryWidget is called
+    // with nothing selected — this is metadata, not a real widget.
+    mockGetSelectedWidget.mockResolvedValue({ type: '_extensionType' });
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+    expect(body.status).toBe('empty');
+    expect(body.selection).toBeNull();
+    expect(body.hint).toContain('show=true');
+  });
+
+  it('returns status=ok for a response with only valueId (real widget, no type/description yet)', async () => {
+    // Real widgets always carry a valueId (inspector node ID), even if type/description
+    // are absent; a valueId alone is sufficient to treat this as a real selection.
+    mockGetSelectedWidget.mockResolvedValue({ valueId: 'inspector-99' });
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+    expect(body.status).toBe('ok');
+    expect(body.selection).not.toBeNull();
+  });
+
   it('errors when not connected', async () => {
     mockIsConnected.mockReturnValue(false);
     const result = await handler('s', {});


### PR DESCRIPTION
## Summary

- `registerFlutterInspectSelectionTool` was returning `status: "ok"` with a bogus `{type: "_extensionType"}` payload when no widget was selected, because the VM Service returns `type: "_extensionType"` metadata (not a real widget type) for empty-selection responses
- Added `isWidgetSelection()` helper that requires a real `valueId` OR a non-metadata `type`/`description`; explicitly rejects `_extensionType` and `Sentinel` VM Service types
- Fixes #436

## Test plan

- [ ] `_extensionType`-only response now correctly returns `status: "empty"`, `selection: null`, and the usage hint
- [ ] Response with only `valueId` (real widget, no type/description) still returns `status: "ok"`
- [ ] All 1312 existing tests continue to pass (`npm test`)
- [ ] `npm run build` passes with zero errors (2 pre-existing `ws` optional-dep warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)