### PR TITLE
fix(flutter): correct RebuiltWidgets event name in track_rebuilds (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - **Breakpoint manager** (#435): Cleans listeners on disconnect and detects VM reconnect to avoid stale state.
 - **Memory profiler** (#440): LRU cap on `previousSnapshots` prevents unbounded memory growth; `forgetAllocationHistory` exposed.
 - **Track rebuilds** (#438): Rolls back listener registration if `track_rebuilds start` fails mid-setup.
+- **Track rebuilds event name** (#438): Fixed filter to match `Flutter.RebuiltWidgets` (past tense, the actual event name Flutter emits from `widget_inspector.dart:2538`) instead of `Flutter.RebuildWidgets`. Without this fix, no rebuild events were captured in live apps.
 - **CPU profiler** (#439): Resets timeline flags on capture failure to avoid leaving streams enabled.
 - **Widget inspector** (#436): Clamps `max_depth` and adds cycle guard to `summariseNode`.
 - **Evaluate** (#434): Security docstring, audit log, Null handling, whitespace guard.

--- a/src/tools/flutter-track-rebuilds.ts
+++ b/src/tools/flutter-track-rebuilds.ts
@@ -5,7 +5,7 @@
  * of Flutter performance regressions and are invisible from screenshots
  * alone. The Flutter framework already tracks dirty-widget rebuilds when
  * asked via `ext.flutter.inspector.trackRebuildDirtyWidgets(true)` and
- * publishes `Flutter.RebuildWidgets` events on the `Extension` stream.
+ * publishes `Flutter.RebuiltWidgets` events on the `Extension` stream.
  *
  * This tool wraps the full lifecycle (start → events accumulate →
  * report or stop → disable tracking) behind a single MCP tool so LLMs
@@ -61,7 +61,7 @@ export function _resetTrackers(): void {
 // ── Event parsing ───────────────────────────────────────────────────────────
 
 /**
- * Shape of a Flutter.RebuildWidgets event payload. Events come encoded as a
+ * Shape of a Flutter.RebuiltWidgets event payload. Events come encoded as a
  * flat `[locationId, count, locationId, count, ...]` array in recent Flutter
  * versions, or as `[[locId, count], ...]` pairs in older ones — we handle both.
  * Locations are a compact map of id → {file, line, column, name} where name
@@ -149,7 +149,7 @@ async function startTracking(
 
   state.listener = (ev: FlutterEvent) => {
     const extensionKind = (ev as unknown as Record<string, unknown>).extensionKind;
-    if (extensionKind !== 'Flutter.RebuildWidgets') return;
+    if (extensionKind !== 'Flutter.RebuiltWidgets') return;
     if (state.eventCount >= MAX_EVENTS_PER_TRACKER) return;
     mergeRebuildEvent(state, (ev as unknown as Record<string, unknown>).extensionData);
   };
@@ -249,7 +249,7 @@ export function registerFlutterTrackRebuildsTool(server: MCPServer): void {
       description:
         'Track widget rebuild counts in a running Flutter app. ' +
         'action="start" enables ext.flutter.inspector.trackRebuildDirtyWidgets and ' +
-        'subscribes to Flutter.RebuildWidgets events; action="report" returns a ' +
+        'subscribes to Flutter.RebuiltWidgets events; action="report" returns a ' +
         'top-N list of {widget, file:line, rebuild_count}; action="stop" disables ' +
         'tracking and clears state. Use duration_ms on "start" to auto-stop after ' +
         'a fixed window. Requires an active flutter_connect session (debug build).',

--- a/tests/unit/flutter-track-rebuilds.test.ts
+++ b/tests/unit/flutter-track-rebuilds.test.ts
@@ -195,14 +195,14 @@ describe('flutter_track_rebuilds handler', () => {
     const registeredListener = mockOnEvent.mock.calls[0][1] as (ev: unknown) => void;
 
     registeredListener({
-      extensionKind: 'Flutter.RebuildWidgets',
+      extensionKind: 'Flutter.RebuiltWidgets',
       extensionData: {
         events: [1, 10, 2, 1],
         locations: { '1': { file: 'hot.dart', line: 5, name: 'Hot' } },
       },
     });
     registeredListener({
-      extensionKind: 'Flutter.RebuildWidgets',
+      extensionKind: 'Flutter.RebuiltWidgets',
       extensionData: { events: [1, 2], locations: {} },
     });
     // Unrelated extension events must be ignored


### PR DESCRIPTION
## Summary

- `flutter_track_rebuilds` listener was filtering for `Flutter.RebuildWidgets` (present tense), but Flutter's framework actually emits `Flutter.RebuiltWidgets` (past tense, `widget_inspector.dart:2538`).
- Without this fix, every real rebuild event was rejected and the tool reported `0 rebuilds` for any live Flutter app.
- Unit tests masked the bug because they fed synthetic events under the same (wrong) name — fixtures updated to use the production name.

## Root cause

```dart
// flutter/packages/flutter/lib/src/widgets/widget_inspector.dart:2538
_postStatsEvent('Flutter.RebuiltWidgets', _rebuildStats);
```

The issue description in #438 cites `Flutter.RebuildWidgets`, which does not match what the framework emits. Verified against a live VM Service (`Extension` stream) on Flutter 3.41.5.

## Changes

- `src/tools/flutter-track-rebuilds.ts` — listener filter, doc comment, tool description
- `tests/unit/flutter-track-rebuilds.test.ts` — test fixtures use the production event name
- `CHANGELOG.md` — add Fixed entry under 0.4.0

## Integration verification

Ran against a purpose-built Flutter debug app on iPhone 16 simulator (50ms `setState` timer, `com.test.rebuildTestApp`) via opensafari MCP tools.

| Metric | Before fix | After fix |
|---|---|---|
| Events captured (3s) | 0 | 60 |
| Total rebuilds (3s) | 0 | 245 |
| Max widget rebuild count | 0 | 60 |
| `count > 10` requirement | ❌ fail | ✅ pass |

Raw `Flutter.RebuiltWidgets` events confirmed via WebSocket capture: 200 events over 5s.

## Test plan

- [x] `npx jest tests/unit/flutter-track-rebuilds.test.ts` — 21/21 pass
- [x] Live iOS sim + Flutter debug app emits rebuild events under the fixed filter
- [x] `trackRebuildDirtyWidgets(enabled: 'false')` call issued on `stop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)