### PR TITLE
docs(flutter-vm-input): DDS requirement docs + integration test fix (#481)

### DIFF
--- a/docs/headless-architecture.md
+++ b/docs/headless-architecture.md
@@ -1,0 +1,36 @@
+# Headless Input Architecture
+
+## Input Backend Tiers
+
+opensafari routes native-app input through a tiered fallback strategy. Each tier is attempted in order; the first available backend wins.
+
+| Tier | Backend | Scope | Headless | Opt-in |
+|------|---------|-------|----------|--------|
+| 0 | `FlutterVMInputBackend` | Flutter apps (debug/profile via `flutter run`) | Yes | None |
+| 1 | `SimctlInputBackend` | Any app (Xcode ≤16) | Yes | None |
+| 2 | `WebKitInputBackend` | Safari web content only | Yes | None |
+| 3 | `AppleScriptInputBackend` | Any app | No (moves mouse, steals focus) | `OPENSAFARI_ALLOW_FOCUS_INPUT=1` |
+
+## Tier 0 — Flutter VM Input (Issue #481)
+
+Dispatches pointer/keyboard/text events directly into the Dart isolate via VM Service `evaluate`. No CGEvent, no Simulator.app foregrounding.
+
+### Requirements
+
+- Flutter app running in **debug or profile** mode
+- Launched via `flutter run` (the DDS/frontend compiler is required for `evaluate`)
+- Apps launched via `simctl launch` expose VM Service but NOT the compilation service
+
+### Library Scoping
+
+The Dart `evaluate` RPC compiles expressions in the scope of a target library. Since no single Flutter library imports all required symbols, each operation targets a different library:
+
+| Operation | Target Library | Key Symbols |
+|-----------|---------------|-------------|
+| tap, swipe | `rendering/mouse_tracker.dart` | `PlatformDispatcher`, `PointerDataPacket`, `PointerChange`, `PointerDeviceKind` (bare `import 'dart:ui'`) |
+| typeText | `widgets/editable_text.dart` | `FocusManager`, `EditableTextState`, `TextEditingValue`, `SelectionChangedCause` |
+| keypress, sendKey | `services/hardware_keyboard.dart` | `HardwareKeyboard`, `KeyDownEvent`, `KeyUpEvent`, `LogicalKeyboardKey` |
+
+### Coordinate System
+
+iOS AX frames use logical points. The Dart payload multiplies by `devicePixelRatio` from the implicit view to convert to the engine's physical pixel expectations.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -64,6 +64,28 @@ Sibling suites added in follow-up PRs (e.g. `issue-423-native.live.test.ts`,
 file. They share the same opt-in model and the same `--testPathIgnorePatterns`
 override.
 
+## Flutter Headless Input Tests (Issue #481)
+
+The `flutter-vm-input.live.test.ts` suite verifies Tier-0 headless input via the Dart VM Service.
+
+### Prerequisites
+
+1. Booted iPhone simulator
+2. Flutter QA fixture running via `flutter run` (**not** `simctl launch` — DDS is required):
+   ```bash
+   cd tests/integration/fixtures/flutter_sample
+   flutter run -d <DEVICE_UDID>
+   ```
+3. Environment: `OPENSAFARI_LIVE_VM=1`
+
+### Run
+
+```bash
+OPENSAFARI_LIVE_VM=1 OSF_DEVICE_ID=<UDID> \
+  npx jest tests/integration/flutter-vm-input.live.test.ts \
+  --runInBand --testPathIgnorePatterns=/node_modules/
+```
+
 ## Why these are not in CI
 
 CI does not run a desktop Simulator window, and the Tier-3 input backend

--- a/tests/integration/flutter-vm-input.live.test.ts
+++ b/tests/integration/flutter-vm-input.live.test.ts
@@ -8,9 +8,9 @@
  * execute it you need:
  *
  *   1. A booted iPhone simulator.
- *   2. The Flutter QA fixture installed and launched in debug/profile mode
- *      (VM Service URL printed to simulator logs). See
- *      `tests/integration/fixtures/flutter_sample/README.md` for setup.
+ *   2. The Flutter QA fixture launched via `flutter run` (DDS required for
+ *      expression evaluation). Plain `simctl launch` won't work because
+ *      the Dart frontend compiler service is only available through DDS.
  *   3. Export `OPENSAFARI_LIVE_VM=1` and pass the device UDID/bundle via
  *      `OSF_DEVICE_ID` / `OSF_BUNDLE_ID` (or rely on the defaults below).
  *
@@ -26,8 +26,7 @@
  * clear routing error rather than silently moving the physical mouse.
  */
 
-import { execSync } from 'child_process';
-import { getInputBackend } from '../../src/tools/native-input-backend';
+import { getInputBackend, resetInputBackend } from '../../src/tools/native-input-backend';
 import { FlutterVMInputBackend } from '../../src/tools/flutter-vm-input-backend';
 import {
   ensureSemanticsActive,
@@ -37,19 +36,8 @@ import {
 const LIVE = process.env.OPENSAFARI_LIVE_VM === '1';
 const DEVICE_ID =
   process.env.OSF_DEVICE_ID ?? '3BEF4E9A-069A-4419-AC62-AB889348EF12';
-const BUNDLE = process.env.OSF_BUNDLE_ID ?? 'com.example.osftest';
 
 jest.setTimeout(180_000);
-
-async function relaunch(): Promise<void> {
-  try {
-    execSync(`xcrun simctl terminate ${DEVICE_ID} ${BUNDLE}`, { stdio: 'pipe' });
-  } catch {
-    /* not running — nothing to do */
-  }
-  execSync(`xcrun simctl launch ${DEVICE_ID} ${BUNDLE}`, { stdio: 'pipe' });
-  await new Promise((r) => setTimeout(r, 1500));
-}
 
 async function readStatus(id = 'status_label'): Promise<string> {
   const bridge = getAccessibilityBridge();
@@ -79,7 +67,8 @@ describe('issue #481 — FlutterVMInputBackend live', () => {
   }
 
   beforeAll(async () => {
-    await relaunch();
+    resetInputBackend();
+    await new Promise((r) => setTimeout(r, 2000));
   });
 
   test('getInputBackend() selects Tier 0 (FlutterVMInputBackend)', async () => {
@@ -89,7 +78,6 @@ describe('issue #481 — FlutterVMInputBackend live', () => {
   });
 
   test('tap on Login button changes status — headless, no focus steal', async () => {
-    await relaunch();
     const before = await readStatus();
     await tapLabel('Login');
     await new Promise((r) => setTimeout(r, 500));
@@ -98,7 +86,6 @@ describe('issue #481 — FlutterVMInputBackend live', () => {
   });
 
   test('typeText into focused TextField fires onChanged', async () => {
-    await relaunch();
     await tapLabel('Email');
     await new Promise((r) => setTimeout(r, 400));
     const backend = await getInputBackend(DEVICE_ID);
@@ -109,7 +96,6 @@ describe('issue #481 — FlutterVMInputBackend live', () => {
   });
 
   test('swipe produces multiple move events in the Flutter gesture arena', async () => {
-    await relaunch();
     const backend = await getInputBackend(DEVICE_ID);
     await backend.swipe(DEVICE_ID, 200, 600, 200, 200, 0.3);
     // No assertion on scroll position — the intent is to prove the gesture


### PR DESCRIPTION
## Summary

- **Integration test fix**: Remove `relaunch()` function that called `simctl terminate` + `simctl launch`, which killed the `flutter run` DDS process. The `evaluate` RPC requires the Dart Development Service (DDS) and frontend compiler, only available via `flutter run`. Apps launched via `simctl launch` return "No compilation service available" for any `evaluate` call.
- **New `docs/headless-architecture.md`**: Documents the 4-tier input backend strategy (Tier 0: FlutterVM, Tier 1: simctl, Tier 2: WebKit, Tier 3: AppleScript) and the per-operation library scoping for Dart expression evaluation.
- **Updated `tests/integration/README.md`**: Added Flutter headless testing section with prerequisites and run instructions.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 100 suites, 1476 tests all green
- [ ] Manual: run `flutter run -d <UDID>` in fixture dir, then `OPENSAFARI_LIVE_VM=1 npx jest tests/integration/flutter-vm-input.live.test.ts --runInBand`

Depends on #514 (library scoping fix) for integration tests to fully pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)