### PR TITLE
feat(flutter): thread bundle_id through AX tools for multi-app VM targeting (#422)

### DIFF
--- a/src/tools/app-inspect.ts
+++ b/src/tools/app-inspect.ts
@@ -18,6 +18,10 @@ export function registerAppInspectTool(server: MCPServer): void {
             type: 'string',
             description: 'Simulator device UDID (defaults to active device)',
           },
+          bundle_id: {
+            type: 'string',
+            description: 'Target Flutter app bundle ID. Used to disambiguate Dart VM Service discovery when multiple Flutter apps run on the same simulator.',
+          },
         },
         required: ['path'],
       },
@@ -36,12 +40,13 @@ export function registerAppInspectTool(server: MCPServer): void {
 
       try {
         const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
+        const bundleId = params.bundle_id as string | undefined;
 
         const bridge = getAccessibilityBridge();
 
         // Ensure Flutter semantics are activated before inspecting
         if (deviceId) {
-          await ensureSemanticsActive(deviceId);
+          await ensureSemanticsActive(deviceId, { bundleId });
         }
 
         const node = await bridge.inspect(elementPath, deviceId);

--- a/src/tools/app-query.ts
+++ b/src/tools/app-query.ts
@@ -30,6 +30,10 @@ export function registerAppQueryTool(server: MCPServer): void {
             type: 'string',
             description: 'Simulator device UDID (defaults to active device)',
           },
+          bundle_id: {
+            type: 'string',
+            description: 'Target Flutter app bundle ID. Only used to disambiguate Dart VM Service discovery when multiple Flutter apps run on the same simulator.',
+          },
           max_results: {
             type: 'number',
             description: 'Maximum number of results (default: 50)',
@@ -56,13 +60,14 @@ export function registerAppQueryTool(server: MCPServer): void {
 
       try {
         const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
+        const bundleId = params.bundle_id as string | undefined;
         const maxResults = params.max_results as number | undefined;
 
         const bridge = getAccessibilityBridge();
 
         // Ensure Flutter semantics are activated before querying
         if (deviceId) {
-          await ensureSemanticsActive(deviceId);
+          await ensureSemanticsActive(deviceId, { bundleId });
         }
 
         const result = await bridge.query(

--- a/src/tools/app-tree.ts
+++ b/src/tools/app-tree.ts
@@ -14,6 +14,10 @@ export function registerAppTreeTool(server: MCPServer): void {
             type: 'string',
             description: 'Simulator device UDID (defaults to active device)',
           },
+          bundle_id: {
+            type: 'string',
+            description: 'Target Flutter app bundle ID. Used to disambiguate Dart VM Service discovery when multiple Flutter apps run on the same simulator — the macOS AX bridge itself always reads the current foreground app.',
+          },
           max_depth: {
             type: 'number',
             description: 'Maximum tree depth to traverse (default: 10)',
@@ -25,13 +29,14 @@ export function registerAppTreeTool(server: MCPServer): void {
     async (_sessionId: string, params: Record<string, unknown>) => {
       try {
         const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId() ?? undefined;
+        const bundleId = params.bundle_id as string | undefined;
         const maxDepth = params.max_depth as number | undefined;
 
         const bridge = getAccessibilityBridge();
 
         // Ensure Flutter semantics are activated before reading the tree
         if (deviceId) {
-          await ensureSemanticsActive(deviceId);
+          await ensureSemanticsActive(deviceId, { bundleId });
         }
 
         const tree = await bridge.dumpTree({ deviceId, maxDepth });


### PR DESCRIPTION
## Summary

Replaces closed PR #468 (auto-closed when base branch `feature/flutter-semantics-vm-fallback` was deleted on merge of #465).

Threads the `bundle_id` parameter through `app_inspect`, `app_query`, and `app_tree` so multi-app VM Service discovery can target the correct Flutter process when several Flutter apps run on the same simulator.

## Changes

- `src/tools/app-inspect.ts`, `app-query.ts`, `app-tree.ts` — accept and forward `bundle_id`.

## Relationship to #465

#465 added the VM Service fallback in `semantics-activator.ts` which accepts a `bundleId` option. This PR surfaces that parameter at the MCP tool boundary so callers can route the fallback to a specific app.

## Test plan

- [x] Build passes on develop + this commit
- [x] Unit tests unaffected (no semantic change to existing code paths)