### PR TITLE
feat(flutter-network): capture WebSocket and HTTP upgrade requests

### DIFF
--- a/src/tools/flutter-network.ts
+++ b/src/tools/flutter-network.ts
@@ -8,6 +8,7 @@
 
 import * as http from 'http';
 import * as https from 'https';
+import * as net from 'net';
 import * as url from 'url';
 import { MCPServer } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
@@ -25,6 +26,7 @@ interface NetworkEntry {
   responseSize: number;
   duration?: number;
   error?: string;
+  isUpgrade?: boolean;
 }
 
 interface ProxyState {
@@ -48,7 +50,8 @@ export function registerFlutterNetworkTool(server: MCPServer): void {
         'Capture HTTP network traffic from Flutter/native apps via a local proxy. ' +
         'Actions: "start" begins capture, "log" returns captured requests, ' +
         '"har" exports as HAR format, "stop" stops capture and cleans up, ' +
-        '"throttle" updates the response delay.',
+        '"throttle" updates the response delay. ' +
+        'WebSocket and other HTTP upgrade requests are captured as entries with is_upgrade=true.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -214,6 +217,96 @@ async function handleStart(
     }
   });
 
+  // Handle WebSocket and other HTTP upgrade requests
+  proxyServer.on('upgrade', (clientReq: http.IncomingMessage, clientSocket: net.Socket, head: Buffer) => {
+    try {
+      const state = proxies.get(deviceId);
+      if (!state) {
+        clientSocket.destroy();
+        return;
+      }
+
+      const reqUrl = clientReq.url ?? '/';
+      const entry: NetworkEntry = {
+        id: ++state.entryId,
+        timestamp: Date.now(),
+        method: clientReq.method ?? 'GET',
+        url: reqUrl,
+        requestHeaders: clientReq.headers as Record<string, string | string[] | undefined>,
+        requestSize: head.length,
+        responseSize: 0,
+        isUpgrade: true,
+      };
+
+      // Parse target from absolute URL or Host header
+      const parsed = url.parse(reqUrl);
+      const host = parsed.hostname ?? (clientReq.headers.host ?? '').split(':')[0];
+      const port = parsed.port
+        ? parseInt(parsed.port, 10)
+        : parsed.protocol === 'https:' ? 443 : 80;
+
+      const upstream = net.connect(port, host, () => {
+        // Reconstruct the upgrade request line + headers + head
+        const requestLine = `${clientReq.method ?? 'GET'} ${parsed.path ?? '/'} HTTP/1.1\r\n`;
+        const headers = Object.entries(clientReq.headers)
+          .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`)
+          .join('\r\n');
+        upstream.write(requestLine + headers + '\r\n\r\n');
+        if (head.length > 0) {
+          upstream.write(head);
+        }
+      });
+
+      let entryAdded = false;
+
+      upstream.on('data', (chunk: Buffer) => {
+        if (!entryAdded) {
+          // Parse status code from first response line
+          const firstLine = chunk.toString('utf8', 0, Math.min(chunk.length, 64));
+          const match = firstLine.match(/^HTTP\/1\.[01]\s+(\d{3})/);
+          if (match) {
+            entry.statusCode = parseInt(match[1], 10);
+          }
+          entry.duration = Date.now() - entry.timestamp;
+          addEntry(state, entry);
+          entryAdded = true;
+        }
+        entry.responseSize += chunk.length;
+      });
+
+      clientSocket.on('data', (chunk: Buffer) => {
+        entry.requestSize += chunk.length;
+      });
+
+      upstream.on('error', (err) => {
+        if (!entryAdded) {
+          entry.error = err.message;
+          entry.duration = Date.now() - entry.timestamp;
+          addEntry(state, entry);
+          entryAdded = true;
+        }
+        clientSocket.destroy();
+      });
+
+      clientSocket.on('error', (err) => {
+        if (!entryAdded) {
+          entry.error = err.message;
+          entry.duration = Date.now() - entry.timestamp;
+          addEntry(state, entry);
+          entryAdded = true;
+        }
+        upstream.destroy();
+      });
+
+      // Bidirectionally pipe the sockets
+      upstream.pipe(clientSocket);
+      clientSocket.pipe(upstream);
+    } catch (err) {
+      console.error(`[flutter_network] upgrade handler error: ${err instanceof Error ? err.message : String(err)}`);
+      clientSocket.destroy();
+    }
+  });
+
   // Start listening
   await new Promise<void>((resolve, reject) => {
     proxyServer.on('error', (err) => {
@@ -309,6 +402,7 @@ function handleLog(
           request_size: e.requestSize,
           response_size: e.responseSize,
           error: e.error,
+          is_upgrade: e.isUpgrade,
         })),
       }, null, 2),
     }],

--- a/tests/unit/flutter-network.test.ts
+++ b/tests/unit/flutter-network.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../src/session-manager', () => ({
   }),
 }));
 
+import * as net from 'net';
 import { MCPServer } from '../../src/mcp-server';
 import { registerFlutterNetworkTool } from '../../src/tools/flutter-network';
 
@@ -148,4 +149,66 @@ describe('flutter_network', () => {
 
     expect(body.error).toMatch(/No proxy/i);
   });
+
+  it('captures WebSocket upgrade requests as entries with is_upgrade=true', async () => {
+    // Spin up a local TCP server that responds to upgrade with 101
+    const upstream = await new Promise<net.Server>((resolve) => {
+      const srv = net.createServer((sock) => {
+        sock.once('data', () => {
+          sock.write(
+            'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n',
+          );
+        });
+      });
+      srv.listen(0, '127.0.0.1', () => resolve(srv));
+    });
+
+    const upstreamPort = (upstream.address() as net.AddressInfo).port;
+
+    try {
+      await handler('s', { action: 'start', port: 18894 });
+
+      // Open raw TCP to the proxy and send a WebSocket upgrade request
+      await new Promise<void>((resolve, reject) => {
+        const client = net.createConnection(18894, '127.0.0.1', () => {
+          const req = [
+            `GET http://127.0.0.1:${upstreamPort}/ws HTTP/1.1`,
+            `Host: 127.0.0.1:${upstreamPort}`,
+            'Upgrade: websocket',
+            'Connection: Upgrade',
+            'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+            'Sec-WebSocket-Version: 13',
+            '',
+            '',
+          ].join('\r\n');
+          client.write(req);
+        });
+
+        client.once('data', () => {
+          client.destroy();
+          resolve();
+        });
+
+        client.on('error', reject);
+        setTimeout(() => { client.destroy(); resolve(); }, 5000);
+      });
+
+      // Wait for async addEntry to run
+      await new Promise((r) => setTimeout(r, 200));
+
+      const logResult = await handler('s', { action: 'log' });
+      const logBody = JSON.parse(logResult.content[0].text);
+
+      const upgradeEntry = logBody.entries.find(
+        (e: Record<string, unknown>) => e.is_upgrade === true,
+      );
+
+      expect(upgradeEntry).toBeDefined();
+      expect(upgradeEntry.status).toBe(101);
+      expect(upgradeEntry.method).toBe('GET');
+    } finally {
+      await handler('s', { action: 'stop' });
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  }, 15000);
 });


### PR DESCRIPTION
## Summary

- Adds a `'upgrade'` event handler to the flutter_network proxy so WebSocket and other HTTP upgrade handshakes are captured alongside regular HTTP traffic.
- Entries gain an `is_upgrade: true` flag in `action: 'log'` output; status code is parsed from the upstream 101 response.
- The two sockets are bidirectionally piped so the WebSocket connection continues working while being observed.
- Resolves one of two remaining items from #427.

## Test plan

- [ ] Run `npx jest tests/unit/flutter-network.test.ts` — all 8 tests pass, including the new `captures WebSocket upgrade requests as entries with is_upgrade=true` test
- [ ] New test spins up a real TCP upstream, sends a forward-proxy style upgrade request through the proxy, and asserts the log entry has `is_upgrade === true`, `status === 101`, `method === 'GET'`
- [ ] Run `npm run build` — build succeeds with no new errors

References #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)