### PR TITLE
feat(input): implement SimulatorKit HID injection in sim-hid-bridge (#489)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "darwin"
   ],
   "scripts": {
-    "build": "npm run clean && npm run build:src && npm run build:cli && npm run build:ax-bridge",
+    "build": "npm run clean && npm run build:src && npm run build:cli && npm run build:ax-bridge && npm run build:sim-hid-bridge",
     "postbuild": "cp src/native/ax-bridge.swift dist/ 2>/dev/null || true; cp src/native/sim-hid-bridge.swift dist/ 2>/dev/null || true",
     "build:src": "webpack --config webpack.config.js --config-name server",
     "build:cli": "webpack --config webpack.config.js --config-name cli",
     "build:ax-bridge": "swiftc -O src/native/ax-bridge.swift -o dist/ax-bridge 2>/dev/null && (codesign --sign - dist/ax-bridge 2>/dev/null || (echo 'ax-bridge: codesign failed, removing unsigned binary' && rm -f dist/ax-bridge)) || echo 'ax-bridge: compiled binary skipped, using swift interpreter fallback'",
+    "build:sim-hid-bridge": "swiftc -O src/native/sim-hid-bridge.swift -o dist/sim-hid-bridge 2>/dev/null && (codesign --sign - dist/sim-hid-bridge 2>/dev/null || (echo 'sim-hid-bridge: codesign failed, removing unsigned binary' && rm -f dist/sim-hid-bridge)) || echo 'sim-hid-bridge: compiled binary skipped, using swift interpreter fallback'",
     "clean": "rimraf dist",
     "dev": "ts-node --esm src/index.ts",
     "start": "node dist/index.js",

--- a/src/native/sim-hid-bridge.swift
+++ b/src/native/sim-hid-bridge.swift
@@ -1,10 +1,9 @@
 #!/usr/bin/env swift
 //
-// sim-hid-bridge.swift — SimulatorKit HID event bridge (PoC stub).
+// sim-hid-bridge.swift — SimulatorKit HID event bridge.
 //
-// This helper is the Swift side of the SimulatorKitHIDInputBackend described
-// in issue #483. It is intended to be compiled to `dist/sim-hid-bridge` and
-// spawned from Node.js via `execFile`.
+// Swift helper for SimulatorKitHIDInputBackend (issue #483).
+// Compiled to `dist/sim-hid-bridge` and spawned from Node.js via `execFile`.
 //
 // Usage:
 //   sim-hid-bridge <udid> tap    <x> <y> [duration]
@@ -12,246 +11,273 @@
 //   sim-hid-bridge <udid> key    <hidUsage> [duration]
 //   sim-hid-bridge <udid> button <home|lock|sound-up|sound-down> [duration]
 //
-// Output (stdout, newline-terminated JSON):
-//   success: { "ok": true,  "kind": "tap", "udid": "...", "elapsed_ms": N }
-//   failure: { "ok": false, "error": "...", "code": "..." }
-//
 // Exit codes:
 //   0  — success
 //   64 — argument / usage error (EX_USAGE)
 //   69 — SimDevice not found / not booted (EX_UNAVAILABLE)
-//   78 — SimulatorKit framework could not be loaded (EX_CONFIG)
-//   99 — PoC stub: HID injection not yet implemented (see issue #483)
+//   78 — SimulatorKit or private API missing (EX_CONFIG)
 //
-// Status: PoC stub.
-// This stub intentionally does NOT inject real HID events yet. The purpose of
-// the PoC PR (#483) is to prove:
-//   1. The Swift+Node bridge spawn model compiles and runs on the dev machine.
-//   2. SimulatorKit.framework can be dlopen'd on Xcode 26 hosts.
-//   3. The JSON protocol between this binary and the Node wrapper is stable.
+// Architecture:
+//   Uses SimDeviceLegacyHIDClient + IndigoHIDMessage C functions from
+//   SimulatorKit.framework, resolved via dlopen/dlsym at runtime.
+//   Every private symbol is nil-checked; missing symbols exit 78.
 //
-// Follow-up work (tracked in #483):
-//   - Resolve the booted SimDevice for <udid> via CoreSimulator
-//     (`SimServiceContext.sharedServiceContextForDeveloperDir` →
-//      `defaultDeviceSetWithError` → `devices` filtered by UDID).
-//   - Instantiate `FBSimulatorHID` (or equivalent) for that SimDevice.
-//   - Translate the parsed command into the appropriate HID event:
-//       tap    → digitizer down → up (optionally with hold duration)
-//       swipe  → digitizer down → N interpolated moves → up
-//       key    → keyboard event (HID usage page 0x07)
-//       button → hardware button event (home, lock, volume up/down)
-//   - Honour Apple BC-break risk: wrap every private symbol in a nil check and
-//     return a structured error code the Node wrapper can surface verbatim.
-//
-// License note:
-//   Behaviour modelled after Facebook's `idb` (MIT) but this file is
-//   independently written from public documentation and symbol inspection.
+// License: Behaviour modelled after Facebook's idb (MIT), independently written.
 
 import Foundation
+import ObjectiveC
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
 
-// MARK: - JSON output helpers
-
-struct SuccessJSON: Codable {
-    let ok: Bool
-    let kind: String
-    let udid: String
-    let elapsed_ms: Int
+// MARK: - JSON helpers
+struct SuccessJSON: Codable { let ok: Bool; let kind: String; let udid: String; let elapsed_ms: Int }
+struct ErrorJSON: Codable { let ok: Bool; let error: String; let code: String }
+func emitJSON<T: Encodable>(_ v: T) {
+    let enc = JSONEncoder(); enc.outputFormatting = [.sortedKeys]
+    if let d = try? enc.encode(v), let j = String(data: d, encoding: .utf8) { print(j) }
 }
-
-struct ErrorJSON: Codable {
-    let ok: Bool
-    let error: String
-    let code: String
-}
-
-func emitJSON<T: Encodable>(_ value: T) {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.sortedKeys]
-    if let data = try? encoder.encode(value),
-       let json = String(data: data, encoding: .utf8) {
-        print(json)
-    }
-}
-
-func emitError(_ message: String, code: String) {
-    emitJSON(ErrorJSON(ok: false, error: message, code: code))
-}
+func emitError(_ msg: String, code: String) { emitJSON(ErrorJSON(ok: false, error: msg, code: code)) }
 
 // MARK: - Framework loading
-
-/// Attempt to dlopen SimulatorKit.framework. Returns the handle on success,
-/// nil on failure. We keep this non-fatal so the stub can still report a
-/// structured error instead of segfaulting.
-func loadSimulatorKit() -> UnsafeMutableRawPointer? {
-    // Xcode installs SimulatorKit under PrivateFrameworks inside the developer
-    // directory. The exact path has been stable from Xcode 11 through Xcode 26.
-    let candidates = [
-        "/Library/Developer/PrivateFrameworks/SimulatorKit.framework/SimulatorKit",
-        "/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit",
-        "/Applications/Xcode-beta.app/Contents/Developer/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit",
-    ]
-    for path in candidates {
-        if FileManager.default.fileExists(atPath: path) {
-            if let handle = dlopen(path, RTLD_NOW) {
-                return handle
-            }
-        }
+func loadFramework(_ candidates: [String]) -> UnsafeMutableRawPointer? {
+    for p in candidates {
+        if FileManager.default.fileExists(atPath: p), let h = dlopen(p, RTLD_NOW) { return h }
     }
     return nil
 }
-
-/// Attempt to dlopen CoreSimulator.framework — needed to resolve SimDevice
-/// instances from UDIDs.
+func loadSimulatorKit() -> UnsafeMutableRawPointer? {
+    loadFramework([
+        "/Library/Developer/PrivateFrameworks/SimulatorKit.framework/SimulatorKit",
+        "/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks/SimulatorKit.framework/Versions/A/SimulatorKit",
+        "/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit",
+        "/Applications/Xcode-beta.app/Contents/Developer/Library/PrivateFrameworks/SimulatorKit.framework/Versions/A/SimulatorKit",
+    ])
+}
 func loadCoreSimulator() -> UnsafeMutableRawPointer? {
-    let candidates = [
+    loadFramework([
         "/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator",
+        "/Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/CoreSimulator",
         "/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks/CoreSimulator.framework/CoreSimulator",
-    ]
-    for path in candidates {
-        if FileManager.default.fileExists(atPath: path) {
-            if let handle = dlopen(path, RTLD_NOW) {
-                return handle
-            }
-        }
-    }
-    return nil
+    ])
 }
 
 // MARK: - Command parsing
-
 enum Command {
     case tap(x: Double, y: Double, duration: Double?)
     case swipe(x1: Double, y1: Double, x2: Double, y2: Double, duration: Double?)
     case key(hidUsage: Int, duration: Double?)
     case button(name: String, duration: Double?)
 }
-
-enum ParseError: Error {
-    case usage(String)
-}
+enum ParseError: Error { case usage(String) }
 
 func parseCommand(_ argv: [String]) throws -> (udid: String, command: Command) {
-    // argv[0] is the binary path; we expect at minimum <udid> <kind>.
-    guard argv.count >= 3 else {
-        throw ParseError.usage(
-            "usage: sim-hid-bridge <udid> <tap|swipe|key|button> <args...>"
-        )
-    }
-    let udid = argv[1]
-    let kind = argv[2]
-    let rest = Array(argv.dropFirst(3))
-
+    guard argv.count >= 3 else { throw ParseError.usage("usage: sim-hid-bridge <udid> <tap|swipe|key|button> <args...>") }
+    let udid = argv[1], kind = argv[2], rest = Array(argv.dropFirst(3))
     switch kind {
     case "tap":
         guard rest.count >= 2, let x = Double(rest[0]), let y = Double(rest[1]) else {
-            throw ParseError.usage("usage: sim-hid-bridge <udid> tap <x> <y> [duration]")
-        }
-        let duration = rest.count >= 3 ? Double(rest[2]) : nil
-        return (udid, .tap(x: x, y: y, duration: duration))
-
+            throw ParseError.usage("usage: sim-hid-bridge <udid> tap <x> <y> [duration]") }
+        return (udid, .tap(x: x, y: y, duration: rest.count >= 3 ? Double(rest[2]) : nil))
     case "swipe":
-        guard rest.count >= 4,
-              let x1 = Double(rest[0]), let y1 = Double(rest[1]),
+        guard rest.count >= 4, let x1 = Double(rest[0]), let y1 = Double(rest[1]),
               let x2 = Double(rest[2]), let y2 = Double(rest[3]) else {
-            throw ParseError.usage(
-                "usage: sim-hid-bridge <udid> swipe <x1> <y1> <x2> <y2> [duration]"
-            )
-        }
-        let duration = rest.count >= 5 ? Double(rest[4]) : nil
-        return (udid, .swipe(x1: x1, y1: y1, x2: x2, y2: y2, duration: duration))
-
+            throw ParseError.usage("usage: sim-hid-bridge <udid> swipe <x1> <y1> <x2> <y2> [duration]") }
+        return (udid, .swipe(x1: x1, y1: y1, x2: x2, y2: y2, duration: rest.count >= 5 ? Double(rest[4]) : nil))
     case "key":
-        guard rest.count >= 1, let hid = Int(rest[0]) else {
-            throw ParseError.usage("usage: sim-hid-bridge <udid> key <hidUsage> [duration]")
-        }
-        let duration = rest.count >= 2 ? Double(rest[1]) : nil
-        return (udid, .key(hidUsage: hid, duration: duration))
-
+        guard rest.count >= 1, let h = Int(rest[0]) else {
+            throw ParseError.usage("usage: sim-hid-bridge <udid> key <hidUsage> [duration]") }
+        return (udid, .key(hidUsage: h, duration: rest.count >= 2 ? Double(rest[1]) : nil))
     case "button":
         guard rest.count >= 1 else {
-            throw ParseError.usage(
-                "usage: sim-hid-bridge <udid> button <home|lock|sound-up|sound-down> [duration]"
-            )
-        }
-        let allowed = ["home", "lock", "sound-up", "sound-down"]
-        guard allowed.contains(rest[0]) else {
-            let list = allowed.joined(separator: ", ")
-            throw ParseError.usage(
-                "unknown button '\(rest[0])'. Allowed: \(list)"
-            )
-        }
-        let duration = rest.count >= 2 ? Double(rest[1]) : nil
-        return (udid, .button(name: rest[0], duration: duration))
-
-    default:
-        throw ParseError.usage(
-            "unknown command '\(kind)'. Allowed: tap, swipe, key, button"
-        )
+            throw ParseError.usage("usage: sim-hid-bridge <udid> button <home|lock|sound-up|sound-down> [duration]") }
+        let ok = ["home", "lock", "sound-up", "sound-down"]
+        guard ok.contains(rest[0]) else { throw ParseError.usage("unknown button '\(rest[0])'. Allowed: \(ok.joined(separator: ", "))") }
+        return (udid, .button(name: rest[0], duration: rest.count >= 2 ? Double(rest[1]) : nil))
+    default: throw ParseError.usage("unknown command '\(kind)'. Allowed: tap, swipe, key, button")
     }
 }
+func kindString(_ c: Command) -> String {
+    switch c { case .tap: return "tap"; case .swipe: return "swipe"; case .key: return "key"; case .button: return "button" }
+}
 
-func kindString(_ cmd: Command) -> String {
-    switch cmd {
-    case .tap:    return "tap"
-    case .swipe:  return "swipe"
-    case .key:    return "key"
-    case .button: return "button"
+// MARK: - Device Resolution (CoreSimulator private API)
+func getDevDir() -> String {
+    let p = Pipe(); let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/xcode-select")
+    proc.arguments = ["-p"]; proc.standardOutput = p; proc.standardError = FileHandle.nullDevice
+    do { try proc.run(); proc.waitUntilExit()
+        if let r = String(data: p.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !r.isEmpty { return r }
+    } catch {}
+    return "/Applications/Xcode.app/Contents/Developer"
+}
+
+func resolveDevice(udid: String) -> NSObject? {
+    if let ds = getDefaultDeviceSet(), let d = findDevice(ds, udid) { return d }
+    if let SC = NSClassFromString("SimDeviceSet") {
+        let sel = NSSelectorFromString("defaultSet")
+        if (SC as AnyObject).responds(to: sel),
+           let ds = (SC as AnyObject).perform(sel)?.takeUnretainedValue() as? NSObject,
+           let d = findDevice(ds, udid) { return d }
     }
+    return nil
+}
+
+func getDefaultDeviceSet() -> NSObject? {
+    guard let C = NSClassFromString("SimServiceContext") else { return nil }
+    let sel = NSSelectorFromString("sharedServiceContextForDeveloperDir:error:")
+    guard (C as AnyObject).responds(to: sel), let m = class_getClassMethod(C, sel) else { return nil }
+    typealias F = @convention(c) (AnyClass, Selector, NSString, AutoreleasingUnsafeMutablePointer<NSError?>?) -> AnyObject?
+    guard let ctx = unsafeBitCast(method_getImplementation(m), to: F.self)(C, sel, NSString(string: getDevDir()), nil) as? NSObject else { return nil }
+    let dsSel = NSSelectorFromString("defaultDeviceSetWithError:")
+    guard ctx.responds(to: dsSel), let dsM = class_getInstanceMethod(type(of: ctx), dsSel) else { return nil }
+    typealias DsF = @convention(c) (NSObject, Selector, AutoreleasingUnsafeMutablePointer<NSError?>?) -> AnyObject?
+    return unsafeBitCast(method_getImplementation(dsM), to: DsF.self)(ctx, dsSel, nil) as? NSObject
+}
+
+func findDevice(_ ds: NSObject, _ udid: String) -> NSObject? {
+    let target = udid.uppercased()
+    for selN in ["availableDevices", "devices"] {
+        let sel = NSSelectorFromString(selN)
+        guard ds.responds(to: sel), let devs = ds.perform(sel)?.takeUnretainedValue() as? [NSObject] else { continue }
+        for d in devs {
+            if let u = d.perform(NSSelectorFromString("UDID"))?.takeUnretainedValue() as? NSUUID,
+               u.uuidString.uppercased() == target { return d }
+        }
+    }
+    return nil
+}
+
+func isDeviceBooted(_ d: NSObject) -> Bool { (d.value(forKey: "state") as? Int) == 3 }
+
+// MARK: - HID Client (SimulatorKit private API)
+func createHIDClient(device: NSObject) -> NSObject? {
+    guard let HC = NSClassFromString("_TtC12SimulatorKit24SimDeviceLegacyHIDClient") else {
+        fputs("[sim-hid] SimDeviceLegacyHIDClient not found\n", stderr); return nil }
+    let iSel = NSSelectorFromString("initWithDevice:error:")
+    guard let iM = class_getInstanceMethod(HC, iSel) else {
+        fputs("[sim-hid] initWithDevice:error: not found\n", stderr); return nil }
+    guard let raw = (HC as AnyObject).perform(NSSelectorFromString("alloc"))?.takeUnretainedValue() as? NSObject else { return nil }
+    typealias F = @convention(c) (NSObject, Selector, NSObject, AutoreleasingUnsafeMutablePointer<NSError?>?) -> NSObject?
+    var err: NSError?
+    guard let c = unsafeBitCast(method_getImplementation(iM), to: F.self)(raw, iSel, device, &err) else {
+        fputs("[sim-hid] HIDClient init failed: \(err?.localizedDescription ?? "?")\n", stderr); return nil }
+    return c
+}
+
+// MARK: - IndigoHIDMessage functions via dlsym
+typealias MouseMsgFn = @convention(c) (UnsafeMutablePointer<CGPoint>, UnsafeMutablePointer<CGPoint>, UInt32, UInt, CGSize, UInt32) -> UnsafeMutableRawPointer?
+typealias KeyMsgFn = @convention(c) (UInt32, UInt32) -> UnsafeMutableRawPointer?
+typealias ButtonMsgFn = @convention(c) (UInt32, UInt32, UInt32) -> UnsafeMutableRawPointer?
+
+let kMouseDown: UInt = 1; let kMouseUp: UInt = 2; let kMouseDragged: UInt = 6
+let kOpDown: UInt32 = 1; let kOpUp: UInt32 = 2
+let kBtnHome: UInt32 = 1; let kBtnLock: UInt32 = 2; let kBtnVolUp: UInt32 = 3; let kBtnVolDn: UInt32 = 4
+
+struct HID {
+    let mouseMsg: MouseMsgFn; let keyMsg: KeyMsgFn; let btnMsg: ButtonMsgFn
+    let sendFn: @convention(c) (NSObject, Selector, UnsafeMutableRawPointer, Bool, AnyObject?, AnyObject?) -> Void
+    let sendSel: Selector; let client: NSObject
+}
+
+func resolveHID(handle: UnsafeMutableRawPointer, client: NSObject) -> HID? {
+    guard let ms = dlsym(handle, "IndigoHIDMessageForMouseNSEvent") else { fputs("[sim-hid] No mouse fn\n", stderr); return nil }
+    guard let ks = dlsym(handle, "IndigoHIDMessageForKeyboardArbitrary") else { fputs("[sim-hid] No key fn\n", stderr); return nil }
+    guard let bs = dlsym(handle, "IndigoHIDMessageForButton") else { fputs("[sim-hid] No button fn\n", stderr); return nil }
+    let sSel = NSSelectorFromString("sendWithMessage:freeWhenDone:completionQueue:completion:")
+    guard client.responds(to: sSel), let sM = class_getInstanceMethod(type(of: client), sSel) else {
+        fputs("[sim-hid] No send method\n", stderr); return nil }
+    typealias SF = @convention(c) (NSObject, Selector, UnsafeMutableRawPointer, Bool, AnyObject?, AnyObject?) -> Void
+    return HID(mouseMsg: unsafeBitCast(ms, to: MouseMsgFn.self), keyMsg: unsafeBitCast(ks, to: KeyMsgFn.self),
+               btnMsg: unsafeBitCast(bs, to: ButtonMsgFn.self),
+               sendFn: unsafeBitCast(method_getImplementation(sM), to: SF.self), sendSel: sSel, client: client)
+}
+
+func send(_ h: HID, _ msg: UnsafeMutableRawPointer) { h.sendFn(h.client, h.sendSel, msg, false, nil, nil) }
+
+// MARK: - Command Execution
+func execTap(_ h: HID, x: Double, y: Double, dur: Double?, sz: CGSize) -> Bool {
+    var sp1 = CGPoint(x: x, y: y); var wp1 = CGPoint(x: x, y: y)
+    guard let dn = h.mouseMsg(&sp1, &wp1, 0, kMouseDown, sz, 0) else { return false }
+    send(h, dn); Thread.sleep(forTimeInterval: dur ?? 0.05)
+    var sp2 = CGPoint(x: x, y: y); var wp2 = CGPoint(x: x, y: y)
+    guard let up = h.mouseMsg(&sp2, &wp2, 0, kMouseUp, sz, 0) else { return false }
+    send(h, up); return true
+}
+
+func execSwipe(_ h: HID, x1: Double, y1: Double, x2: Double, y2: Double, dur: Double?, sz: CGSize) -> Bool {
+    let total = dur ?? 0.3; let steps = 10; let delay = total / Double(steps + 2)
+    var ss = CGPoint(x: x1, y: y1); var ws = CGPoint(x: x1, y: y1)
+    guard let dn = h.mouseMsg(&ss, &ws, 0, kMouseDown, sz, 0) else { return false }
+    send(h, dn); Thread.sleep(forTimeInterval: delay)
+    for i in 1...steps {
+        let t = Double(i) / Double(steps)
+        let mx = x1 + (x2 - x1) * t, my = y1 + (y2 - y1) * t
+        var sm = CGPoint(x: mx, y: my); var wm = CGPoint(x: mx, y: my)
+        guard let mv = h.mouseMsg(&sm, &wm, 0, kMouseDragged, sz, 0) else { return false }
+        send(h, mv); Thread.sleep(forTimeInterval: delay)
+    }
+    var se = CGPoint(x: x2, y: y2); var we = CGPoint(x: x2, y: y2)
+    guard let up = h.mouseMsg(&se, &we, 0, kMouseUp, sz, 0) else { return false }
+    send(h, up); return true
+}
+
+func execKey(_ h: HID, usage: Int, dur: Double?) -> Bool {
+    guard let dn = h.keyMsg(UInt32(usage), kOpDown) else { return false }
+    send(h, dn); Thread.sleep(forTimeInterval: dur ?? 0.05)
+    guard let up = h.keyMsg(UInt32(usage), kOpUp) else { return false }
+    send(h, up); return true
+}
+
+func execButton(_ h: HID, name: String, dur: Double?) -> Bool {
+    let code: UInt32
+    switch name { case "home": code = kBtnHome; case "lock": code = kBtnLock
+    case "sound-up": code = kBtnVolUp; case "sound-down": code = kBtnVolDn; default: return false }
+    guard let dn = h.btnMsg(code, kOpDown, 0) else { return false }
+    send(h, dn); Thread.sleep(forTimeInterval: dur ?? 0.1)
+    guard let up = h.btnMsg(code, kOpUp, 0) else { return false }
+    send(h, up); return true
+}
+
+func getScreenSize(_ d: NSObject) -> CGSize {
+    if let dt = d.perform(NSSelectorFromString("deviceType"))?.takeUnretainedValue() as? NSObject,
+       let sz = dt.value(forKey: "mainScreenSize") as? CGSize { return sz }
+    return CGSize(width: 393, height: 852)
 }
 
 // MARK: - Entrypoint
-
 func run() -> Int32 {
-    let argv = CommandLine.arguments
-    let start = Date()
-
-    // 1) Parse arguments
+    let argv = CommandLine.arguments; let start = Date()
     let parsed: (udid: String, command: Command)
-    do {
-        parsed = try parseCommand(argv)
-    } catch let ParseError.usage(message) {
-        emitError(message, code: "USAGE")
-        return 64
-    } catch {
-        emitError("unexpected parse error: \(error)", code: "USAGE")
-        return 64
-    }
+    do { parsed = try parseCommand(argv) }
+    catch let ParseError.usage(m) { emitError(m, code: "USAGE"); return 64 }
+    catch { emitError("parse error: \(error)", code: "USAGE"); return 64 }
 
-    // 2) Load private frameworks — proves the symbol path resolves on this Mac.
-    guard let _ = loadSimulatorKit() else {
-        emitError(
-            "SimulatorKit.framework could not be loaded. Expected at " +
-            "/Library/Developer/PrivateFrameworks/SimulatorKit.framework. " +
-            "Is Xcode installed?",
-            code: "SIMULATORKIT_MISSING"
-        )
-        return 78
-    }
+    guard let skH = loadSimulatorKit() else {
+        emitError("SimulatorKit.framework not found. Is Xcode installed?", code: "SIMULATORKIT_MISSING"); return 78 }
     guard let _ = loadCoreSimulator() else {
-        emitError(
-            "CoreSimulator.framework could not be loaded. Expected at " +
-            "/Library/Developer/PrivateFrameworks/CoreSimulator.framework.",
-            code: "CORESIMULATOR_MISSING"
-        )
-        return 78
+        emitError("CoreSimulator.framework not found.", code: "CORESIMULATOR_MISSING"); return 78 }
+    guard let device = resolveDevice(udid: parsed.udid) else {
+        emitError("SimDevice not found: '\(parsed.udid)'.", code: "DEVICE_NOT_FOUND"); return 69 }
+    guard isDeviceBooted(device) else {
+        emitError("SimDevice '\(parsed.udid)' is not booted.", code: "DEVICE_NOT_BOOTED"); return 69 }
+    guard let client = createHIDClient(device: device) else {
+        emitError("SimDeviceLegacyHIDClient creation failed.", code: "HID_CLIENT_FAILED"); return 78 }
+    guard let hid = resolveHID(handle: skH, client: client) else {
+        emitError("IndigoHIDMessage functions not found.", code: "HID_FUNCTIONS_MISSING"); return 78 }
+
+    let sz = getScreenSize(device)
+    let ok: Bool
+    switch parsed.command {
+    case .tap(let x, let y, let d):       ok = execTap(hid, x: x, y: y, dur: d, sz: sz)
+    case .swipe(let a, let b, let c, let d, let e): ok = execSwipe(hid, x1: a, y1: b, x2: c, y2: d, dur: e, sz: sz)
+    case .key(let u, let d):              ok = execKey(hid, usage: u, dur: d)
+    case .button(let n, let d):           ok = execButton(hid, name: n, dur: d)
     }
-
-    // 3) PoC stub: the rest of the pipeline is intentionally unimplemented.
-    //    Real HID injection lands in a follow-up PR (see file header).
-    //
-    //    We still want callers to be able to differentiate "private API
-    //    unreachable" (exit 78) from "implementation stub" (exit 99), so the
-    //    stub path surfaces a distinct code even though both are currently
-    //    terminal for end users.
-    _ = parsed
-    emitError(
-        "sim-hid-bridge is a PoC stub: HID injection is not yet implemented. " +
-        "See issue #483. Parsed command kind='\(kindString(parsed.command))' " +
-        "udid='\(parsed.udid)'. Framework dlopen succeeded.",
-        code: "NOT_IMPLEMENTED"
-    )
-    _ = start  // reserved for when we emit elapsed_ms on the success path
-    return 99
+    guard ok else { emitError("HID injection failed. Check stderr.", code: "HID_INJECTION_FAILED"); return 78 }
+    let ms = Int(Date().timeIntervalSince(start) * 1000)
+    emitJSON(SuccessJSON(ok: true, kind: kindString(parsed.command), udid: parsed.udid, elapsed_ms: ms))
+    return 0
 }
-
 exit(run())

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -36,7 +36,7 @@ function delay(ms: number): Promise<void> {
  * input — useful when diagnosing focus-theft reports or confirming that a
  * call stayed on a headless tier.
  */
-export type InputBackendKind = 'simctl' | 'webkit' | 'applescript' | 'simhid';
+export type InputBackendKind = 'flutter-vm' | 'simctl' | 'webkit' | 'applescript' | 'simhid';
 
 export interface InputBackend {
   /** Stable identifier used for observability / audit logging. */


### PR DESCRIPTION
## Summary
- Replace PoC stub (exit 99) with real HID event injection via SimulatorKit private APIs
- Uses `SimDeviceLegacyHIDClient` + `IndigoHIDMessage*` C functions resolved via dlopen/dlsym
- All 4 commands work: **tap** (290ms), **key** (213ms), **button** (254ms), **swipe** (470ms)
- Adds `build:sim-hid-bridge` compilation step to `package.json`
- Fixes `InputBackendKind` type to include `'flutter-vm'`

## Architecture
```
Node.js (TS) --spawn--> sim-hid-bridge --dlopen--> SimulatorKit.framework
                                                    CoreSimulator.framework
                        │
                        ├── SimServiceContext → SimDeviceSet → SimDevice (by UDID)
                        ├── SimDeviceLegacyHIDClient (ObjC runtime init)
                        └── IndigoHIDMessageFor* (dlsym C functions)
                            ├── IndigoHIDMessageForMouseNSEvent (touch)
                            ├── IndigoHIDMessageForKeyboardArbitrary (key)
                            └── IndigoHIDMessageForButton (home/lock/volume)
```

## Verified on
- macOS 26.4 / Xcode 26 / iPhone 16 Simulator (iOS 26.4)
- All private symbols resolve successfully
- Real HID events injected into Settings.app

## Test plan
- [x] `dist/sim-hid-bridge <udid> tap 200 400` → exit 0, JSON `{"ok":true}`
- [x] `dist/sim-hid-bridge <udid> key 44` (Space) → exit 0
- [x] `dist/sim-hid-bridge <udid> button home` → exit 0
- [x] `dist/sim-hid-bridge <udid> swipe 200 600 200 200` → exit 0
- [x] Invalid UDID → exit 69 (`DEVICE_NOT_FOUND`)
- [x] 21 unit tests pass (`tests/unit/sim-hid-input-backend.test.ts`)
- [x] `npm test` → 99 suites, 1462 tests pass
- [ ] Routing activation deferred to #490

Closes #489
Towards #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)