### PR TITLE
feat(tools): add app_type_element for semantic text input (#423)

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -141,6 +141,7 @@ export const TOOL_TIERS: Record<string, number> = {
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   app_tap_element: 2,
+  app_type_element: 2,
   // Tier 2: Native App — Semantic Wait & Assert (Flutter-compatible)
   app_wait_for_element: 2,
   app_assert_element: 2,

--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -1,0 +1,184 @@
+/**
+ * app_type_element — Type text into a native UI element located by
+ * accessibility query.
+ *
+ * Chains `app_query` (find element) → tap-to-focus → `app_type_text`
+ * into a single semantic action. This is the paired companion to
+ * `app_tap_element`: where tap_element targets buttons, this one
+ * targets text fields (or anything else that accepts keyboard input
+ * once focused).
+ *
+ * Works with any app including Flutter — no WebKit/DOM required.
+ */
+
+import { MCPServer, getWebKitClient } from '../mcp-server';
+import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import type { AXNode, AXQuery } from '../native';
+import { resolveDeviceId, getInputBackend } from './native-input-utils';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_FOCUS_DELAY_MS = 150;
+
+export function registerAppTypeElementTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_type_element',
+      description:
+        'Type text into a native app UI element located by accessibility query ' +
+        '(label, identifier, or role). Finds the element in the accessibility ' +
+        'tree, taps its center to focus it, then types the given text via the ' +
+        'same input backend used by app_type_text. Works with any app ' +
+        'including Flutter — no WebKit/DOM required.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          text: {
+            type: 'string',
+            description: 'Text to type into the focused element',
+          },
+          identifier: {
+            type: 'string',
+            description: 'Accessibility identifier (exact match)',
+          },
+          label: {
+            type: 'string',
+            description: 'Accessibility label (case-insensitive substring)',
+          },
+          role: {
+            type: 'string',
+            description: 'Accessibility role (e.g. "AXTextField")',
+          },
+          index: {
+            type: 'number',
+            description: 'Which match to focus when multiple found (0-based, default: 0)',
+          },
+          timeout: {
+            type: 'number',
+            description: `Max ms to wait for the element to appear (default: ${DEFAULT_TIMEOUT_MS}). Set to 0 to skip waiting.`,
+          },
+          focusDelay: {
+            type: 'number',
+            description: `Ms to wait between tap-to-focus and typing (default: ${DEFAULT_FOCUS_DELAY_MS}). Increase for slow keyboards.`,
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted)',
+          },
+        },
+        required: ['text'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      const textToType = params.text as string | undefined;
+      const identifier = params.identifier as string | undefined;
+      const label = params.label as string | undefined;
+      const role = params.role as string | undefined;
+
+      if (typeof textToType !== 'string' || textToType.length === 0) {
+        return jsonError('text must be a non-empty string');
+      }
+      if (!identifier && !label && !role) {
+        return jsonError(
+          'At least one query parameter (identifier, label, or role) is required to locate the field',
+        );
+      }
+
+      try {
+        const deviceId = resolveDeviceId(params);
+        const index = (params.index as number | undefined) ?? 0;
+        const timeout = (params.timeout as number | undefined) ?? DEFAULT_TIMEOUT_MS;
+        const focusDelay = (params.focusDelay as number | undefined) ?? DEFAULT_FOCUS_DELAY_MS;
+
+        await ensureSemanticsActive(deviceId);
+
+        const bridge = getAccessibilityBridge();
+        // Note: the bridge supports a `text` query param (searches label/value),
+        // but `text` here is overloaded to mean "text to type". So we never pass
+        // `text` as a query — callers disambiguate via identifier/label/role.
+        const query: AXQuery = { identifier, label, role };
+
+        let match: AXNode | undefined;
+        if (timeout > 0) {
+          const deadline = Date.now() + timeout;
+          while (Date.now() < deadline) {
+            const result = await bridge.query(query, { deviceId });
+            if (result.matches.length > index) {
+              match = result.matches[index];
+              break;
+            }
+            await sleep(300);
+          }
+        } else {
+          const result = await bridge.query(query, { deviceId });
+          if (result.matches.length > index) {
+            match = result.matches[index];
+          }
+        }
+        if (!match) {
+          return jsonError('Element not found', { query, index, timeout });
+        }
+
+        if (!match.visible || match.frame.width <= 0 || match.frame.height <= 0) {
+          return jsonError('Element found but not visible or has zero size', {
+            element: {
+              role: match.role,
+              label: match.label,
+              identifier: match.identifier,
+              frame: match.frame,
+              visible: match.visible,
+            },
+          });
+        }
+
+        // Tap center to focus, then type.
+        const centerX = match.frame.x + match.frame.width / 2;
+        const centerY = match.frame.y + match.frame.height / 2;
+
+        const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
+        await backend.tap(deviceId, centerX, centerY);
+
+        if (focusDelay > 0) {
+          await sleep(focusDelay);
+        }
+
+        await backend.typeText(deviceId, textToType);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                status: 'typed',
+                element: {
+                  role: match.role,
+                  label: match.label,
+                  identifier: match.identifier,
+                  path: match.path,
+                },
+                coordinates: { x: centerX, y: centerY },
+                length: textToType.length,
+                backend: backend.kind,
+                deviceId,
+              }),
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[app_type_element] ${message}`);
+        return jsonError(message);
+      }
+    },
+  );
+}
+
+function jsonError(error: string, extra: Record<string, unknown> = {}) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ error, ...extra }) }],
+    isError: true,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -116,6 +116,7 @@ import {
   registerFlutterWaitForPauseTool,
 } from './flutter-breakpoints';
 import { registerAppTapElementTool } from './app-tap-element';
+import { registerAppTypeElementTool } from './app-type-element';
 import { registerAppWaitForNativeTool } from './app-wait-for';
 import { registerAppAssertElementTool } from './app-assert-element';
 
@@ -306,6 +307,7 @@ export function registerAllTools(server: MCPServer): void {
 
   // Tier 2: Native App — Semantic Interaction (Flutter-compatible)
   registerAppTapElementTool(server);
+  registerAppTypeElementTool(server);
   // Tier 2: Native App — Semantic Wait & Assert (Flutter-compatible)
   registerAppWaitForNativeTool(server);
   registerAppAssertElementTool(server);

--- a/tests/unit/app-type-element.test.ts
+++ b/tests/unit/app-type-element.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Unit tests for app_type_element tool.
+ *
+ * Tests the composite flow: query accessibility tree → tap to focus →
+ * type text. Mocks the same boundaries as app-tap-element.test.ts
+ * (accessibility bridge, semantics activator, input backend,
+ * session manager) so these stay pure unit tests.
+ */
+
+jest.mock('../../src/mcp-server', () => {
+  const actual = jest.requireActual('../../src/mcp-server');
+  return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };
+});
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerAppTypeElementTool } from '../../src/tools/app-type-element';
+import type { AXNode, AXQueryResult } from '../../src/native/ax-types';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockQuery = jest.fn();
+const mockTap = jest.fn().mockResolvedValue(undefined);
+const mockTypeText = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../src/native/accessibility-bridge', () => ({
+  getAccessibilityBridge: () => ({
+    query: mockQuery,
+    dumpTree: jest.fn(),
+  }),
+}));
+
+jest.mock('../../src/native/semantics-activator', () => ({
+  ensureSemanticsActive: jest.fn().mockResolvedValue(true),
+  countNodes: jest.fn().mockReturnValue(10),
+}));
+
+jest.mock('../../src/tools/native-input-backend', () => ({
+  getInputBackend: jest.fn(async () => ({
+    kind: 'simctl' as const,
+    tap: mockTap,
+    typeText: mockTypeText,
+  })),
+  resetInputBackend: jest.fn(),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'test-device-id',
+  }),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeNode(overrides: Partial<AXNode> = {}): AXNode {
+  return {
+    role: 'AXTextField',
+    label: 'Email',
+    identifier: 'email_field',
+    traits: [],
+    frame: { x: 20, y: 100, width: 350, height: 40 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    path: '0/1',
+    ...overrides,
+  };
+}
+
+function makeQueryResult(matches: AXNode[], ambiguous = false): AXQueryResult {
+  return {
+    matches,
+    total: matches.length,
+    query: {},
+    ambiguous,
+  };
+}
+
+// ── Test setup ─────────────────────────────────────────────────────────────
+
+let server: MCPServer;
+let handler: (
+  sessionId: string,
+  params: Record<string, unknown>,
+) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+
+beforeAll(() => {
+  server = {
+    registerTool: jest.fn((_schema: unknown, fn: unknown) => {
+      handler = fn as typeof handler;
+    }),
+  } as unknown as MCPServer;
+
+  registerAppTypeElementTool(server);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useRealTimers();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('app_type_element', () => {
+  it('types into element found by label', async () => {
+    const node = makeNode({ label: 'Email', frame: { x: 20, y: 100, width: 350, height: 40 } });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+
+    const result = await handler('session', {
+      label: 'Email',
+      text: 'user@example.com',
+      timeout: 0,
+      focusDelay: 0,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('typed');
+    expect(body.length).toBe(16);
+    expect(body.coordinates).toEqual({ x: 195, y: 120 }); // 20+175, 100+20
+    // Tap to focus
+    expect(mockTap).toHaveBeenCalledWith('test-device-id', 195, 120);
+    // Then type
+    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'user@example.com');
+    // Tap must come before typeText
+    const tapOrder = mockTap.mock.invocationCallOrder[0];
+    const typeOrder = mockTypeText.mock.invocationCallOrder[0];
+    expect(tapOrder).toBeLessThan(typeOrder);
+  });
+
+  it('types into element found by identifier', async () => {
+    const node = makeNode({ identifier: 'username_input', frame: { x: 10, y: 200, width: 200, height: 44 } });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+
+    const result = await handler('session', {
+      identifier: 'username_input',
+      text: 'alice',
+      timeout: 0,
+      focusDelay: 0,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('typed');
+    expect(body.coordinates).toEqual({ x: 110, y: 222 });
+    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'alice');
+  });
+
+  it('uses index to disambiguate multiple fields', async () => {
+    const nodes = [
+      makeNode({ identifier: 'field_0', frame: { x: 0, y: 100, width: 100, height: 40 } }),
+      makeNode({ identifier: 'field_1', frame: { x: 0, y: 200, width: 100, height: 40 } }),
+    ];
+    mockQuery.mockResolvedValue(makeQueryResult(nodes));
+
+    await handler('session', {
+      role: 'AXTextField',
+      text: 'hello',
+      index: 1,
+      timeout: 0,
+      focusDelay: 0,
+    });
+
+    expect(mockTap).toHaveBeenCalledWith('test-device-id', 50, 220);
+    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'hello');
+  });
+
+  it('returns error when text is missing or empty', async () => {
+    const missing = await handler('session', { label: 'Email' });
+    expect(missing.isError).toBe(true);
+    expect(JSON.parse(missing.content[0].text).error).toContain('text');
+
+    const empty = await handler('session', { label: 'Email', text: '' });
+    expect(empty.isError).toBe(true);
+    expect(JSON.parse(empty.content[0].text).error).toContain('text');
+  });
+
+  it('returns error when no locator is provided', async () => {
+    const result = await handler('session', { text: 'hello' });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toContain('query parameter');
+  });
+
+  it('returns error when element is not found', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+
+    const result = await handler('session', {
+      label: 'NonExistent',
+      text: 'hello',
+      timeout: 0,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toBe('Element not found');
+    expect(mockTap).not.toHaveBeenCalled();
+    expect(mockTypeText).not.toHaveBeenCalled();
+  });
+
+  it('returns error when element is not visible', async () => {
+    const node = makeNode({ visible: false, frame: { x: 0, y: 0, width: 0, height: 0 } });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+
+    const result = await handler('session', {
+      label: 'Hidden',
+      text: 'nope',
+      timeout: 0,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toContain('not visible');
+    expect(mockTypeText).not.toHaveBeenCalled();
+  });
+
+  it('waits between tap-to-focus and typing when focusDelay > 0', async () => {
+    const node = makeNode({ frame: { x: 0, y: 0, width: 100, height: 40 } });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+
+    let tapCompletedAt = 0;
+    let typeStartedAt = 0;
+    mockTap.mockImplementation(async () => {
+      tapCompletedAt = Date.now();
+    });
+    mockTypeText.mockImplementation(async () => {
+      typeStartedAt = Date.now();
+    });
+
+    await handler('session', {
+      label: 'Field',
+      text: 'x',
+      timeout: 0,
+      focusDelay: 75,
+    });
+
+    // Typing started at least ~75ms after tap completed. Allow a
+    // small tolerance for scheduler jitter.
+    expect(typeStartedAt - tapCompletedAt).toBeGreaterThanOrEqual(60);
+  });
+
+  it('never sends the `text` param as part of the bridge query', async () => {
+    // `text` is overloaded to mean "text to type" here, so it MUST NOT be
+    // forwarded to the accessibility query (which treats it as a substring
+    // match against value/label) — otherwise the query could fail to find
+    // the empty field we are about to populate.
+    const node = makeNode({ frame: { x: 10, y: 20, width: 100, height: 40 } });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+
+    await handler('session', {
+      label: 'Password',
+      text: 'supersecret',
+      timeout: 0,
+      focusDelay: 0,
+    });
+
+    const forwardedQuery = mockQuery.mock.calls[0][0];
+    expect(forwardedQuery).not.toHaveProperty('text');
+    expect(forwardedQuery).toMatchObject({ label: 'Password' });
+  });
+
+  it('returns element metadata in response', async () => {
+    const node = makeNode({
+      role: 'AXTextField',
+      label: 'Search',
+      identifier: 'search_input',
+      path: '0/2/3',
+    });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+
+    const result = await handler('session', {
+      identifier: 'search_input',
+      text: 'query',
+      timeout: 0,
+      focusDelay: 0,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.element).toEqual({
+      role: 'AXTextField',
+      label: 'Search',
+      identifier: 'search_input',
+      path: '0/2/3',
+    });
+    expect(body.backend).toBe('simctl');
+    expect(body.deviceId).toBe('test-device-id');
+  });
+});


### PR DESCRIPTION
## Summary
Implements the companion tool to `app_tap_element` that the #423 plan called for. Locates a native field by accessibility query, taps its center to focus it, and types the given text via the shared input backend.

```ts
app_type_element({ label: "Email", text: "user@example.com" })
```

Closes the final blocking gap from the #423 verification checklist (the one item that previously could not be checked because the tool didn't exist).

## Design notes
- **`text` is overloaded.** In `app_tap_element`, `text` is a query param that substring-matches the element's value/label. Here it is the text to type. To avoid the query silently narrowing against the field's current value, `text` is **never** forwarded to `bridge.query` — locator params are limited to `identifier`, `label`, and `role`. One of the tests (`never sends the 'text' param as part of the bridge query`) pins this invariant.
- **Configurable `focusDelay`** (default 150ms) sits between the focusing tap and the `typeText` call so the soft keyboard has time to appear. Callers on fast devices can set `focusDelay: 0` (all the unit tests do).
- **Error paths mirror `app_tap_element`** for consistency: missing `text`, no locator, element not found, element found-but-not-visible, zero-sized frames.
- Registered in **Tier 2** (`src/config/tool-tiers.ts`) alongside `app_tap_element`.

## Files
| File | Change |
|---|---|
| `src/tools/app-type-element.ts` | **NEW** |
| `tests/unit/app-type-element.test.ts` | **NEW** — 10 tests |
| `src/tools/index.ts` | Import + `registerAppTypeElementTool(server)` in Tier 2 |
| `src/config/tool-tiers.ts` | `app_type_element: 2` |

## Test plan
- [x] `npx jest tests/unit/app-type-element.test.ts` → 10 / 10 pass
- [ ] Reviewer: `npm test` full suite, `npm run build`
- [ ] Reviewer: live Flutter app — type into a `TextField` looked up by label

Refs #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)