### PR TITLE
feat(flutter): thread bundle_id through AX tools for multi-app targeting (#422)

### DIFF
--- a/src/tools/app-inspect.ts
+++ b/src/tools/app-inspect.ts
@@ -18,6 +18,10 @@ export function registerAppInspectTool(server: MCPServer): void {
             type: 'string',
             description: 'Simulator device UDID (defaults to active device)',
           },
+          bundle_id: {
+            type: 'string',
+            description: 'Target Flutter app bundle ID. Used to disambiguate Dart VM Service discovery when multiple Flutter apps run on the same simulator.',
+          },
         },
         required: ['path'],
       },
@@ -36,12 +40,13 @@ export function registerAppInspectTool(server: MCPServer): void {
 
       try {
         const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
+        const bundleId = params.bundle_id as string | undefined;
 
         const bridge = getAccessibilityBridge();
 
         // Ensure Flutter semantics are activated before inspecting
         if (deviceId) {
-          await ensureSemanticsActive(deviceId);
+          await ensureSemanticsActive(deviceId, { bundleId });
         }
 
         const node = await bridge.inspect(elementPath, deviceId);

--- a/src/tools/app-query.ts
+++ b/src/tools/app-query.ts
@@ -30,6 +30,10 @@ export function registerAppQueryTool(server: MCPServer): void {
             type: 'string',
             description: 'Simulator device UDID (defaults to active device)',
           },
+          bundle_id: {
+            type: 'string',
+            description: 'Target Flutter app bundle ID. Only used to disambiguate Dart VM Service discovery when multiple Flutter apps run on the same simulator.',
+          },
           max_results: {
             type: 'number',
             description: 'Maximum number of results (default: 50)',
@@ -56,13 +60,14 @@ export function registerAppQueryTool(server: MCPServer): void {
 
       try {
         const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
+        const bundleId = params.bundle_id as string | undefined;
         const maxResults = params.max_results as number | undefined;
 
         const bridge = getAccessibilityBridge();
 
         // Ensure Flutter semantics are activated before querying
         if (deviceId) {
-          await ensureSemanticsActive(deviceId);
+          await ensureSemanticsActive(deviceId, { bundleId });
         }
 
         const result = await bridge.query(

--- a/src/tools/app-tree.ts
+++ b/src/tools/app-tree.ts
@@ -14,6 +14,10 @@ export function registerAppTreeTool(server: MCPServer): void {
             type: 'string',
             description: 'Simulator device UDID (defaults to active device)',
           },
+          bundle_id: {
+            type: 'string',
+            description: 'Target Flutter app bundle ID. Used to disambiguate Dart VM Service discovery when multiple Flutter apps run on the same simulator — the macOS AX bridge itself always reads the current foreground app.',
+          },
           max_depth: {
             type: 'number',
             description: 'Maximum tree depth to traverse (default: 10)',
@@ -25,13 +29,14 @@ export function registerAppTreeTool(server: MCPServer): void {
     async (_sessionId: string, params: Record<string, unknown>) => {
       try {
         const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
+        const bundleId = params.bundle_id as string | undefined;
         const maxDepth = params.max_depth as number | undefined;
 
         const bridge = getAccessibilityBridge();
 
         // Ensure Flutter semantics are activated before reading the tree
         if (deviceId) {
-          await ensureSemanticsActive(deviceId);
+          await ensureSemanticsActive(deviceId, { bundleId });
         }
 
         const tree = await bridge.dumpTree({ deviceId, maxDepth });


### PR DESCRIPTION
## Summary

Builds on top of #465 (VM Service fallback). When multiple Flutter apps run on the same simulator, Dart VM Service URL discovery can match any of them. Letting callers pass an explicit `bundle_id` routes semantics activation to the right app.

## Changes

- `app_tree`, `app_query`, `app_inspect` each accept an optional `bundle_id` input parameter.
- The param is forwarded to `ensureSemanticsActive(deviceId, { bundleId })`, which forwards it to `discoverVMServiceUrl({ bundleId })` during the VM Service fallback path.
- When `bundle_id` is omitted, behaviour is unchanged — activation targets whichever Flutter VM service the log walker finds first.
- Native (non-Flutter) apps are untouched: the quick-check returns early and neither simctl nor VM Service paths run.

## Stacked on #465

This PR targets \`feature/flutter-semantics-vm-fallback\` (PR #465) as its base. Retarget onto \`develop\` after #465 merges.

## Checklist items this helps unlock in #422

- [x] Multiple Flutter apps running simultaneously — activation targets correct app

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] Existing \`semantics-activator\` unit tests (13/13) still pass — the new param is additive and defaults through
- [ ] Reviewer: manual test with two Flutter apps (e.g. \`com.test.rebuildTestApp\` + \`com.omofictions.omofictionsApp\`) — confirm VM Service discovery targets the passed bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)