### PR TITLE
docs(flutter): add Flutter QA workflow documentation (#422)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,65 @@ OpenSafari shares battle-tested infrastructure with [OpenChrome](https://github.
 
 ---
 
+## Flutter QA Workflow
+
+OpenSafari drives Flutter apps running in the iOS Simulator using the same native-app tools used for UIKit/SwiftUI. The only wrinkle is that **Flutter's accessibility tree is lazy** — it only populates when an assistive technology (VoiceOver, XCTest) connects. OpenSafari auto-activates it so widget labels are queryable.
+
+### Auto-activation (no app changes required)
+
+`app_tree`, `app_query`, `app_inspect`, `app_tap_element`, `app_wait_for`, and `app_assert_element` all call `ensureSemanticsActive()` before reading the accessibility tree. The activator:
+
+1. Quick-checks the tree — if it already has ≥5 nodes, semantics is already active.
+2. Toggles `com.apple.Accessibility.AccessibilityEnabled` via `xcrun simctl spawn defaults write` — this triggers Flutter's `SemanticsBinding` without enabling VoiceOver spoken feedback.
+3. Polls the tree (up to 3s) until it populates, or falls back gracefully if activation never succeeds.
+
+### Recommended workflow
+
+```ts
+// 1. Boot simulator and launch the Flutter app
+await device_boot('iPhone 16');
+await app_launch({ bundleId: 'com.example.flutterApp' });
+
+// 2. Terminate Safari if it's running — its background elements can
+//    dominate the macOS AX tree and hide Flutter widgets.
+await app_terminate({ bundleId: 'com.apple.mobilesafari' });
+await app_switch_app({ bundleId: 'com.example.flutterApp' });
+
+// 3. Read the tree — Flutter Semantics nodes appear automatically.
+const tree = await app_tree({ max_depth: 5 });
+
+// 4. Query widgets by label, identifier, or role.
+const button = await app_query({ label: 'Login' });
+const email  = await app_query({ identifier: 'email-field' });
+```
+
+### Making widgets queryable
+
+| Flutter API | Queryable via | Notes |
+|-------------|----------------|-------|
+| `Semantics(label: 'Login')` | `app_query({ label: 'Login' })` | Preferred for human-readable labels |
+| `Semantics(identifier: 'login-btn')` | `app_query({ identifier: 'login-btn' })` | Flutter 3.19+ — stable selector for tests |
+| Plain `Text('Counter: 42')` | `app_query({ text: 'Counter' })` | Works when the text widget auto-synthesizes semantics |
+| `Key('login-btn')` | **Not queryable** | Keys are a Flutter-internal reference — they do **not** surface to the native AX tree |
+
+### Release builds
+
+Approach A (simctl defaults write) works for both debug and release builds. If a release app still reports an empty tree, add the explicit opt-in to `main.dart`:
+
+```dart
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SemanticsBinding.instance.ensureSemantics(); // enable for OpenSafari QA
+  runApp(const MyApp());
+}
+```
+
+For debug/profile builds, `flutter_connect` + `flutter_widget_tree` additionally expose the Dart VM Service, which returns the full Flutter widget hierarchy (including render-tree nodes that never reach the native AX bridge).
+
+See [docs/troubleshooting.md](docs/troubleshooting.md) for common failure modes (empty trees, missing labels, Safari shadowing).
+
+---
+
 ## Quick Start
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,3 +14,6 @@
 | Port conflict | Another process on 9222 | Use `--webkit-debug-port` flag |
 | Rotation failed | Simulator.app not open | Rotation requires GUI; use WebKit viewport fallback |
 | Dark mode toggle failed | Device not booted | Boot device first with `device_boot` |
+| `app_tree` returns empty tree on Flutter app | Flutter's Semantics tree is lazy — it only populates when an assistive technology connects | `app_tree`, `app_query`, and `app_inspect` auto-call `ensureSemanticsActive()` which toggles `com.apple.Accessibility.AccessibilityEnabled` via `simctl`. If the tree stays empty, restart the app after the first call (the activation flag only affects new accessibility sessions) or add `SemanticsBinding.instance.ensureSemantics()` to `main.dart` for release builds. |
+| Flutter widget labels missing from `app_query` | Widget uses `Key('...')` or raw text — neither surfaces to the accessibility tree | Wrap target widgets with `Semantics(label: '…')` or `Semantics(identifier: '…')` (Flutter 3.19+). `Key` values do **not** appear in the AX tree. |
+| Safari toolbar elements appear instead of Flutter widgets | Safari is auto-relaunched as a background system app and its AX elements dominate the tree | Terminate Safari with `app_terminate com.apple.mobilesafari`, then call `app_switch_app` to the Flutter bundle. Re-run `app_tree` after the switch. |

--- a/src/tools/app-inspect.ts
+++ b/src/tools/app-inspect.ts
@@ -6,7 +6,7 @@ export function registerAppInspectTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_inspect',
-      description: 'Inspect a specific native UI element by its index path (from app_tree or app_query results). Returns detailed metadata including role, label, value, identifier, traits, frame, visibility, enabled, and focused state.',
+      description: 'Inspect a specific native UI element by its index path (from app_tree or app_query results). Returns detailed metadata including role, label, value, identifier, traits, frame, visibility, enabled, and focused state. Compatible with Flutter apps — the tool auto-activates Flutter\'s lazy Semantics tree before inspection.',
       inputSchema: {
         type: 'object' as const,
         properties: {

--- a/src/tools/app-query.ts
+++ b/src/tools/app-query.ts
@@ -6,7 +6,7 @@ export function registerAppQueryTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_query',
-      description: 'Query native app UI elements by accessibility identifier, label, text, or role. Returns matching elements with metadata. Reports ambiguity when an identifier matches multiple elements.',
+      description: 'Query native app UI elements by accessibility identifier, label, text, or role. Returns matching elements with metadata. Reports ambiguity when an identifier matches multiple elements. Compatible with Flutter apps — the tool auto-activates Flutter\'s lazy Semantics tree so `Semantics(label:/identifier:)` widgets are queryable.',
       inputSchema: {
         type: 'object' as const,
         properties: {

--- a/src/tools/app-tree.ts
+++ b/src/tools/app-tree.ts
@@ -6,7 +6,7 @@ export function registerAppTreeTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_tree',
-      description: 'Dump the native accessibility tree of the foreground app in iOS Simulator. Returns a structured JSON snapshot of the UI hierarchy including roles, labels, identifiers, traits, frames, and visibility state.',
+      description: 'Dump the native accessibility tree of the foreground app in iOS Simulator. Returns a structured JSON snapshot of the UI hierarchy including roles, labels, identifiers, traits, frames, and visibility state. Compatible with Flutter apps — the tool auto-activates Flutter\'s lazy Semantics tree before reading so widget labels/text appear as accessibility nodes.',
       inputSchema: {
         type: 'object' as const,
         properties: {


### PR DESCRIPTION
## Summary

Fulfils the **Documentation** section of the #422 verification checklist.

- `app_tree`, `app_query`, `app_inspect` descriptions now mention Flutter compatibility and the auto-activation of the lazy Semantics tree.
- `README.md` gains a dedicated **Flutter QA Workflow** section: what auto-activation does, the recommended launch sequence (terminate Safari → switch → read tree), a widget-queryability table (`Semantics(label:)` / `Semantics(identifier:)` / plain `Text` / `Key` cannot be queried), and the `main.dart` opt-in for release builds.
- `docs/troubleshooting.md` gains three entries: empty Flutter tree, missing widget labels, Safari shadowing.

No runtime code changes — documentation-only PR.

## Checklist items unlocked in #422

- [x] Tool descriptions updated to mention Flutter compatibility
- [x] README section on Flutter QA workflow
- [x] Troubleshooting guide for empty accessibility trees

## Test plan

- [x] \`npx tsc --noEmit\` passes (no type errors introduced)
- [x] \`npx jest tests/unit/semantics-activator.test.ts\` — 10/10 pass
- [x] Read the rendered README section and troubleshooting table
- [ ] Reviewer: sanity-check the tool descriptions in the MCP inspector output

🤖 Generated with [Claude Code](https://claude.com/claude-code)