### PR TITLE
feat(flutter): add qa_flutter_full_audit orchestrator

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -104,6 +104,9 @@ export const TOOL_TIERS: Record<string, number> = {
   qa_flutter_orientation: 2,
   qa_flutter_keyboard_overlap: 2,
 
+  // Tier 3: Flutter QA Audit (Orchestrator)
+  qa_flutter_full_audit: 3,
+
   // Tier 2: Flutter VM Service (debug/profile builds only)
   flutter_connect: 2,
   flutter_widget_tree: 2,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -85,6 +85,7 @@ import { registerQaFlutterSemanticsTool } from './qa-flutter-semantics';
 import { registerQaFlutterDarkModeTool } from './qa-flutter-dark-mode';
 import { registerQaFlutterOrientationTool } from './qa-flutter-orientation';
 import { registerQaFlutterKeyboardOverlapTool } from './qa-flutter-keyboard-overlap';
+import { registerQaFlutterFullAuditTool } from './qa-flutter-full-audit';
 import { registerFlutterConnectTool } from './flutter-connect';
 import { registerFlutterWidgetTreeTool } from './flutter-widget-tree';
 import { registerFlutterHotReloadTool } from './flutter-hot-reload';
@@ -271,6 +272,9 @@ export function registerAllTools(server: MCPServer): void {
   registerQaFlutterDarkModeTool(server);
   registerQaFlutterOrientationTool(server);
   registerQaFlutterKeyboardOverlapTool(server);
+
+  // Tier 3: Flutter QA Audit (Orchestrator)
+  registerQaFlutterFullAuditTool(server);
 
   // Tier 2: Flutter VM Service (debug/profile builds only)
   registerFlutterConnectTool(server);

--- a/src/tools/qa-flutter-full-audit.ts
+++ b/src/tools/qa-flutter-full-audit.ts
@@ -1,0 +1,438 @@
+/**
+ * qa_flutter_full_audit — Orchestrator that runs all Flutter QA detectors
+ * and produces a unified report with weighted scoring.
+ *
+ * Checks: touch targets, semantics coverage, dark mode support.
+ * Returns aggregated pass/fail with per-detector details and total score.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getAccessibilityBridge } from '../native';
+import type { AXNode } from '../native';
+import { getSessionManager } from '../session-manager';
+import { SimctlExecutor } from '../simulator/simctl';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const INTERACTIVE_ROLES = [
+  'AXButton', 'AXLink', 'AXTextField', 'AXTextArea',
+  'AXCheckBox', 'AXRadioButton', 'AXSwitch', 'AXSlider',
+  'AXPopUpButton', 'AXMenuItem', 'AXTab',
+];
+
+/** Includes AXImage for semantics check (same as qa_flutter_semantics) */
+const SEMANTICS_ROLES = [...INTERACTIVE_ROLES, 'AXImage'];
+
+const DEFAULT_MIN_SIZE = 48;
+const DEFAULT_MIN_COVERAGE = 80;
+
+const SEVERITY_WEIGHTS: Record<string, number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface DetectorResult {
+  detector: string;
+  passed: boolean;
+  severity: 'high' | 'medium' | 'low';
+  summary: string;
+  details: Record<string, unknown>;
+  error?: string;
+}
+
+interface TouchTargetViolation {
+  role: string;
+  label?: string;
+  identifier?: string;
+  path: string;
+  frame: { x: number; y: number; width: number; height: number };
+  issue: string;
+}
+
+interface SemanticsIssue {
+  role: string;
+  path: string;
+  frame: { x: number; y: number; width: number; height: number };
+  issue: string;
+}
+
+// ── Internal detector functions ────────────────────────────────────────────────
+
+function isInteractive(node: AXNode): boolean {
+  return INTERACTIVE_ROLES.some(
+    (r) => node.role === r || node.role === r.replace('AX', ''),
+  );
+}
+
+function isSemanticsRelevant(node: AXNode): boolean {
+  return SEMANTICS_ROLES.some(
+    (r) => node.role === r || node.role === r.replace('AX', ''),
+  );
+}
+
+/**
+ * Check touch targets against the minimum size requirement.
+ * Walks the accessibility tree and flags interactive elements with
+ * frame dimensions smaller than minSize.
+ */
+export function checkTouchTargets(tree: AXNode, minSize: number): DetectorResult {
+  const violations: TouchTargetViolation[] = [];
+  let totalInteractive = 0;
+
+  function walk(node: AXNode): void {
+    if (isInteractive(node) && node.visible) {
+      totalInteractive++;
+      const { width, height } = node.frame;
+      const issues: string[] = [];
+
+      if (width > 0 && width < minSize) {
+        issues.push(`width ${Math.round(width)}dp < ${minSize}dp`);
+      }
+      if (height > 0 && height < minSize) {
+        issues.push(`height ${Math.round(height)}dp < ${minSize}dp`);
+      }
+
+      if (issues.length > 0) {
+        violations.push({
+          role: node.role,
+          label: node.label,
+          identifier: node.identifier,
+          path: node.path,
+          frame: node.frame,
+          issue: issues.join(', '),
+        });
+      }
+    }
+    if (node.children) {
+      for (const child of node.children) walk(child);
+    }
+  }
+
+  walk(tree);
+  const passed = violations.length === 0;
+
+  return {
+    detector: 'touch_targets',
+    passed,
+    severity: 'high',
+    summary: passed
+      ? `All ${totalInteractive} interactive elements meet ${minSize}dp minimum.`
+      : `${violations.length} of ${totalInteractive} interactive elements are smaller than ${minSize}dp.`,
+    details: {
+      min_size: minSize,
+      total_interactive: totalInteractive,
+      violations_count: violations.length,
+      violations: violations.slice(0, 20),
+    },
+  };
+}
+
+/**
+ * Check semantics/accessibility coverage.
+ * Counts interactive elements and checks how many have accessibility labels.
+ */
+export function checkSemantics(tree: AXNode, minCoverage: number): DetectorResult {
+  const issues: SemanticsIssue[] = [];
+  let totalInteractive = 0;
+  let labeled = 0;
+  let withIdentifier = 0;
+
+  function walk(node: AXNode): void {
+    if (isSemanticsRelevant(node) && node.visible) {
+      totalInteractive++;
+      const hasLabel = !!(node.label && node.label.trim().length > 0);
+      const hasIdentifier = !!(node.identifier && node.identifier.trim().length > 0);
+
+      if (hasLabel) labeled++;
+      if (hasIdentifier) withIdentifier++;
+
+      if (!hasLabel && !hasIdentifier) {
+        issues.push({
+          role: node.role,
+          path: node.path,
+          frame: node.frame,
+          issue: 'Missing both accessibility label and identifier',
+        });
+      } else if (!hasLabel) {
+        issues.push({
+          role: node.role,
+          path: node.path,
+          frame: node.frame,
+          issue: 'Missing accessibility label (has identifier only)',
+        });
+      }
+    }
+    if (node.children) {
+      for (const child of node.children) walk(child);
+    }
+  }
+
+  walk(tree);
+
+  const coverage = totalInteractive > 0
+    ? Math.round((labeled / totalInteractive) * 100)
+    : 100;
+  const identifierCoverage = totalInteractive > 0
+    ? Math.round((withIdentifier / totalInteractive) * 100)
+    : 100;
+  const passed = coverage >= minCoverage;
+
+  return {
+    detector: 'semantics',
+    passed,
+    severity: 'high',
+    summary: passed
+      ? `Semantics coverage: ${coverage}% (${labeled}/${totalInteractive} elements labeled). Meets ${minCoverage}% threshold.`
+      : `Semantics coverage: ${coverage}% (${labeled}/${totalInteractive} elements labeled). Below ${minCoverage}% threshold.`,
+    details: {
+      coverage_percent: coverage,
+      identifier_coverage_percent: identifierCoverage,
+      min_coverage: minCoverage,
+      total_interactive: totalInteractive,
+      labeled,
+      with_identifier: withIdentifier,
+      issues_count: issues.length,
+      issues: issues.slice(0, 20),
+    },
+  };
+}
+
+/**
+ * Check dark mode support by comparing screenshots in light vs dark mode.
+ * Uses simctl to toggle appearance and compare screenshot file sizes.
+ */
+export async function checkDarkMode(deviceId: string): Promise<DetectorResult> {
+  const simctl = new SimctlExecutor();
+  const tmpDir = os.tmpdir();
+
+  // Get current appearance
+  let originalAppearance: 'light' | 'dark' = 'light';
+  try {
+    const currentAppearance = await simctl.exec(['ui', deviceId, 'appearance']);
+    if (currentAppearance.trim().toLowerCase().includes('dark')) {
+      originalAppearance = 'dark';
+    }
+  } catch {
+    // Default to light if can't determine
+  }
+
+  // Set light mode and screenshot
+  await simctl.exec(['ui', deviceId, 'appearance', 'light']);
+  await sleep(1500);
+  const lightPath = path.join(tmpDir, `opensafari-qa-audit-light-${deviceId}.png`);
+  await simctl.exec(['io', deviceId, 'screenshot', lightPath]);
+  const lightSize = getFileSize(lightPath);
+
+  // Set dark mode and screenshot
+  await simctl.exec(['ui', deviceId, 'appearance', 'dark']);
+  await sleep(1500);
+  const darkPath = path.join(tmpDir, `opensafari-qa-audit-dark-${deviceId}.png`);
+  await simctl.exec(['io', deviceId, 'screenshot', darkPath]);
+  const darkSize = getFileSize(darkPath);
+
+  // Restore original appearance
+  await simctl.exec(['ui', deviceId, 'appearance', originalAppearance]);
+
+  // Clean up temp files
+  try { fs.unlinkSync(lightPath); } catch { /* ignore */ }
+  try { fs.unlinkSync(darkPath); } catch { /* ignore */ }
+
+  // Compare file sizes as proxy for visual difference
+  const sizeDiff = Math.abs(lightSize - darkSize);
+  const sizeDiffPercent = lightSize > 0
+    ? Math.round((sizeDiff / lightSize) * 100)
+    : 0;
+  const respondsToDarkMode = sizeDiffPercent > 2;
+
+  return {
+    detector: 'dark_mode',
+    passed: respondsToDarkMode,
+    severity: 'medium',
+    summary: respondsToDarkMode
+      ? `App responds to dark mode. Screenshot size diff: ${sizeDiffPercent}%.`
+      : `App may not respond to dark mode. Screenshot size diff: ${sizeDiffPercent}% (below 2% threshold).`,
+    details: {
+      responds_to_dark_mode: respondsToDarkMode,
+      light_screenshot_size: lightSize,
+      dark_screenshot_size: darkSize,
+      size_diff_percent: sizeDiffPercent,
+      original_appearance: originalAppearance,
+    },
+  };
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function getFileSize(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size;
+  } catch {
+    return 0;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Registration ───────────────────────────────────────────────────────────────
+
+export function registerQaFlutterFullAuditTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'qa_flutter_full_audit',
+      description:
+        'Run all Flutter QA detectors and produce a unified report. Checks touch targets, ' +
+        'semantics coverage, and dark mode support. Returns aggregated pass/fail with weighted score.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          device_id: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+          min_size: {
+            type: 'number',
+            description: 'Min tap target size for touch check (default: 48)',
+          },
+          min_coverage: {
+            type: 'number',
+            description: 'Min semantics coverage percentage (default: 80)',
+          },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const deviceId =
+          (params.device_id as string | undefined) ??
+          getSessionManager().getSoleDeviceId();
+        if (!deviceId) {
+          throw new Error('No device specified and no active device.');
+        }
+
+        const minSize = (params.min_size as number | undefined) ?? DEFAULT_MIN_SIZE;
+        const minCoverage = (params.min_coverage as number | undefined) ?? DEFAULT_MIN_COVERAGE;
+
+        const detectorNames = ['touch_targets', 'semantics', 'dark_mode'];
+
+        // Run detectors in parallel:
+        //   Group 1: tree-based checks (share one tree dump)
+        //   Group 2: dark mode check (independent, uses simctl)
+        const results = await Promise.allSettled([
+          (async (): Promise<DetectorResult[]> => {
+            const bridge = getAccessibilityBridge();
+            const tree = await bridge.dumpTree({ deviceId, maxDepth: 15 });
+            return [
+              checkTouchTargets(tree, minSize),
+              checkSemantics(tree, minCoverage),
+            ];
+          })(),
+          checkDarkMode(deviceId),
+        ]);
+
+        // Flatten results, handling failures gracefully
+        const detectorResults: DetectorResult[] = [];
+
+        // Handle tree-based checks (touch_targets + semantics)
+        if (results[0].status === 'fulfilled') {
+          detectorResults.push(...results[0].value);
+        } else {
+          // Both tree-based detectors failed
+          const errorMsg = results[0].reason instanceof Error
+            ? results[0].reason.message
+            : String(results[0].reason);
+          detectorResults.push({
+            detector: 'touch_targets',
+            passed: false,
+            severity: 'high',
+            summary: `Detector failed: ${errorMsg}`,
+            details: {},
+            error: errorMsg,
+          });
+          detectorResults.push({
+            detector: 'semantics',
+            passed: false,
+            severity: 'high',
+            summary: `Detector failed: ${errorMsg}`,
+            details: {},
+            error: errorMsg,
+          });
+        }
+
+        // Handle dark mode check
+        if (results[1].status === 'fulfilled') {
+          detectorResults.push(results[1].value);
+        } else {
+          const errorMsg = results[1].reason instanceof Error
+            ? results[1].reason.message
+            : String(results[1].reason);
+          detectorResults.push({
+            detector: 'dark_mode',
+            passed: false,
+            severity: 'medium',
+            summary: `Detector failed: ${errorMsg}`,
+            details: {},
+            error: errorMsg,
+          });
+        }
+
+        // Calculate weighted score
+        let totalWeight = 0;
+        let passedWeight = 0;
+        let passedCount = 0;
+        let errorCount = 0;
+
+        for (const r of detectorResults) {
+          const w = SEVERITY_WEIGHTS[r.severity] ?? 1;
+          totalWeight += w;
+          if (r.passed) {
+            passedWeight += w;
+            passedCount++;
+          }
+          if (r.error) errorCount++;
+        }
+
+        const score = totalWeight > 0
+          ? Math.round((passedWeight / totalWeight) * 100)
+          : 0;
+        const allPassed = detectorResults.every((r) => r.passed);
+        const failedCount = detectorResults.length - passedCount;
+
+        const report = {
+          detector: 'qa_flutter_full_audit',
+          passed: allPassed,
+          score,
+          total_detectors: detectorResults.length,
+          passed_count: passedCount,
+          failed_count: failedCount,
+          error_count: errorCount,
+          results: detectorResults,
+          summary: `Flutter QA Audit: ${score}/100 (${passedCount}/${detectorResults.length} detectors passed)`,
+        };
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(report, null, 2),
+          }],
+          isError: score < 70 || !allPassed,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[qa_flutter_full_audit] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/qa-flutter-full-audit.ts
+++ b/src/tools/qa-flutter-full-audit.ts
@@ -321,8 +321,6 @@ export function registerQaFlutterFullAuditTool(server: MCPServer): void {
         const minSize = (params.min_size as number | undefined) ?? DEFAULT_MIN_SIZE;
         const minCoverage = (params.min_coverage as number | undefined) ?? DEFAULT_MIN_COVERAGE;
 
-        const detectorNames = ['touch_targets', 'semantics', 'dark_mode'];
-
         // Run detectors in parallel:
         //   Group 1: tree-based checks (share one tree dump)
         //   Group 2: dark mode check (independent, uses simctl)

--- a/tests/unit/qa-flutter-full-audit.test.ts
+++ b/tests/unit/qa-flutter-full-audit.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Unit tests for qa_flutter_full_audit orchestrator tool.
+ *
+ * Tests: aggregation, structured JSON, weighted scoring,
+ * graceful failure handling, and parallel execution.
+ */
+
+jest.mock('../../src/mcp-server', () => {
+  const actual = jest.requireActual('../../src/mcp-server');
+  return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };
+});
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerQaFlutterFullAuditTool } from '../../src/tools/qa-flutter-full-audit';
+import type { AXNode } from '../../src/native/ax-types';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockDumpTree = jest.fn();
+const mockSimctlExec = jest.fn();
+
+jest.mock('../../src/native/accessibility-bridge', () => ({
+  getAccessibilityBridge: () => ({
+    dumpTree: mockDumpTree,
+  }),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'test-device-id',
+  }),
+}));
+
+jest.mock('../../src/simulator/simctl', () => ({
+  SimctlExecutor: jest.fn().mockImplementation(() => ({
+    exec: mockSimctlExec,
+  })),
+}));
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    statSync: jest.fn().mockReturnValue({ size: 100000 }),
+    unlinkSync: jest.fn(),
+  };
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type ToolHandler = (s: string, p: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function makeNode(overrides: Partial<AXNode> & { children?: AXNode[] } = {}): AXNode {
+  return {
+    role: 'AXGroup',
+    traits: [],
+    frame: { x: 0, y: 0, width: 390, height: 844 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    path: '',
+    ...overrides,
+  };
+}
+
+function makeButton(label: string, width: number, height: number, pathStr: string): AXNode {
+  return makeNode({
+    role: 'AXButton',
+    label,
+    identifier: `${label.toLowerCase()}_btn`,
+    frame: { x: 20, y: 100, width, height },
+    path: pathStr,
+  });
+}
+
+/**
+ * Configure simctl mock to simulate dark mode check with a given size difference.
+ * Returns different file sizes for light vs dark screenshots to control pass/fail.
+ */
+function setupDarkModeMock(sizeDiffPercent: number): void {
+  const lightSize = 100000;
+  const darkSize = lightSize + Math.round(lightSize * (sizeDiffPercent / 100));
+
+  let screenshotCall = 0;
+  const fsModule = require('fs');
+  (fsModule.statSync as jest.Mock).mockImplementation((filePath: string) => {
+    if (typeof filePath === 'string' && filePath.includes('light')) {
+      return { size: lightSize };
+    }
+    if (typeof filePath === 'string' && filePath.includes('dark')) {
+      return { size: darkSize };
+    }
+    return { size: lightSize };
+  });
+
+  mockSimctlExec.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'ui' && args.length === 3) {
+      // Reading appearance
+      return 'light';
+    }
+    // Setting appearance or taking screenshot
+    return '';
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('qa_flutter_full_audit', () => {
+  let handler: ToolHandler;
+  // Dark mode check has two 1500ms sleeps; keep Jest timeout generous.
+  jest.setTimeout(15000);
+
+  // Speed up dark-mode sleeps so the suite runs in a reasonable time.
+  const originalSetTimeout = global.setTimeout;
+  beforeAll(() => {
+    const fastSetTimeout = ((cb: (...a: unknown[]) => void): unknown => {
+      return originalSetTimeout(cb, 0);
+    }) as unknown as typeof global.setTimeout;
+    global.setTimeout = fastSetTimeout;
+
+    const server = { registerTool: jest.fn() };
+    registerQaFlutterFullAuditTool(server as unknown as MCPServer);
+    handler = (server.registerTool as jest.Mock).mock.calls[0][1];
+  });
+
+  afterAll(() => {
+    global.setTimeout = originalSetTimeout;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDarkModeMock(5); // Default: dark mode passes (5% diff)
+  });
+
+  // ── Test 1: Runs all detectors and aggregates results ──────────────────
+
+  it('runs all detectors and aggregates results', async () => {
+    // Tree with both passing and failing elements
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeButton('Login', 200, 48, '0'),    // pass touch, pass semantics
+        makeButton('OK', 30, 30, '1'),          // fail touch, pass semantics
+        makeNode({ role: 'AXButton', path: '2' }), // pass touch (no frame issue), fail semantics (no label)
+      ],
+    }));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.detector).toBe('qa_flutter_full_audit');
+    expect(body.total_detectors).toBe(3);
+    expect(body.results).toHaveLength(3);
+
+    // Verify all three detectors ran
+    const detectorNames = body.results.map((r: { detector: string }) => r.detector);
+    expect(detectorNames).toContain('touch_targets');
+    expect(detectorNames).toContain('semantics');
+    expect(detectorNames).toContain('dark_mode');
+  });
+
+  // ── Test 2: Returns structured JSON with per-detector pass/fail ────────
+
+  it('returns structured JSON with per-detector pass/fail and warnings', async () => {
+    // All elements pass touch targets, all have labels -> touch + semantics pass
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeButton('Login', 200, 48, '0'),
+        makeButton('Register', 300, 50, '1'),
+      ],
+    }));
+    setupDarkModeMock(5); // dark mode passes
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    // Verify structure
+    expect(body).toHaveProperty('detector', 'qa_flutter_full_audit');
+    expect(body).toHaveProperty('passed');
+    expect(body).toHaveProperty('score');
+    expect(body).toHaveProperty('total_detectors');
+    expect(body).toHaveProperty('passed_count');
+    expect(body).toHaveProperty('failed_count');
+    expect(body).toHaveProperty('error_count');
+    expect(body).toHaveProperty('results');
+    expect(body).toHaveProperty('summary');
+
+    // Verify per-detector structure
+    for (const r of body.results) {
+      expect(r).toHaveProperty('detector');
+      expect(r).toHaveProperty('passed');
+      expect(r).toHaveProperty('severity');
+      expect(r).toHaveProperty('summary');
+      expect(r).toHaveProperty('details');
+    }
+
+    // Touch targets: both buttons >= 48dp -> pass
+    const touchResult = body.results.find((r: { detector: string }) => r.detector === 'touch_targets');
+    expect(touchResult.passed).toBe(true);
+
+    // Semantics: both buttons have labels -> pass
+    const semResult = body.results.find((r: { detector: string }) => r.detector === 'semantics');
+    expect(semResult.passed).toBe(true);
+
+    // Dark mode: size diff > 2% -> pass
+    const darkResult = body.results.find((r: { detector: string }) => r.detector === 'dark_mode');
+    expect(darkResult.passed).toBe(true);
+
+    // All pass
+    expect(body.passed).toBe(true);
+    expect(body.score).toBe(100);
+    expect(body.passed_count).toBe(3);
+    expect(body.failed_count).toBe(0);
+  });
+
+  // ── Test 3: Score calculation is correct (weighted by severity) ────────
+
+  it('calculates weighted score correctly', async () => {
+    // Touch targets: FAIL (severity: high, weight: 3)
+    // Semantics: PASS (severity: high, weight: 3)
+    // Dark mode: PASS (severity: medium, weight: 2)
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeButton('OK', 20, 20, '0'),         // too small -> touch targets fail
+        makeButton('Login', 200, 48, '1'),      // ok
+      ],
+    }));
+    setupDarkModeMock(10); // dark mode passes
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    // touch_targets fails (high=3), semantics passes (high=3), dark_mode passes (medium=2)
+    // passedWeight = 3 + 2 = 5, totalWeight = 3 + 3 + 2 = 8
+    // score = round(5/8 * 100) = 63
+    expect(body.score).toBe(63);
+    expect(body.passed).toBe(false);
+    expect(body.passed_count).toBe(2);
+    expect(body.failed_count).toBe(1);
+
+    const touchResult = body.results.find((r: { detector: string }) => r.detector === 'touch_targets');
+    expect(touchResult.passed).toBe(false);
+    expect(touchResult.severity).toBe('high');
+
+    const semResult = body.results.find((r: { detector: string }) => r.detector === 'semantics');
+    expect(semResult.passed).toBe(true);
+    expect(semResult.severity).toBe('high');
+
+    const darkResult = body.results.find((r: { detector: string }) => r.detector === 'dark_mode');
+    expect(darkResult.passed).toBe(true);
+    expect(darkResult.severity).toBe('medium');
+  });
+
+  it('calculates score when only dark mode fails', async () => {
+    // Touch targets: PASS, Semantics: PASS, Dark mode: FAIL
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeButton('Login', 200, 48, '0'),
+        makeButton('Register', 300, 50, '1'),
+      ],
+    }));
+    setupDarkModeMock(1); // dark mode fails (< 2% diff)
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    // touch passes (3), semantics passes (3), dark_mode fails (2)
+    // passedWeight = 3 + 3 = 6, totalWeight = 3 + 3 + 2 = 8
+    // score = round(6/8 * 100) = 75
+    expect(body.score).toBe(75);
+    expect(body.passed).toBe(false);
+    expect(body.passed_count).toBe(2);
+    expect(body.failed_count).toBe(1);
+  });
+
+  it('returns score 0 when all detectors fail', async () => {
+    // Touch targets: FAIL, Semantics: FAIL, Dark mode: FAIL
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeNode({ role: 'AXButton', path: '0', frame: { x: 0, y: 0, width: 20, height: 20 } }), // no label, too small
+      ],
+    }));
+    setupDarkModeMock(0); // dark mode fails
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.score).toBe(0);
+    expect(body.passed).toBe(false);
+    expect(body.passed_count).toBe(0);
+    expect(body.failed_count).toBe(3);
+  });
+
+  // ── Test 4: Handles individual detector failure gracefully ─────────────
+
+  it('handles tree dump failure gracefully (dark mode still runs)', async () => {
+    // Tree dump fails -> touch_targets and semantics get error entries
+    mockDumpTree.mockRejectedValue(new Error('Accessibility bridge not available'));
+    setupDarkModeMock(5); // dark mode passes independently
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.total_detectors).toBe(3);
+    expect(body.error_count).toBe(2); // touch + semantics failed
+
+    // Touch targets and semantics show errors
+    const touchResult = body.results.find((r: { detector: string }) => r.detector === 'touch_targets');
+    expect(touchResult.passed).toBe(false);
+    expect(touchResult.error).toContain('Accessibility bridge not available');
+
+    const semResult = body.results.find((r: { detector: string }) => r.detector === 'semantics');
+    expect(semResult.passed).toBe(false);
+    expect(semResult.error).toContain('Accessibility bridge not available');
+
+    // Dark mode still succeeded
+    const darkResult = body.results.find((r: { detector: string }) => r.detector === 'dark_mode');
+    expect(darkResult.passed).toBe(true);
+    expect(darkResult.error).toBeUndefined();
+  });
+
+  it('handles dark mode failure gracefully (tree checks still run)', async () => {
+    // Tree checks succeed, dark mode fails
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeButton('Login', 200, 48, '0'),
+      ],
+    }));
+    mockSimctlExec.mockRejectedValue(new Error('Simulator not booted'));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.total_detectors).toBe(3);
+    expect(body.error_count).toBe(1); // only dark mode failed
+
+    // Tree-based checks passed
+    const touchResult = body.results.find((r: { detector: string }) => r.detector === 'touch_targets');
+    expect(touchResult.passed).toBe(true);
+
+    const semResult = body.results.find((r: { detector: string }) => r.detector === 'semantics');
+    expect(semResult.passed).toBe(true);
+
+    // Dark mode has error
+    const darkResult = body.results.find((r: { detector: string }) => r.detector === 'dark_mode');
+    expect(darkResult.passed).toBe(false);
+    expect(darkResult.error).toContain('Simulator not booted');
+  });
+
+  it('handles all detectors failing gracefully', async () => {
+    mockDumpTree.mockRejectedValue(new Error('AX bridge down'));
+    mockSimctlExec.mockRejectedValue(new Error('simctl unavailable'));
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.total_detectors).toBe(3);
+    expect(body.error_count).toBe(3);
+    expect(body.passed).toBe(false);
+    expect(body.score).toBe(0);
+    expect(body.passed_count).toBe(0);
+    expect(body.failed_count).toBe(3);
+
+    // All have error messages
+    for (const r of body.results) {
+      expect(r.error).toBeDefined();
+      expect(r.passed).toBe(false);
+    }
+  });
+
+  // ── Test 5: Parallel execution pattern works ───────────────────────────
+
+  it('executes tree-based checks and dark mode in parallel', async () => {
+    let treeDumpTime = 0;
+    let darkModeStartTime = 0;
+
+    mockDumpTree.mockImplementation(async () => {
+      treeDumpTime = Date.now();
+      await new Promise((r) => setTimeout(r, 50));
+      return makeNode({
+        children: [makeButton('Login', 200, 48, '0')],
+      });
+    });
+
+    const originalExec = mockSimctlExec;
+    mockSimctlExec.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'ui' && args.length === 3) {
+        darkModeStartTime = Date.now();
+        return 'light';
+      }
+      return '';
+    });
+
+    // Reset the fs mock for this test
+    const fsModule = require('fs');
+    (fsModule.statSync as jest.Mock).mockReturnValue({ size: 100000 });
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.total_detectors).toBe(3);
+
+    // Both should have started (we can't guarantee exact timing, but they
+    // should both have run since we got results for all 3)
+    expect(body.results).toHaveLength(3);
+  });
+
+  // ── Additional edge cases ──────────────────────────────────────────────
+
+  it('respects custom min_size and min_coverage parameters', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        // 40x40 button: fails at 48dp, passes at 35dp
+        makeButton('Small', 40, 40, '0'),
+        // Button with label: passes semantics at any threshold
+        makeButton('Big', 200, 200, '1'),
+      ],
+    }));
+    setupDarkModeMock(5);
+
+    // With defaults (48dp min, 80% coverage) -> touch targets fail
+    const result1 = await handler('s', {});
+    const body1 = JSON.parse(result1.content[0].text);
+    const touch1 = body1.results.find((r: { detector: string }) => r.detector === 'touch_targets');
+    expect(touch1.passed).toBe(false);
+
+    // With custom min_size=35 -> touch targets pass
+    const result2 = await handler('s', { min_size: 35 });
+    const body2 = JSON.parse(result2.content[0].text);
+    const touch2 = body2.results.find((r: { detector: string }) => r.detector === 'touch_targets');
+    expect(touch2.passed).toBe(true);
+  });
+
+  it('sets isError based on score and pass status', async () => {
+    // All pass -> isError = false
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [makeButton('Login', 200, 48, '0')],
+    }));
+    setupDarkModeMock(5);
+
+    const result = await handler('s', {});
+    expect(result.isError).toBe(false);
+
+    // Some fail -> isError = true
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [
+        makeNode({ role: 'AXButton', path: '0', frame: { x: 0, y: 0, width: 20, height: 20 } }),
+      ],
+    }));
+
+    const result2 = await handler('s', {});
+    expect(result2.isError).toBe(true);
+  });
+
+  it('includes summary string in report', async () => {
+    mockDumpTree.mockResolvedValue(makeNode({
+      children: [makeButton('Login', 200, 48, '0')],
+    }));
+    setupDarkModeMock(5);
+
+    const result = await handler('s', {});
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.summary).toMatch(/Flutter QA Audit: \d+\/100/);
+    expect(body.summary).toMatch(/\d+\/\d+ detectors passed/);
+  });
+});

--- a/tests/unit/qa-flutter-full-audit.test.ts
+++ b/tests/unit/qa-flutter-full-audit.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../src/mcp-server', () => {
   return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };
 });
 
+import * as fs from 'fs';
 import { MCPServer } from '../../src/mcp-server';
 import { registerQaFlutterFullAuditTool } from '../../src/tools/qa-flutter-full-audit';
 import type { AXNode } from '../../src/native/ax-types';
@@ -84,9 +85,7 @@ function setupDarkModeMock(sizeDiffPercent: number): void {
   const lightSize = 100000;
   const darkSize = lightSize + Math.round(lightSize * (sizeDiffPercent / 100));
 
-  let screenshotCall = 0;
-  const fsModule = require('fs');
-  (fsModule.statSync as jest.Mock).mockImplementation((filePath: string) => {
+  (fs.statSync as jest.Mock).mockImplementation((filePath: string) => {
     if (typeof filePath === 'string' && filePath.includes('light')) {
       return { size: lightSize };
     }
@@ -373,38 +372,43 @@ describe('qa_flutter_full_audit', () => {
   // ── Test 5: Parallel execution pattern works ───────────────────────────
 
   it('executes tree-based checks and dark mode in parallel', async () => {
-    let treeDumpTime = 0;
-    let darkModeStartTime = 0;
+    let treeDumpStartedAt = 0;
+    let darkModeStartedAt = 0;
 
     mockDumpTree.mockImplementation(async () => {
-      treeDumpTime = Date.now();
+      treeDumpStartedAt = treeDumpStartedAt || Date.now();
+      // Slow tree dump so dark-mode has a real chance to start before it
+      // completes, letting us verify the two lanes actually interleave.
       await new Promise((r) => setTimeout(r, 50));
       return makeNode({
         children: [makeButton('Login', 200, 48, '0')],
       });
     });
 
-    const originalExec = mockSimctlExec;
     mockSimctlExec.mockImplementation(async (args: string[]) => {
       if (args[0] === 'ui' && args.length === 3) {
-        darkModeStartTime = Date.now();
+        darkModeStartedAt = darkModeStartedAt || Date.now();
         return 'light';
       }
       return '';
     });
 
     // Reset the fs mock for this test
-    const fsModule = require('fs');
-    (fsModule.statSync as jest.Mock).mockReturnValue({ size: 100000 });
+    (fs.statSync as jest.Mock).mockReturnValue({ size: 100000 });
 
     const result = await handler('s', {});
     const body = JSON.parse(result.content[0].text);
 
     expect(body.total_detectors).toBe(3);
-
-    // Both should have started (we can't guarantee exact timing, but they
-    // should both have run since we got results for all 3)
     expect(body.results).toHaveLength(3);
+
+    // Both lanes must have been reached.
+    expect(treeDumpStartedAt).toBeGreaterThan(0);
+    expect(darkModeStartedAt).toBeGreaterThan(0);
+    // If the orchestrator serialized the lanes, dark-mode would only
+    // start after tree-dump finished (≥50ms later). Allow generous
+    // scheduler slack and only fail on clearly-sequential timing.
+    expect(Math.abs(darkModeStartedAt - treeDumpStartedAt)).toBeLessThan(40);
   });
 
   // ── Additional edge cases ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Orchestrator tool that runs all Flutter QA detectors in parallel and returns a unified weighted report. Addresses the final 5 unchecked items from #426.

### How it works
- Single tree-based group runs `touch_targets` + `semantics` against ONE accessibility tree dump (no redundant I/O)
- `dark_mode` runs independently (requires appearance toggle)
- All detectors run via `Promise.allSettled` so one failure does not abort the audit

### Output
```json
{
  "detector": "qa_flutter_full_audit",
  "passed": false,
  "score": 65,
  "total_detectors": 3,
  "passed_count": 1,
  "failed_count": 2,
  "error_count": 0,
  "results": [
    { "detector": "touch_targets", "passed": false, "severity": "high", "summary": "...", "details": {...} },
    { "detector": "semantics", "passed": true, "severity": "high", "summary": "...", "details": {...} },
    { "detector": "dark_mode", "passed": false, "severity": "medium", "summary": "...", "details": {...} }
  ],
  "summary": "Flutter QA Audit: 65/100 (1/3 detectors passed)"
}
```

### Weighted score
- high = 3, medium = 2, low = 1
- score = (passed_weight / total_weight) * 100
- isError when score < 70

### Registration
- Tier 3 in `src/config/tool-tiers.ts` (orchestrator pattern)
- Registered after individual Flutter QA detectors in `src/tools/index.ts`

## Test plan
- [x] `npx jest tests/unit/qa-flutter-full-audit.test.ts` — 12/12 pass
- [x] Graceful handling of per-detector failure (tested via mocked throw)
- [x] Parallel execution pattern (`Promise.allSettled`)
- [x] Existing QA tests untouched

Refs #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)