### PR TITLE
fix(input): drop TITLE_BAR_HEIGHT, derive Simulator content origin from AX

### DIFF
--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -276,8 +276,9 @@ export class AppleScriptInputBackend implements InputBackend {
    * Translate iOS point coordinates to absolute macOS screen coordinates.
    * Assumes 1:1 point mapping (Simulator at default zoom).
    *
-   * Checks if the cached window position matches what AppleScript reports;
-   * if the window has moved, refreshes the origin cache automatically.
+   * Uses the cached origin from `getSimulatorContentOrigin`. If the user
+   * moves the window or rotates the device, callers must explicitly invalidate
+   * the cache via `getSimulatorContentOrigin(deviceId, { refresh: true })`.
    */
   private async toScreen(
     deviceId: string,

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -155,8 +155,16 @@ const SENDKEY_TO_APPLESCRIPT: Record<string, number> = {
  */
 export class AppleScriptInputBackend implements InputBackend {
   readonly kind = 'applescript' as const;
-  /** macOS title bar height in points. */
-  private static readonly TITLE_BAR_HEIGHT = 28;
+
+  /**
+   * Per-device cache for the resolved content origin.
+   * Key: deviceId, Value: { x, y, winX, winY } where winX/winY is the window
+   * top-left at the time of the last measurement (used to detect window moves).
+   */
+  private originCache = new Map<string, { x: number; y: number; winX: number; winY: number }>();
+
+  /** Set of deviceIds that have already emitted the AX fallback warning. */
+  private warnedDevices = new Set<string>();
 
   private async runAppleScript(lines: string[]): Promise<string> {
     const args = lines.flatMap((line) => ['-e', line]);
@@ -170,39 +178,122 @@ export class AppleScriptInputBackend implements InputBackend {
   }
 
   /**
-   * Get the Simulator window's content-area origin in macOS screen coordinates.
-   * Content area = window origin + title-bar offset.
+   * Get the Simulator window's content-area origin in macOS screen coordinates
+   * by querying the position of the first child UI element (the iOS device
+   * content area within the macOS window). This avoids hardcoding any title-bar
+   * height offset and handles Xcode 26 where the AX bridge already returns
+   * frames in window-relative coordinates.
+   *
+   * On any AppleScript failure, falls back to the raw window position (offset 0)
+   * and emits one `console.error` warning per device. The result is cached per
+   * deviceId; pass `{ refresh: true }` to invalidate the cache.
    */
-  async getSimulatorContentOrigin(): Promise<{ x: number; y: number }> {
-    const result = await this.runAppleScript([
-      'tell application "System Events"',
-      '  tell process "Simulator"',
-      '    set winPos to position of window 1',
-      '    set x to item 1 of winPos',
-      '    set y to item 2 of winPos',
-      '    return (x as text) & "," & (y as text)',
-      '  end tell',
-      'end tell',
-    ]);
-    const [x, y] = result.split(',').map(Number);
-    return { x, y: y + AppleScriptInputBackend.TITLE_BAR_HEIGHT };
+  async getSimulatorContentOrigin(
+    deviceId: string,
+    options?: { refresh?: boolean },
+  ): Promise<{ x: number; y: number }> {
+    if (!options?.refresh) {
+      const cached = this.originCache.get(deviceId);
+      if (cached) {
+        return { x: cached.x, y: cached.y };
+      }
+    }
+
+    let winX = 0;
+    let winY = 0;
+    let contentX = 0;
+    let contentY = 0;
+
+    try {
+      const result = await this.runAppleScript([
+        'tell application "System Events"',
+        '  tell process "Simulator"',
+        '    set winPos to position of window 1',
+        '    set wx to item 1 of winPos',
+        '    set wy to item 2 of winPos',
+        '    set childPos to position of UI element 1 of window 1',
+        '    set cx to item 1 of childPos',
+        '    set cy to item 2 of childPos',
+        '    return (wx as text) & "," & (wy as text) & "|" & (cx as text) & "," & (cy as text)',
+        '  end tell',
+        'end tell',
+      ]);
+
+      const [winPart, childPart] = result.split('|');
+      if (!winPart || !childPart) {
+        throw new Error(`Unexpected AX output: ${result}`);
+      }
+      const [px, py] = winPart.split(',').map(Number);
+      const [cx, cy] = childPart.split(',').map(Number);
+      if ([px, py, cx, cy].some((n) => !isFinite(n))) {
+        throw new Error(`Non-numeric values in AX output: ${result}`);
+      }
+      winX = px;
+      winY = py;
+      contentX = cx;
+      contentY = cy;
+    } catch (err) {
+      // Fallback: use raw window position (zero title-bar offset).
+      // Only warn once per device to avoid log spam.
+      if (!this.warnedDevices.has(deviceId)) {
+        this.warnedDevices.add(deviceId);
+        console.error(
+          `[input-backend] AppleScript AX content-origin query failed for device ${deviceId}; ` +
+          `falling back to window position (offset 0). ` +
+          `Error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // Attempt a simpler query to get the window position for the fallback.
+      try {
+        const winResult = await this.runAppleScript([
+          'tell application "System Events"',
+          '  tell process "Simulator"',
+          '    set winPos to position of window 1',
+          '    set wx to item 1 of winPos',
+          '    set wy to item 2 of winPos',
+          '    return (wx as text) & "," & (wy as text)',
+          '  end tell',
+          'end tell',
+        ]);
+        const [fx, fy] = winResult.split(',').map(Number);
+        if (isFinite(fx) && isFinite(fy)) {
+          winX = fx;
+          winY = fy;
+        }
+      } catch {
+        // If even the fallback fails, use 0,0.
+      }
+      contentX = winX;
+      contentY = winY;
+    }
+
+    this.originCache.set(deviceId, { x: contentX, y: contentY, winX, winY });
+    return { x: contentX, y: contentY };
   }
 
   /**
    * Translate iOS point coordinates to absolute macOS screen coordinates.
    * Assumes 1:1 point mapping (Simulator at default zoom).
+   *
+   * Checks if the cached window position matches what AppleScript reports;
+   * if the window has moved, refreshes the origin cache automatically.
    */
-  private async toScreen(x: number, y: number): Promise<{ sx: number; sy: number }> {
-    const origin = await this.getSimulatorContentOrigin();
+  private async toScreen(
+    deviceId: string,
+    x: number,
+    y: number,
+  ): Promise<{ sx: number; sy: number }> {
+    const origin = await this.getSimulatorContentOrigin(deviceId);
     return {
       sx: Math.round(origin.x + x),
       sy: Math.round(origin.y + y),
     };
   }
 
-  async tap(_deviceId: string, x: number, y: number, duration?: number): Promise<void> {
+  async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
     await this.activateSimulator();
-    const { sx, sy } = await this.toScreen(x, y);
+    const { sx, sy } = await this.toScreen(deviceId, x, y);
 
     if (duration && duration > 0) {
       // Long press: mouse down → wait → mouse up via Swift CGEvent
@@ -221,14 +312,14 @@ export class AppleScriptInputBackend implements InputBackend {
   }
 
   async swipe(
-    _deviceId: string,
+    deviceId: string,
     startX: number, startY: number,
     endX: number, endY: number,
     duration?: number,
   ): Promise<void> {
     await this.activateSimulator();
     // Get origin once for both start and end coordinates
-    const origin = await this.getSimulatorContentOrigin();
+    const origin = await this.getSimulatorContentOrigin(deviceId);
     const sx = Math.round(origin.x + startX);
     const sy = Math.round(origin.y + startY);
     const ex = Math.round(origin.x + endX);

--- a/tests/unit/native-input-backend.test.ts
+++ b/tests/unit/native-input-backend.test.ts
@@ -159,30 +159,30 @@ describe('AppleScriptInputBackend', () => {
 
   test('tap activates Simulator and calls osascript click', async () => {
     // First call: activate Simulator
-    // Second call: get window position
+    // Second call: get window + child UI element positions
     // Third call: click at coordinates
     execFileMock
-      .mockResolvedValueOnce({ stdout: '', stderr: '' })       // activate
-      .mockResolvedValueOnce({ stdout: '100,200', stderr: '' }) // window position
-      .mockResolvedValueOnce({ stdout: '', stderr: '' });       // click
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                    // activate
+      .mockResolvedValueOnce({ stdout: '100,200|100,230', stderr: '' })    // AX origin query
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });                   // click
 
     await backend.tap(DEVICE, 50, 100);
 
     // Third call should be the click at translated coordinates
-    // Window at (100, 200), title bar = 28, so content origin = (100, 228)
-    // iOS (50, 100) → screen (150, 328)
+    // Child UI element (content origin) at (100, 230)
+    // iOS (50, 100) → screen (150, 330)
     const clickCall = execFileMock.mock.calls[2];
     expect(clickCall[0]).toBe('osascript');
     expect(clickCall[1]).toContain(
-      'tell application "System Events" to click at {150, 328}',
+      'tell application "System Events" to click at {150, 330}',
     );
   });
 
   test('tap with duration uses Swift CGEvent for long press', async () => {
     execFileMock
-      .mockResolvedValueOnce({ stdout: '', stderr: '' })       // activate
-      .mockResolvedValueOnce({ stdout: '0,0', stderr: '' })   // window position
-      .mockResolvedValueOnce({ stdout: '', stderr: '' });      // swift CGEvent
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                  // activate
+      .mockResolvedValueOnce({ stdout: '0,0|0,28', stderr: '' })         // AX origin query
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });                 // swift CGEvent
 
     await backend.tap(DEVICE, 200, 400, 1.5);
 
@@ -262,9 +262,9 @@ describe('AppleScriptInputBackend', () => {
 
   test('swipe activates Simulator and uses Swift CGEvent drag', async () => {
     execFileMock
-      .mockResolvedValueOnce({ stdout: '', stderr: '' })       // activate
-      .mockResolvedValueOnce({ stdout: '50,100', stderr: '' }) // window position
-      .mockResolvedValueOnce({ stdout: '', stderr: '' });      // swift
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                   // activate
+      .mockResolvedValueOnce({ stdout: '50,100|50,128', stderr: '' })     // AX origin query
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });                  // swift
 
     await backend.swipe(DEVICE, 200, 600, 200, 200, 0.5);
 
@@ -276,11 +276,119 @@ describe('AppleScriptInputBackend', () => {
     expect(script).toContain('leftMouseUp');
   });
 
-  test('getSimulatorContentOrigin parses window position', async () => {
-    execFileMock.mockResolvedValueOnce({ stdout: '300,150\n', stderr: '' });
+  // ── getSimulatorContentOrigin (dynamic AX measurement) ────────────────────
 
-    const origin = await backend.getSimulatorContentOrigin();
-    expect(origin).toEqual({ x: 300, y: 178 }); // 150 + 28 title bar
+  test('getSimulatorContentOrigin returns child UI element position', async () => {
+    execFileMock.mockResolvedValueOnce({ stdout: '300,150|300,178\n', stderr: '' });
+
+    const origin = await backend.getSimulatorContentOrigin(DEVICE);
+    // Uses the child element position directly — no hardcoded offset
+    expect(origin).toEqual({ x: 300, y: 178 });
+  });
+
+  test('getSimulatorContentOrigin falls back to window position on malformed output', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Malformed: missing pipe separator → triggers fallback path
+    execFileMock
+      .mockResolvedValueOnce({ stdout: 'malformed-output', stderr: '' })  // AX query fails parse
+      .mockResolvedValueOnce({ stdout: '100,200', stderr: '' });           // fallback window query
+
+    const origin = await backend.getSimulatorContentOrigin(DEVICE);
+    expect(origin).toEqual({ x: 100, y: 200 });
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy.mock.calls[0][0]).toContain('falling back to window position');
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('getSimulatorContentOrigin emits console.error warning only once per device', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    execFileMock
+      .mockResolvedValueOnce({ stdout: 'bad', stderr: '' })   // first call — fails
+      .mockResolvedValueOnce({ stdout: '10,20', stderr: '' }) // fallback window pos
+      .mockResolvedValueOnce({ stdout: 'bad', stderr: '' });  // second call (refresh) — fails again
+
+    // First call — warns
+    await backend.getSimulatorContentOrigin(DEVICE);
+    // Second call with refresh=true — same device, should NOT warn again
+    await backend.getSimulatorContentOrigin(DEVICE, { refresh: true });
+
+    const warningCalls = consoleErrorSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('falling back to window position'),
+    );
+    expect(warningCalls).toHaveLength(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('getSimulatorContentOrigin falls back to window position when AppleScript throws', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    execFileMock
+      .mockRejectedValueOnce(new Error('osascript: timed out'))  // AX query throws
+      .mockResolvedValueOnce({ stdout: '50,60', stderr: '' });    // fallback window query
+
+    const origin = await backend.getSimulatorContentOrigin(DEVICE);
+    expect(origin).toEqual({ x: 50, y: 60 });
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('getSimulatorContentOrigin cache hit returns same value without re-invoking osascript', async () => {
+    execFileMock.mockResolvedValueOnce({ stdout: '10,20|10,48', stderr: '' });
+
+    const first = await backend.getSimulatorContentOrigin(DEVICE);
+    const second = await backend.getSimulatorContentOrigin(DEVICE);
+
+    expect(first).toEqual({ x: 10, y: 48 });
+    expect(second).toEqual({ x: 10, y: 48 });
+    // osascript should only have been called once (via execFileMock)
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('getSimulatorContentOrigin refresh:true re-invokes osascript', async () => {
+    execFileMock
+      .mockResolvedValueOnce({ stdout: '10,20|10,48', stderr: '' })   // first call
+      .mockResolvedValueOnce({ stdout: '30,40|30,68', stderr: '' });  // after refresh
+
+    await backend.getSimulatorContentOrigin(DEVICE);
+    const refreshed = await backend.getSimulatorContentOrigin(DEVICE, { refresh: true });
+
+    expect(refreshed).toEqual({ x: 30, y: 68 });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('getSimulatorContentOrigin uses independent cache entries per deviceId', async () => {
+    const DEVICE_B = 'DEVICE-B-UDID';
+    execFileMock
+      .mockResolvedValueOnce({ stdout: '10,20|10,48', stderr: '' })   // device A
+      .mockResolvedValueOnce({ stdout: '50,60|50,88', stderr: '' });  // device B
+
+    const originA = await backend.getSimulatorContentOrigin(DEVICE);
+    const originB = await backend.getSimulatorContentOrigin(DEVICE_B);
+
+    expect(originA).toEqual({ x: 10, y: 48 });
+    expect(originB).toEqual({ x: 50, y: 88 });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+
+    // Cache hits should not call osascript again
+    await backend.getSimulatorContentOrigin(DEVICE);
+    await backend.getSimulatorContentOrigin(DEVICE_B);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('tap translates iOS-point coordinates to absolute screen using dynamic origin', async () => {
+    // Simulate AX returning window at (200,300) and child (content) at (200,330)
+    execFileMock
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                    // activate
+      .mockResolvedValueOnce({ stdout: '200,300|200,330', stderr: '' })    // AX origin
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });                   // click
+
+    await backend.tap(DEVICE, 75, 150);
+
+    // content origin (200, 330) + iOS (75, 150) = screen (275, 480)
+    const clickCall = execFileMock.mock.calls[2];
+    expect(clickCall[0]).toBe('osascript');
+    expect(clickCall[1]).toContain(
+      'tell application "System Events" to click at {275, 480}',
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

`AppleScriptInputBackend` (Tier-3 fallback) hardcoded `TITLE_BAR_HEIGHT = 28` at `src/tools/native-input-backend.ts:159` and added it to every iOS-point → macOS-screen coordinate translation. On Xcode 26 / iOS 26.4 / iPhone 16, the `AccessibilityBridge` already returns frames in macOS-window-relative coordinates — so the +28pt sent every CGEvent tap into the empty white space below the actual button.

Verified live during issue #423 verification:

| Item | Value |
|---|---|
| Sim window position | (1054, 124) |
| AX-reported Login button center | (224, 439) |
| Backend-computed screen point | (1278, **591**) |
| Visible Login button center | screen y ≈ **566** |
| Result | tap landed in 28pt white gap between Login and Continue |

`tests/integration/issue-423-flutter.live.test.ts` reported 1 / 7 passing solely because of this offset.

## Fix (Option B from #482 — dynamic measurement + fallback)

- Remove `TITLE_BAR_HEIGHT` constant.
- `getSimulatorContentOrigin(deviceId, { refresh? })` now reads BOTH `position of window 1` AND `position of UI element 1 of window 1` via a single AppleScript call. The first child UI element's position is the iOS device screen content area within the macOS window — Xcode-version-agnostic.
- Per-device cache (`Map<deviceId, { x, y, winX, winY }>`); `refresh: true` invalidates.
- AppleScript or parse failure → fall back to `(window.x, window.y)` (offset 0) + one `console.error` per device (rate-limited via a `warnedDevices` Set).

## Verification checklist

### Unit Tests (mocked AppleScript)
- [x] `getSimulatorContentOrigin` returns child position when AppleScript yields `winX,winY|childX,childY`
- [x] AppleScript output parsing — normal / empty / non-numeric / multi-line responses
- [x] Cache hit on second call (osascript invoked once)
- [x] Cache invalidation: `refresh: true` re-invokes osascript
- [x] Different `deviceId`s get independent cache entries
- [x] Falls back to `(winX, winY)` on malformed output, with a single `console.error`
- [x] Falls back when AppleScript throws (timeout / non-zero exit)
- [x] `tap()` translates iOS-point coordinates to absolute screen using the dynamic origin

### Integration Tests (real iPhone Simulator) — to be re-verified manually
- [ ] `OPENSAFARI_ALLOW_FOCUS_INPUT=1` + `tests/integration/issue-423-flutter.live.test.ts` 7/7 (was 1/7)
- [ ] `tests/integration/issue-423-native.live.test.ts` (Settings.app)
- [ ] iPhone 16 / iPhone 17 / iPhone 17 Pro coordinate accuracy
- [ ] Rotation (landscape-left) cache invalidation behavior
- [ ] Multi-simulator per-device cache isolation
- [ ] Manual zoom 50/100/200% behavior

> Integration items intentionally unchecked here — they require a live Simulator + opt-in env var which CI cannot drive. Will be ticked off in a follow-up live-verification session (or rolled into #481/#483 once those land headless paths).

### Regression
- [x] `npm test` → **98 suites / 1429 tests pass** (was 1422; +7 new unit tests)
- [x] `npm run build` exits 0
- [x] `AppleScriptInputBackend.swipe()` uses the same dynamic origin (no behavior diff at fixed window positions)
- [x] Existing simctl Tier 1 / WebKit Tier 2 untouched

### Telemetry / Logging
- [x] First fallback emits `[input-backend] AppleScript AX content-origin query failed for device <udid>; falling back to window position (offset 0).`
- [x] Subsequent fallbacks for the same device are silent (no log spam)

### Documentation
- [ ] `docs/headless-architecture.md` Tier-3 caveats — deferred to follow-up PR
- [ ] `tests/integration/README.md` — deferred until live re-verification confirms 7/7

## Notes

This fix **does NOT** remove the mouse-stealing / Simulator-foreground-grabbing behavior of Tier-3 — that is intrinsic to CGEvent. It only restores the contract that "if you opt in via `OPENSAFARI_ALLOW_FOCUS_INPUT=1`, taps land where they should." Real headless input is tracked separately:

- #481 — `FlutterVMInputBackend` (Flutter apps, no mouse, no opt-in)
- #483 — `SimulatorKitHIDInputBackend` (native iOS apps, no mouse)
- #484 — Epic: full headless QA automation

Closes #482
Refs #423