### PR TITLE
fix(flutter): recognize live getParentChain shape so ancestor_chain is populated (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - **`flutter_widget_at_point` returns wrapper type in `widget_type`** (#436): The tool previously surfaced the raw inspector `_ElementDiagnosticableTreeNode` wrapper in the `widget_type` field because `summariseNode` reads the inspector's own `type` key first. The public payload now prefers `widgetRuntimeType` (e.g. `"ElevatedButton"`) and falls back to `description` before the wrapper `type`, so callers see the Flutter widget name that the checklist promises. Covered by new unit tests that mirror the live Flutter 3.11.3 VM Service payload.
+- **`flutter_widget_at_point` `ancestor_chain` always empty against real apps** (#436): `flattenParentChain` only recognised the synthetic `{chain: [...]}` and `{result: {chain: [...]}}` shapes used by the unit tests. The live Flutter 3.11+ response from `ext.flutter.inspector.getParentChain` is `{type: "_extensionType", result: [{node, children}, ...]}` — the `result` key IS the chain array. That third shape is now detected via `Array.isArray(raw.result)`, so the tool returns the real ancestor path instead of an empty list.
 
 ## [0.4.4] - 2026-04-15
 

--- a/src/tools/flutter-widget-at-point.ts
+++ b/src/tools/flutter-widget-at-point.ts
@@ -130,15 +130,26 @@ function toPublicShape(summary: WidgetSummary): {
 }
 
 /**
- * Flatten the `getParentChain` response into `WidgetSummary[]`. The VM
- * Service returns `{ chain: [{ node: {...}, children: [...] }, ...] }` or
- * similar; we tolerate a couple of shapes for robustness across Flutter
- * versions.
+ * Flatten the `getParentChain` response into `WidgetSummary[]`.
+ *
+ * Three payload shapes are seen in the wild:
+ *   1. `{ chain: [{ node: {...}, children: [...] }, ...] }` — synthetic /
+ *      DevTools fixtures.
+ *   2. `{ result: { chain: [...] } }` — wrapped chain from older inspector
+ *      variants.
+ *   3. `{ type: "_extensionType", result: [{ node: {...}, children: [...] }, ...] }`
+ *      — the live Flutter 3.11+ VM Service response, where the top-level
+ *      `result` key *is* the chain array. The pre-fix code only recognised
+ *      shapes (1) and (2), so `ancestor_chain` was always empty against
+ *      real apps (issue #436 live verification).
  */
 export function flattenParentChain(raw: Record<string, unknown>): WidgetSummary[] {
+  const resultField = (raw as { result?: unknown }).result;
   const chain =
     (raw as { chain?: unknown[] }).chain ??
-    (raw as { result?: { chain?: unknown[] } }).result?.chain ??
+    (Array.isArray(resultField)
+      ? resultField
+      : (resultField as { chain?: unknown[] } | undefined)?.chain) ??
     [];
 
   if (!Array.isArray(chain)) return [];

--- a/tests/unit/flutter-widget-at-point.test.ts
+++ b/tests/unit/flutter-widget-at-point.test.ts
@@ -88,6 +88,38 @@ describe('flattenParentChain', () => {
     expect(out[0].type).toBe('X');
   });
 
+  it('accepts the live Flutter 3.11+ shape where result itself is the chain array', () => {
+    // Reproduces the real VM Service response from
+    // ext.flutter.inspector.getParentChain on Flutter 3.11.3: the top-level
+    // `result` key IS the chain array (not an object with a `chain` field).
+    // Pre-fix flattenParentChain returned [] here, which made
+    // `flutter_widget_at_point` report `ancestor_chain: []` on every live hit.
+    const raw = {
+      type: '_extensionType',
+      result: [
+        { node: { type: 'A', creationLocation: { file: 'a.dart', line: 1, column: 1 } } },
+        { node: { type: 'B', creationLocation: { file: 'b.dart', line: 2, column: 2 } } },
+      ],
+    };
+    const out = flattenParentChain(raw as unknown as Record<string, unknown>);
+    expect(out.map((n) => n.type)).toEqual(['A', 'B']);
+  });
+
+  it('flattens the live result-array shape through the user-defined filter', () => {
+    const raw = {
+      type: '_extensionType',
+      result: [
+        { node: { type: 'RootWidget' } }, // no creationLocation — framework
+        { node: { type: 'MyApp', creationLocation: { file: 'package:myapp/main.dart', line: 1, column: 1 } } },
+        { node: { type: 'MaterialApp', creationLocation: { file: 'package:flutter/src/material/app.dart', line: 1, column: 1 } } },
+        { node: { type: 'HomePage', creationLocation: { file: 'package:myapp/home.dart', line: 1, column: 1 } } },
+      ],
+    };
+    const filtered = flattenParentChain(raw as unknown as Record<string, unknown>)
+      .filter(isUserDefinedWidget);
+    expect(filtered.map((n) => n.type)).toEqual(['MyApp', 'HomePage']);
+  });
+
   it('returns [] for malformed input', () => {
     expect(flattenParentChain({})).toEqual([]);
     expect(flattenParentChain({ chain: 'nope' as unknown as unknown[] })).toEqual([]);


### PR DESCRIPTION
## Summary

Closes the second open integration item on #436 (`ancestor_chain` always empty against real apps).

The live Flutter 3.11+ VM Service response from `ext.flutter.inspector.getParentChain` is:

```json
{
  \"type\": \"_extensionType\",
  \"result\": [
    { \"node\": { ... }, \"children\": [ ... ] },
    { \"node\": { ... }, \"children\": [ ... ] }
  ]
}
```

— i.e. the top-level `result` key *is* the chain array. The prior `flattenParentChain` only recognised `{chain: [...]}` (used by DevTools fixtures) and `{result: {chain: [...]}}` (older inspector wrapper). Neither matches the live payload, so every real call fell through to the `[]` default.

This PR adds an `Array.isArray(raw.result)` branch alongside the existing two, so the tool returns the real ancestor path instead of an empty list. No other call sites change.

## Before / after

- **Before** (against the `flutter-qa-app` fixture on iPhone 16, live): `flutter_widget_at_point({x:80, y:465})` → `ancestor_chain: []` even though the VM Service returned a RootWidget → View → … → ElevatedButton chain.
- **After** (unit-covered): the flatten helper picks up `result[*].node`, and `isUserDefinedWidget` filtering correctly drops framework entries (`RootWidget`, `MaterialApp`, `package:flutter/…`) leaving user widgets like `MyApp` / `HomePage`.

## Test plan

- [x] `npm run build` — green
- [x] `npm test` — **98 suites, 1424 tests pass** (adds 2 new unit tests pinning the live response shape and the filtered user-defined path)
- [x] New tests: `accepts the live Flutter 3.11+ shape where result itself is the chain array` + `flattens the live result-array shape through the user-defined filter`

## Notes

- Complementary to #479 (which fixed `widget_type` on the same tool). The two are independent PRs as requested — each addresses one checklist item on #436.
- Still best-effort: if `getParentChain` throws (older Flutter), the handler already falls back to `ancestor_chain: []` plus a stderr audit entry; that path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)