### PR TITLE
fix(flutter): surface user-visible widget name in flutter_widget_at_point widget_type (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`flutter_widget_at_point` returns wrapper type in `widget_type`** (#436): The tool previously surfaced the raw inspector `_ElementDiagnosticableTreeNode` wrapper in the `widget_type` field because `summariseNode` reads the inspector's own `type` key first. The public payload now prefers `widgetRuntimeType` (e.g. `"ElevatedButton"`) and falls back to `description` before the wrapper `type`, so callers see the Flutter widget name that the checklist promises. Covered by new unit tests that mirror the live Flutter 3.11.3 VM Service payload.
+
 ## [0.4.4] - 2026-04-15
 
 ### Added — Flutter widget-at-point mapping and release-constraint branching

--- a/src/tools/flutter-widget-at-point.ts
+++ b/src/tools/flutter-widget-at-point.ts
@@ -108,6 +108,12 @@ export function isUserDefinedWidget(node: WidgetSummary | null | undefined): boo
 /**
  * Extract `{ type, description, creation_location, widget_id }` from an
  * inspector payload (already one-level summarised).
+ *
+ * The raw inspector node wraps every widget in `_ElementDiagnosticableTreeNode`,
+ * so `summary.type` carries the wrapper class, not the Flutter widget name.
+ * Prefer `widgetRuntimeType` (always the user-visible widget, e.g.
+ * `"ElevatedButton"`), then `description`, and fall back to `type` only when
+ * neither is present so the public `widget_type` identifies the widget.
  */
 function toPublicShape(summary: WidgetSummary): {
   widget_type: string;
@@ -116,7 +122,7 @@ function toPublicShape(summary: WidgetSummary): {
   creation_location?: { file: string; line: number; column: number };
 } {
   return {
-    widget_type: summary.type,
+    widget_type: summary.widgetRuntimeType ?? summary.description ?? summary.type,
     description: summary.description,
     widget_id: summary.valueId,
     creation_location: summary.creationLocation,

--- a/tests/unit/flutter-widget-at-point.test.ts
+++ b/tests/unit/flutter-widget-at-point.test.ts
@@ -316,9 +316,13 @@ describe('flutter_widget_at_point handler', () => {
     mockEvaluate.mockResolvedValueOnce({ valueAsString: '2|750|1334' });
     mockSelectWidgetAtPoint.mockResolvedValueOnce({
       hit: true,
+      // Shape matches the live VM Service payload: every widget is wrapped in
+      // `_ElementDiagnosticableTreeNode`, the user-visible widget name lives in
+      // `widgetRuntimeType`, and `description` carries the formatted form.
       selection: {
-        type: 'ElevatedButton',
-        description: 'ElevatedButton(onPressed)',
+        type: '_ElementDiagnosticableTreeNode',
+        widgetRuntimeType: 'ElevatedButton',
+        description: 'ElevatedButton',
         valueId: 'inspector-42',
         creationLocation: { file: 'package:myapp/home.dart', line: 47, column: 12 },
       },
@@ -365,7 +369,9 @@ describe('flutter_widget_at_point handler', () => {
     mockSelectWidgetAtPoint.mockResolvedValueOnce({
       hit: true,
       selection: {
-        type: 'Text',
+        type: '_ElementDiagnosticableTreeNode',
+        widgetRuntimeType: 'Text',
+        description: 'Text',
         valueId: 'inspector-9',
         creationLocation: { file: 'package:myapp/home.dart', line: 1, column: 1 },
       },
@@ -376,6 +382,51 @@ describe('flutter_widget_at_point handler', () => {
     const body = JSON.parse(result.content[0].text);
     expect(body.widget_type).toBe('Text');
     expect(body.ancestor_chain).toEqual([]);
+  });
+
+  it('surfaces the user-visible widget in widget_type even when the inspector wraps the node', async () => {
+    // Matches the Flutter 3.11.3 VM Service payload: the outer `type` is the
+    // diagnostic wrapper, and the actual Flutter widget name only appears in
+    // `widgetRuntimeType`. Callers expect `widget_type` to identify the
+    // widget — not the inspector's bookkeeping class — so the tool must
+    // prefer `widgetRuntimeType` / `description` over the wrapper `type`.
+    mockEvaluate.mockResolvedValueOnce({ valueAsString: '3|1179|2556' });
+    mockSelectWidgetAtPoint.mockResolvedValueOnce({
+      hit: true,
+      selection: {
+        type: '_ElementDiagnosticableTreeNode',
+        widgetRuntimeType: 'ElevatedButton',
+        description: 'ElevatedButton',
+        valueId: 'inspector-199',
+        creationLocation: { file: 'package:myapp/home.dart', line: 65, column: 22 },
+      },
+    });
+    mockGetParentChain.mockResolvedValueOnce({ chain: [] });
+
+    const result = await handler('s', { x: 80, y: 465 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.widget_type).toBe('ElevatedButton');
+    expect(body.description).toBe('ElevatedButton');
+    expect(body.widget_id).toBe('inspector-199');
+  });
+
+  it('falls back to description when widgetRuntimeType is absent', async () => {
+    mockEvaluate.mockResolvedValueOnce({ valueAsString: '2|750|1334' });
+    mockSelectWidgetAtPoint.mockResolvedValueOnce({
+      hit: true,
+      selection: {
+        type: '_ElementDiagnosticableTreeNode',
+        description: 'Scaffold',
+        valueId: 'inspector-7',
+        creationLocation: { file: 'package:myapp/home.dart', line: 2, column: 1 },
+      },
+    });
+    mockGetParentChain.mockResolvedValueOnce({ chain: [] });
+
+    const result = await handler('s', { x: 10, y: 20 });
+    const body = JSON.parse(result.content[0].text);
+    expect(body.widget_type).toBe('Scaffold');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes one of the two open integration items on #436.

- `flutter_widget_at_point` previously returned `widget_type: "_ElementDiagnosticableTreeNode"` — the Flutter inspector's diagnostic wrapper — because `summariseNode` reads the inspector payload's `type` key first, and on Flutter 3.11+ that key is always `_ElementDiagnosticableTreeNode`. The actual widget name sits in `widgetRuntimeType` (and `description`).
- `toPublicShape` now prefers `widgetRuntimeType ?? description ?? type`, so callers see `widget_type: "ElevatedButton"` as promised in the issue's API contract.

Fix scope is deliberately narrow: only `toPublicShape` in `src/tools/flutter-widget-at-point.ts` changes. `summariseNode` stays intact so `flutter_root_widget` / `flutter_inspect_selection` payloads remain byte-for-byte compatible for existing consumers.

## Live evidence from #436

Before:
```
flutter_widget_at_point({x:80, y:465}) →
  widget_type: "_ElementDiagnosticableTreeNode"   // ← wrong
  description: "ElevatedButton"
```

After (verified by new unit tests mirroring the live payload shape):
```
flutter_widget_at_point({x:80, y:465}) →
  widget_type: "ElevatedButton"                   // ← matches issue checklist
  description: "ElevatedButton"
```

## Test plan

- [x] `npm run build` — green
- [x] `npm test` — **98 suites, 1424 tests pass** (was 1422; this PR adds 2 new tests)
- [x] Updated two existing handler tests to use the realistic VM Service payload shape (`type: "_ElementDiagnosticableTreeNode"` + `widgetRuntimeType: "..."`)
- [x] Added an explicit test pinning the preference order (`widgetRuntimeType` > `description` > wrapper `type`)
- [x] Added a fallback test covering the `widgetRuntimeType`-absent case

## Notes

- No changes to `summariseNode` — the fix is localized to the tool's public projection.
- Follow-up PR for the remaining checklist item (`ancestor_chain` empty on live) will land next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)