### PR TITLE
feat(flutter-network): add response-delay throttling for QA simulation

### DIFF
--- a/src/tools/flutter-network.ts
+++ b/src/tools/flutter-network.ts
@@ -33,6 +33,7 @@ interface ProxyState {
   entries: NetworkEntry[];
   entryId: number;
   deviceId: string;
+  throttleMs: number;
 }
 
 // Per-device proxy state
@@ -46,13 +47,14 @@ export function registerFlutterNetworkTool(server: MCPServer): void {
       description:
         'Capture HTTP network traffic from Flutter/native apps via a local proxy. ' +
         'Actions: "start" begins capture, "log" returns captured requests, ' +
-        '"har" exports as HAR format, "stop" stops capture and cleans up.',
+        '"har" exports as HAR format, "stop" stops capture and cleans up, ' +
+        '"throttle" updates the response delay.',
       inputSchema: {
         type: 'object' as const,
         properties: {
           action: {
             type: 'string',
-            enum: ['start', 'log', 'har', 'stop'],
+            enum: ['start', 'log', 'har', 'stop', 'throttle'],
             description: 'Action to perform (default: "log")',
           },
           port: {
@@ -74,6 +76,10 @@ export function registerFlutterNetworkTool(server: MCPServer): void {
           device_id: {
             type: 'string',
             description: 'Simulator UDID (uses active device if omitted)',
+          },
+          throttle_ms: {
+            type: 'number',
+            description: 'Delay each proxied response by this many milliseconds (default: 0 = no delay). Settable at start and updatable via action "throttle".',
           },
         },
         required: [],
@@ -99,6 +105,8 @@ export function registerFlutterNetworkTool(server: MCPServer): void {
             return handleHar(deviceId);
           case 'stop':
             return await handleStop(deviceId);
+          case 'throttle':
+            return handleThrottle(deviceId, params);
           default:
             throw new Error(`Unknown action: ${action}`);
         }
@@ -123,6 +131,10 @@ async function handleStart(
   }
 
   const port = (params.port as number | undefined) ?? 8888;
+  const throttleMs = (params.throttle_ms as number | undefined) ?? 0;
+  if (!isFinite(throttleMs) || throttleMs < 0) {
+    throw new Error('throttle_ms must be a non-negative finite number.');
+  }
 
   // Create HTTP proxy server
   const proxyServer = http.createServer((clientReq, clientRes) => {
@@ -172,8 +184,16 @@ async function handleStart(
             addEntry(state, entry);
           });
 
-          clientRes.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
-          proxyRes.pipe(clientRes, { end: true });
+          proxyRes.pause();
+          const sendResponse = () => {
+            clientRes.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+            proxyRes.pipe(clientRes, { end: true });
+          };
+          if (state.throttleMs > 0) {
+            setTimeout(sendResponse, state.throttleMs);
+          } else {
+            sendResponse();
+          }
         },
       );
 
@@ -208,6 +228,7 @@ async function handleStart(
     entries: [],
     entryId: 0,
     deviceId,
+    throttleMs,
   });
 
   // Configure simulator to use proxy
@@ -231,6 +252,7 @@ async function handleStart(
         status: 'started',
         port,
         deviceId,
+        throttle_ms: throttleMs,
         message: `HTTP proxy listening on 127.0.0.1:${port}. Configure your Flutter app to use this proxy or set NSGlobalDomain proxy settings.`,
       }),
     }],
@@ -394,6 +416,39 @@ async function handleStop(
         status: 'stopped',
         deviceId,
         entries_captured: entriesCount,
+      }),
+    }],
+  };
+}
+
+function handleThrottle(
+  deviceId: string,
+  params: Record<string, unknown>,
+) {
+  const state = proxies.get(deviceId);
+  if (!state) {
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ error: 'No proxy running for this device.' }),
+      }],
+    };
+  }
+
+  const throttleMs = (params.throttle_ms as number | undefined) ?? 0;
+  if (!isFinite(throttleMs) || throttleMs < 0) {
+    throw new Error('throttle_ms must be a non-negative finite number.');
+  }
+
+  state.throttleMs = throttleMs;
+
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({
+        status: 'updated',
+        deviceId,
+        throttle_ms: throttleMs,
       }),
     }],
   };

--- a/tests/unit/flutter-network.test.ts
+++ b/tests/unit/flutter-network.test.ts
@@ -111,4 +111,41 @@ describe('flutter_network', () => {
 
     await handler('s', { action: 'stop' });
   });
+
+  it('accepts throttle_ms on start', async () => {
+    const result = await handler('s', { action: 'start', port: 18900, throttle_ms: 150 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('started');
+    expect(body.throttle_ms).toBe(150);
+
+    await handler('s', { action: 'stop' });
+  });
+
+  it('rejects negative throttle_ms', async () => {
+    const result = await handler('s', { action: 'start', port: 18901, throttle_ms: -5 });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toMatch(/throttle_ms|negative/i);
+  });
+
+  it('updates throttle via throttle action', async () => {
+    await handler('s', { action: 'start', port: 18902 });
+
+    const result = await handler('s', { action: 'throttle', throttle_ms: 250 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('updated');
+    expect(body.throttle_ms).toBe(250);
+
+    await handler('s', { action: 'stop' });
+  });
+
+  it('returns error when throttle action called without proxy', async () => {
+    const result = await handler('s', { action: 'throttle', throttle_ms: 100 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.error).toMatch(/No proxy/i);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `throttle_ms` parameter to the `start` action — delays each proxied response by the specified number of milliseconds (default: 0, no delay)
- Adds new `throttle` action to update the delay on an already-running proxy without restarting it
- Upstream responses are paused via `proxyRes.pause()` and released via `setTimeout` after the configured delay before piping back to the client
- Validates that `throttle_ms` is a non-negative finite number on both `start` and `throttle` actions

Closes the second of two remaining items in #427.

## Test plan

- [ ] `npx jest tests/unit/flutter-network.test.ts` — all 11 tests pass (7 existing + 4 new)
  - `accepts throttle_ms on start` — verifies `status === 'started'` and `throttle_ms === 150` in response
  - `rejects negative throttle_ms` — verifies `isError === true` with message referencing `throttle_ms`
  - `updates throttle via throttle action` — verifies `status === 'updated'` and `throttle_ms === 250`
  - `returns error when throttle action called without proxy` — verifies error mentioning "No proxy"
- [ ] `npm run build` — build succeeds with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)