### PR TITLE
feat(telemetry): wire FlutterVMInputBackend into timedInput telemetry (#502)

### DIFF
--- a/src/metrics/input-telemetry.ts
+++ b/src/metrics/input-telemetry.ts
@@ -1,0 +1,135 @@
+/**
+ * Input backend latency telemetry — Phase 1 of Epic #484 reliability ACs.
+ *
+ * Wraps every `InputBackend` operation so we can emit per-operation timing
+ * (`elapsed_ms`) for the downstream p50/p95/p99 rollups. The sink is
+ * intentionally minimal: a single structured `console.error` line per event
+ * tagged `[input-telemetry]`. That keeps the stream grep/jq-friendly and
+ * leaves room for Phase 2 (attaching metadata to MCP tool responses) and
+ * Phase 3 (OpenTelemetry / Prometheus exporters) without a rewrite.
+ *
+ * See issue #502 for the rollout checklist.
+ */
+
+import type { InputBackendKind } from '../tools/native-input-backend';
+
+/**
+ * Stable set of operations we time. Matches the `InputBackend` interface
+ * verbs so a consumer can partition metrics by user-visible action type.
+ */
+export type InputOperation = 'tap' | 'swipe' | 'typeText' | 'keypress' | 'sendKey';
+
+/**
+ * One telemetry event. Keys are deliberately snake_case so downstream
+ * Prometheus / OpenTelemetry wiring can map labels 1:1 without renames.
+ */
+export interface InputTelemetryEvent {
+  backendKind: InputBackendKind;
+  operation: InputOperation;
+  deviceId: string;
+  elapsed_ms: number;
+  ok: boolean;
+  /** Present only when `ok === false`. */
+  error?: string;
+}
+
+/** Alias retained for the shape referenced in the proposal in #502. */
+export type InputOperationResult = InputTelemetryEvent;
+
+/**
+ * Env var that disables the console sink. Set `OPENSAFARI_INPUT_TELEMETRY=0`
+ * (or `false`) to silence emission without touching source. Any other value
+ * — including unset — leaves telemetry on.
+ */
+export const OPENSAFARI_INPUT_TELEMETRY_ENV = 'OPENSAFARI_INPUT_TELEMETRY';
+
+function isTelemetryEnabled(): boolean {
+  const value = process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  return value !== '0' && value !== 'false';
+}
+
+type TelemetrySink = (event: InputTelemetryEvent) => void;
+
+function consoleSink(event: InputTelemetryEvent): void {
+  if (!isTelemetryEnabled()) return;
+  console.error(`[input-telemetry] ${JSON.stringify(event)}`);
+}
+
+let activeSink: TelemetrySink = consoleSink;
+
+/** Emit a telemetry event through the active sink. Never throws. */
+export function emitInputTelemetry(event: InputTelemetryEvent): void {
+  try {
+    activeSink(event);
+  } catch {
+    // The telemetry path must never mask an input-backend failure.
+  }
+}
+
+/**
+ * Override the telemetry sink. Intended for unit tests that want to assert
+ * on the emitted events without parsing stderr. Pass `null` to restore the
+ * default `console.error` sink.
+ */
+export function __setInputTelemetrySinkForTest(sink: TelemetrySink | null): void {
+  activeSink = sink ?? consoleSink;
+}
+
+/**
+ * Millisecond-precision elapsed time. Uses `process.hrtime.bigint()` when
+ * available (Node) and falls back to `Date.now()` so the helper is safe to
+ * import from environments that only provide the Web timing API.
+ */
+function nowNs(): bigint {
+  if (typeof process !== 'undefined' && typeof process.hrtime?.bigint === 'function') {
+    return process.hrtime.bigint();
+  }
+  return BigInt(Date.now()) * 1_000_000n;
+}
+
+function elapsedMs(startNs: bigint): number {
+  const deltaNs = nowNs() - startNs;
+  // Round to the nearest integer millisecond. Negative deltas are impossible
+  // with hrtime but we clamp to 0 defensively for the Date.now() fallback.
+  const ms = Number(deltaNs) / 1e6;
+  return Math.max(0, Math.round(ms));
+}
+
+/**
+ * Wrap an `InputBackend` operation so every call emits a structured timing
+ * event on completion (success and failure alike).
+ *
+ * Callers keep their signatures unchanged — `timedInput` simply threads the
+ * returned promise through. On rejection it emits an `ok: false` event with
+ * the error message attached and re-throws so routing/error handling stay
+ * authoritative.
+ */
+export async function timedInput<T>(
+  backendKind: InputBackendKind,
+  operation: InputOperation,
+  deviceId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = nowNs();
+  try {
+    const result = await fn();
+    emitInputTelemetry({
+      backendKind,
+      operation,
+      deviceId,
+      elapsed_ms: elapsedMs(start),
+      ok: true,
+    });
+    return result;
+  } catch (err) {
+    emitInputTelemetry({
+      backendKind,
+      operation,
+      deviceId,
+      elapsed_ms: elapsedMs(start),
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}

--- a/src/tools/flutter-vm-input-backend.ts
+++ b/src/tools/flutter-vm-input-backend.ts
@@ -27,6 +27,7 @@
 import type { FlutterVMClient } from '../flutter';
 import { FlutterVMError } from '../flutter';
 import type { InputBackend, InputBackendKind } from './native-input-backend';
+import { timedInput } from '../metrics/input-telemetry';
 
 /**
  * Structured error surfaced by FlutterVMInputBackend when the underlying VM
@@ -164,7 +165,15 @@ export class FlutterVMInputBackend implements InputBackend {
    * the event queue even in a quiescent state.
    */
   async tap(
-    _deviceId: string,
+    deviceId: string,
+    x: number,
+    y: number,
+    duration?: number,
+  ): Promise<void> {
+    await timedInput(this.kind, 'tap', deviceId, () => this.tapInternal(x, y, duration));
+  }
+
+  private async tapInternal(
     x: number,
     y: number,
     duration?: number,
@@ -222,7 +231,19 @@ export class FlutterVMInputBackend implements InputBackend {
    * the gesture arena classifies it as a swipe rather than a flick or tap.
    */
   async swipe(
-    _deviceId: string,
+    deviceId: string,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    duration?: number,
+  ): Promise<void> {
+    await timedInput(this.kind, 'swipe', deviceId, () =>
+      this.swipeInternal(startX, startY, endX, endY, duration),
+    );
+  }
+
+  private async swipeInternal(
     startX: number,
     startY: number,
     endX: number,
@@ -290,7 +311,11 @@ export class FlutterVMInputBackend implements InputBackend {
    * callbacks fire naturally. Falls through silently (no-op) if nothing is
    * focused — same behaviour as WebKitInputBackend.
    */
-  async typeText(_deviceId: string, text: string): Promise<void> {
+  async typeText(deviceId: string, text: string): Promise<void> {
+    await timedInput(this.kind, 'typeText', deviceId, () => this.typeTextInternal(text));
+  }
+
+  private async typeTextInternal(text: string): Promise<void> {
     const textLit = dartStringLiteral(text);
 
     // Read the live TextInputConnection client id so the platform message
@@ -353,7 +378,11 @@ export class FlutterVMInputBackend implements InputBackend {
    * Dispatch a HID key code through `HardwareKeyboard`. Only a curated set of
    * control keys is supported — matches the WebKit/AppleScript backends.
    */
-  async keypress(_deviceId: string, keyCode: string): Promise<void> {
+  async keypress(deviceId: string, keyCode: string): Promise<void> {
+    await timedInput(this.kind, 'keypress', deviceId, () => this.keypressInternal(keyCode));
+  }
+
+  private async keypressInternal(keyCode: string): Promise<void> {
     const entry = HID_TO_LOGICAL_KEY[keyCode];
     if (!entry) {
       throw new Error(
@@ -365,7 +394,11 @@ export class FlutterVMInputBackend implements InputBackend {
   }
 
   /** Dispatch a named key ("Return", "Escape", ...) through HardwareKeyboard. */
-  async sendKey(_deviceId: string, keyName: string): Promise<void> {
+  async sendKey(deviceId: string, keyName: string): Promise<void> {
+    await timedInput(this.kind, 'sendKey', deviceId, () => this.sendKeyInternal(keyName));
+  }
+
+  private async sendKeyInternal(keyName: string): Promise<void> {
     const entry = SENDKEY_TO_LOGICAL_KEY[keyName];
     if (!entry) {
       throw new Error(

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -25,6 +25,7 @@ import type { FlutterVMClient } from '../flutter';
 import { getFlutterVMClient } from '../flutter';
 import { FlutterVMInputBackend } from './flutter-vm-input-backend';
 import { tryCreateSimulatorKitHIDBackend } from './sim-hid-input-backend';
+import { timedInput } from '../metrics/input-telemetry';
 
 const execFileAsync = promisify(execFile);
 
@@ -75,14 +76,16 @@ export class SimctlInputBackend implements InputBackend {
   }
 
   async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
-    if (duration && duration > 0) {
-      await this.simctl.exec([
-        'io', deviceId, 'input', 'press',
-        String(x), String(y), String(duration),
-      ]);
-    } else {
-      await this.simctl.exec(['io', deviceId, 'input', 'tap', String(x), String(y)]);
-    }
+    await timedInput(this.kind, 'tap', deviceId, async () => {
+      if (duration && duration > 0) {
+        await this.simctl.exec([
+          'io', deviceId, 'input', 'press',
+          String(x), String(y), String(duration),
+        ]);
+      } else {
+        await this.simctl.exec(['io', deviceId, 'input', 'tap', String(x), String(y)]);
+      }
+    });
   }
 
   async swipe(
@@ -91,31 +94,39 @@ export class SimctlInputBackend implements InputBackend {
     endX: number, endY: number,
     duration?: number,
   ): Promise<void> {
-    try {
-      await this.simctl.exec([
-        'io', deviceId, 'input', 'swipe',
-        String(startX), String(startY), String(endX), String(endY),
-      ]);
-    } catch {
-      // Fallback: `drag` accepts a duration argument
-      await this.simctl.exec([
-        'io', deviceId, 'input', 'drag',
-        String(startX), String(startY), String(endX), String(endY),
-        String(duration ?? 0.5),
-      ]);
-    }
+    await timedInput(this.kind, 'swipe', deviceId, async () => {
+      try {
+        await this.simctl.exec([
+          'io', deviceId, 'input', 'swipe',
+          String(startX), String(startY), String(endX), String(endY),
+        ]);
+      } catch {
+        // Fallback: `drag` accepts a duration argument
+        await this.simctl.exec([
+          'io', deviceId, 'input', 'drag',
+          String(startX), String(startY), String(endX), String(endY),
+          String(duration ?? 0.5),
+        ]);
+      }
+    });
   }
 
   async typeText(deviceId: string, text: string): Promise<void> {
-    await this.simctl.exec(['io', deviceId, 'input', 'text', text]);
+    await timedInput(this.kind, 'typeText', deviceId, async () => {
+      await this.simctl.exec(['io', deviceId, 'input', 'text', text]);
+    });
   }
 
   async keypress(deviceId: string, keyCode: string): Promise<void> {
-    await this.simctl.exec(['io', deviceId, 'input', 'keypress', keyCode]);
+    await timedInput(this.kind, 'keypress', deviceId, async () => {
+      await this.simctl.exec(['io', deviceId, 'input', 'keypress', keyCode]);
+    });
   }
 
   async sendKey(deviceId: string, keyName: string): Promise<void> {
-    await this.simctl.exec(['io', deviceId, 'sendkey', keyName]);
+    await timedInput(this.kind, 'sendKey', deviceId, async () => {
+      await this.simctl.exec(['io', deviceId, 'sendkey', keyName]);
+    });
   }
 }
 
@@ -297,23 +308,25 @@ export class AppleScriptInputBackend implements InputBackend {
   }
 
   async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
-    await this.activateSimulator();
-    const { sx, sy } = await this.toScreen(deviceId, x, y);
+    await timedInput(this.kind, 'tap', deviceId, async () => {
+      await this.activateSimulator();
+      const { sx, sy } = await this.toScreen(deviceId, x, y);
 
-    if (duration && duration > 0) {
-      // Long press: mouse down → wait → mouse up via Swift CGEvent
-      await execFileAsync('swift', ['-e', [
-        'import Cocoa',
-        `let p = CGPoint(x: ${sx}, y: ${sy})`,
-        'CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
-        `Thread.sleep(forTimeInterval: ${duration})`,
-        'CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
-      ].join('\n')], { timeout: Math.max(15_000, duration * 1000 + 5000) });
-    } else {
-      await this.runAppleScript([
-        `tell application "System Events" to click at {${sx}, ${sy}}`,
-      ]);
-    }
+      if (duration && duration > 0) {
+        // Long press: mouse down → wait → mouse up via Swift CGEvent
+        await execFileAsync('swift', ['-e', [
+          'import Cocoa',
+          `let p = CGPoint(x: ${sx}, y: ${sy})`,
+          'CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
+          `Thread.sleep(forTimeInterval: ${duration})`,
+          'CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
+        ].join('\n')], { timeout: Math.max(15_000, duration * 1000 + 5000) });
+      } else {
+        await this.runAppleScript([
+          `tell application "System Events" to click at {${sx}, ${sy}}`,
+        ]);
+      }
+    });
   }
 
   async swipe(
@@ -322,71 +335,79 @@ export class AppleScriptInputBackend implements InputBackend {
     endX: number, endY: number,
     duration?: number,
   ): Promise<void> {
-    await this.activateSimulator();
-    // Get origin once for both start and end coordinates
-    const origin = await this.getSimulatorContentOrigin(deviceId);
-    const sx = Math.round(origin.x + startX);
-    const sy = Math.round(origin.y + startY);
-    const ex = Math.round(origin.x + endX);
-    const ey = Math.round(origin.y + endY);
-    const dur = duration ?? 0.5;
-    const steps = 20;
-    const stepDelay = dur / steps;
+    await timedInput(this.kind, 'swipe', deviceId, async () => {
+      await this.activateSimulator();
+      // Get origin once for both start and end coordinates
+      const origin = await this.getSimulatorContentOrigin(deviceId);
+      const sx = Math.round(origin.x + startX);
+      const sy = Math.round(origin.y + startY);
+      const ex = Math.round(origin.x + endX);
+      const ey = Math.round(origin.y + endY);
+      const dur = duration ?? 0.5;
+      const steps = 20;
+      const stepDelay = dur / steps;
 
-    // Mouse drag via Swift CGEvent (macOS built-in, no external deps)
-    await execFileAsync('swift', ['-e', [
-      'import Cocoa',
-      `let x1: CGFloat = ${sx}, y1: CGFloat = ${sy}`,
-      `let x2: CGFloat = ${ex}, y2: CGFloat = ${ey}`,
-      `let steps = ${steps}`,
-      `let stepDelay = ${stepDelay}`,
-      'CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: CGPoint(x: x1, y: y1), mouseButton: .left)!.post(tap: .cghidEventTap)',
-      'Thread.sleep(forTimeInterval: 0.05)',
-      'for i in 1...steps {',
-      '  let t = CGFloat(i) / CGFloat(steps)',
-      '  let p = CGPoint(x: x1 + (x2 - x1) * t, y: y1 + (y2 - y1) * t)',
-      '  CGEvent(mouseEventSource: nil, mouseType: .leftMouseDragged, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
-      '  Thread.sleep(forTimeInterval: stepDelay)',
-      '}',
-      'CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: CGPoint(x: x2, y: y2), mouseButton: .left)!.post(tap: .cghidEventTap)',
-    ].join('\n')], { timeout: 15_000 });
+      // Mouse drag via Swift CGEvent (macOS built-in, no external deps)
+      await execFileAsync('swift', ['-e', [
+        'import Cocoa',
+        `let x1: CGFloat = ${sx}, y1: CGFloat = ${sy}`,
+        `let x2: CGFloat = ${ex}, y2: CGFloat = ${ey}`,
+        `let steps = ${steps}`,
+        `let stepDelay = ${stepDelay}`,
+        'CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: CGPoint(x: x1, y: y1), mouseButton: .left)!.post(tap: .cghidEventTap)',
+        'Thread.sleep(forTimeInterval: 0.05)',
+        'for i in 1...steps {',
+        '  let t = CGFloat(i) / CGFloat(steps)',
+        '  let p = CGPoint(x: x1 + (x2 - x1) * t, y: y1 + (y2 - y1) * t)',
+        '  CGEvent(mouseEventSource: nil, mouseType: .leftMouseDragged, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
+        '  Thread.sleep(forTimeInterval: stepDelay)',
+        '}',
+        'CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: CGPoint(x: x2, y: y2), mouseButton: .left)!.post(tap: .cghidEventTap)',
+      ].join('\n')], { timeout: 15_000 });
+    });
   }
 
-  async typeText(_deviceId: string, text: string): Promise<void> {
-    await this.activateSimulator();
-    // Escape special AppleScript characters
-    const escaped = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    await this.runAppleScript([
-      `tell application "System Events" to keystroke "${escaped}"`,
-    ]);
+  async typeText(deviceId: string, text: string): Promise<void> {
+    await timedInput(this.kind, 'typeText', deviceId, async () => {
+      await this.activateSimulator();
+      // Escape special AppleScript characters
+      const escaped = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      await this.runAppleScript([
+        `tell application "System Events" to keystroke "${escaped}"`,
+      ]);
+    });
   }
 
-  async keypress(_deviceId: string, keyCode: string): Promise<void> {
-    await this.activateSimulator();
-    const asKeyCode = HID_TO_APPLESCRIPT[keyCode];
-    if (asKeyCode === undefined) {
-      throw new Error(
-        `Unknown HID key code "${keyCode}" for AppleScript backend. ` +
-        `Supported: ${Object.keys(HID_TO_APPLESCRIPT).join(', ')}`,
-      );
-    }
-    await this.runAppleScript([
-      `tell application "System Events" to key code ${asKeyCode}`,
-    ]);
+  async keypress(deviceId: string, keyCode: string): Promise<void> {
+    await timedInput(this.kind, 'keypress', deviceId, async () => {
+      await this.activateSimulator();
+      const asKeyCode = HID_TO_APPLESCRIPT[keyCode];
+      if (asKeyCode === undefined) {
+        throw new Error(
+          `Unknown HID key code "${keyCode}" for AppleScript backend. ` +
+          `Supported: ${Object.keys(HID_TO_APPLESCRIPT).join(', ')}`,
+        );
+      }
+      await this.runAppleScript([
+        `tell application "System Events" to key code ${asKeyCode}`,
+      ]);
+    });
   }
 
-  async sendKey(_deviceId: string, keyName: string): Promise<void> {
-    await this.activateSimulator();
-    const asKeyCode = SENDKEY_TO_APPLESCRIPT[keyName];
-    if (asKeyCode === undefined) {
-      throw new Error(
-        `Unknown key name "${keyName}" for AppleScript backend. ` +
-        `Supported: ${Object.keys(SENDKEY_TO_APPLESCRIPT).join(', ')}`,
-      );
-    }
-    await this.runAppleScript([
-      `tell application "System Events" to key code ${asKeyCode}`,
-    ]);
+  async sendKey(deviceId: string, keyName: string): Promise<void> {
+    await timedInput(this.kind, 'sendKey', deviceId, async () => {
+      await this.activateSimulator();
+      const asKeyCode = SENDKEY_TO_APPLESCRIPT[keyName];
+      if (asKeyCode === undefined) {
+        throw new Error(
+          `Unknown key name "${keyName}" for AppleScript backend. ` +
+          `Supported: ${Object.keys(SENDKEY_TO_APPLESCRIPT).join(', ')}`,
+        );
+      }
+      await this.runAppleScript([
+        `tell application "System Events" to key code ${asKeyCode}`,
+      ]);
+    });
   }
 }
 
@@ -434,103 +455,113 @@ export class WebKitInputBackend implements InputBackend {
   readonly kind = 'webkit' as const;
   constructor(private client: BrowserBackend) {}
 
-  async tap(_deviceId: string, x: number, y: number, duration?: number): Promise<void> {
-    if (duration && duration > 0) {
-      // Long press via touch events with delay
-      await this.client.evaluate(`
-        (async function(x, y, duration) {
-          var el = document.elementFromPoint(x, y);
-          if (!el) return;
-          var touch = document.createTouch(window, el, 1, x, y, x, y);
-          var touchList = document.createTouchList(touch);
-          el.dispatchEvent(new TouchEvent('touchstart', { touches: touchList, changedTouches: touchList, bubbles: true }));
-          await new Promise(function(r) { setTimeout(r, duration); });
-          var emptyList = document.createTouchList();
-          el.dispatchEvent(new TouchEvent('touchend', { touches: emptyList, changedTouches: touchList, bubbles: true }));
-        })(${x}, ${y}, ${duration * 1000})
-      `);
-    } else {
-      // Normal tap — delegate to BrowserBackend.click() which dispatches
-      // touchstart → touchend → click with emulateUserGesture
-      await this.client.click({ x, y });
-    }
+  async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
+    await timedInput(this.kind, 'tap', deviceId, async () => {
+      if (duration && duration > 0) {
+        // Long press via touch events with delay
+        await this.client.evaluate(`
+          (async function(x, y, duration) {
+            var el = document.elementFromPoint(x, y);
+            if (!el) return;
+            var touch = document.createTouch(window, el, 1, x, y, x, y);
+            var touchList = document.createTouchList(touch);
+            el.dispatchEvent(new TouchEvent('touchstart', { touches: touchList, changedTouches: touchList, bubbles: true }));
+            await new Promise(function(r) { setTimeout(r, duration); });
+            var emptyList = document.createTouchList();
+            el.dispatchEvent(new TouchEvent('touchend', { touches: emptyList, changedTouches: touchList, bubbles: true }));
+          })(${x}, ${y}, ${duration * 1000})
+        `);
+      } else {
+        // Normal tap — delegate to BrowserBackend.click() which dispatches
+        // touchstart → touchend → click with emulateUserGesture
+        await this.client.click({ x, y });
+      }
+    });
   }
 
   async swipe(
-    _deviceId: string,
+    deviceId: string,
     startX: number, startY: number,
     endX: number, endY: number,
     duration?: number,
   ): Promise<void> {
-    const scrollX = startX - endX;
-    const scrollY = startY - endY;
-    const steps = 20;
-    const stepDelay = ((duration ?? 0.5) * 1000) / steps;
+    await timedInput(this.kind, 'swipe', deviceId, async () => {
+      const scrollX = startX - endX;
+      const scrollY = startY - endY;
+      const steps = 20;
+      const stepDelay = ((duration ?? 0.5) * 1000) / steps;
 
-    // Two-pronged: window.scrollBy for native scroll + touch events for JS handlers
-    await this.client.evaluate(`
-      (async function(sx, sy, ex, ey, scrollX, scrollY, steps, stepDelay) {
-        window.scrollBy(scrollX, scrollY);
+      // Two-pronged: window.scrollBy for native scroll + touch events for JS handlers
+      await this.client.evaluate(`
+        (async function(sx, sy, ex, ey, scrollX, scrollY, steps, stepDelay) {
+          window.scrollBy(scrollX, scrollY);
 
-        var el = document.elementFromPoint(sx, sy);
-        if (!el) el = document.body;
-        var makeTouch = function(x, y) { return document.createTouch(window, el, 1, x, y, x, y); };
-        var startTouch = makeTouch(sx, sy);
-        var startList = document.createTouchList(startTouch);
-        el.dispatchEvent(new TouchEvent('touchstart', { touches: startList, changedTouches: startList, bubbles: true }));
-        for (var i = 1; i <= steps; i++) {
-          var x = sx + (ex - sx) * (i / steps);
-          var y = sy + (ey - sy) * (i / steps);
-          var moveTouch = makeTouch(x, y);
-          var moveList = document.createTouchList(moveTouch);
-          el.dispatchEvent(new TouchEvent('touchmove', { touches: moveList, changedTouches: moveList, bubbles: true }));
-          await new Promise(function(r) { setTimeout(r, stepDelay); });
-        }
-        var endTouch = makeTouch(ex, ey);
-        var endList = document.createTouchList(endTouch);
-        var emptyList = document.createTouchList();
-        el.dispatchEvent(new TouchEvent('touchend', { touches: emptyList, changedTouches: endList, bubbles: true }));
-      })(${startX}, ${startY}, ${endX}, ${endY}, ${scrollX}, ${scrollY}, ${steps}, ${stepDelay})
-    `);
+          var el = document.elementFromPoint(sx, sy);
+          if (!el) el = document.body;
+          var makeTouch = function(x, y) { return document.createTouch(window, el, 1, x, y, x, y); };
+          var startTouch = makeTouch(sx, sy);
+          var startList = document.createTouchList(startTouch);
+          el.dispatchEvent(new TouchEvent('touchstart', { touches: startList, changedTouches: startList, bubbles: true }));
+          for (var i = 1; i <= steps; i++) {
+            var x = sx + (ex - sx) * (i / steps);
+            var y = sy + (ey - sy) * (i / steps);
+            var moveTouch = makeTouch(x, y);
+            var moveList = document.createTouchList(moveTouch);
+            el.dispatchEvent(new TouchEvent('touchmove', { touches: moveList, changedTouches: moveList, bubbles: true }));
+            await new Promise(function(r) { setTimeout(r, stepDelay); });
+          }
+          var endTouch = makeTouch(ex, ey);
+          var endList = document.createTouchList(endTouch);
+          var emptyList = document.createTouchList();
+          el.dispatchEvent(new TouchEvent('touchend', { touches: emptyList, changedTouches: endList, bubbles: true }));
+        })(${startX}, ${startY}, ${endX}, ${endY}, ${scrollX}, ${scrollY}, ${steps}, ${stepDelay})
+      `);
+    });
   }
 
-  async typeText(_deviceId: string, text: string): Promise<void> {
-    const escaped = JSON.stringify(text);
-    await this.client.evaluate(`
-      (function() {
-        var el = document.activeElement;
-        if (!el || el === document.body) return;
-        var p = Object.getPrototypeOf(el);
-        while (p && !Object.getOwnPropertyDescriptor(p, 'value')) {
-          p = Object.getPrototypeOf(p);
-        }
-        var desc = p ? Object.getOwnPropertyDescriptor(p, 'value') : null;
-        var cur = (desc && desc.get) ? desc.get.call(el) : (el.value || '');
-        if (desc && desc.set) {
-          desc.set.call(el, cur + ${escaped});
-        } else if ('value' in el) {
-          el.value = cur + ${escaped};
-        }
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-        el.dispatchEvent(new Event('change', { bubbles: true }));
-      })()
-    `);
+  async typeText(deviceId: string, text: string): Promise<void> {
+    await timedInput(this.kind, 'typeText', deviceId, async () => {
+      const escaped = JSON.stringify(text);
+      await this.client.evaluate(`
+        (function() {
+          var el = document.activeElement;
+          if (!el || el === document.body) return;
+          var p = Object.getPrototypeOf(el);
+          while (p && !Object.getOwnPropertyDescriptor(p, 'value')) {
+            p = Object.getPrototypeOf(p);
+          }
+          var desc = p ? Object.getOwnPropertyDescriptor(p, 'value') : null;
+          var cur = (desc && desc.get) ? desc.get.call(el) : (el.value || '');
+          if (desc && desc.set) {
+            desc.set.call(el, cur + ${escaped});
+          } else if ('value' in el) {
+            el.value = cur + ${escaped};
+          }
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        })()
+      `);
+    });
   }
 
-  async keypress(_deviceId: string, keyCode: string): Promise<void> {
-    const keyName = HID_TO_WEBKIT_KEY[keyCode];
-    if (!keyName) {
-      throw new Error(
-        `Unknown HID key code "${keyCode}" for WebKit backend. ` +
-        `Supported: ${Object.keys(HID_TO_WEBKIT_KEY).join(', ')}`,
-      );
-    }
-    await this.client.press(keyName);
+  async keypress(deviceId: string, keyCode: string): Promise<void> {
+    await timedInput(this.kind, 'keypress', deviceId, async () => {
+      const keyName = HID_TO_WEBKIT_KEY[keyCode];
+      if (!keyName) {
+        throw new Error(
+          `Unknown HID key code "${keyCode}" for WebKit backend. ` +
+          `Supported: ${Object.keys(HID_TO_WEBKIT_KEY).join(', ')}`,
+        );
+      }
+      await this.client.press(keyName);
+    });
   }
 
-  async sendKey(_deviceId: string, keyName: string): Promise<void> {
-    const mapped = SENDKEY_TO_WEBKIT_KEY[keyName] ?? keyName;
-    await this.client.press(mapped);
+  async sendKey(deviceId: string, keyName: string): Promise<void> {
+    await timedInput(this.kind, 'sendKey', deviceId, async () => {
+      const mapped = SENDKEY_TO_WEBKIT_KEY[keyName] ?? keyName;
+      await this.client.press(mapped);
+    });
   }
 }
 

--- a/src/tools/sim-hid-input-backend.ts
+++ b/src/tools/sim-hid-input-backend.ts
@@ -28,6 +28,7 @@ import { promisify } from 'util';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import type { InputBackend } from './native-input-backend';
+import { timedInput } from '../metrics/input-telemetry';
 
 const execFileAsync = promisify(execFile);
 
@@ -111,11 +112,13 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
   constructor(private readonly bridgePath: string) {}
 
   async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
-    const args = [deviceId, 'tap', String(x), String(y)];
-    if (duration !== undefined && duration > 0) {
-      args.push(String(duration));
-    }
-    await this.run(args);
+    await timedInput(this.kind, 'tap', deviceId, async () => {
+      const args = [deviceId, 'tap', String(x), String(y)];
+      if (duration !== undefined && duration > 0) {
+        args.push(String(duration));
+      }
+      await this.run(args);
+    });
   }
 
   async swipe(
@@ -126,62 +129,70 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
     endY: number,
     duration?: number,
   ): Promise<void> {
-    const args = [
-      deviceId, 'swipe',
-      String(startX), String(startY),
-      String(endX), String(endY),
-    ];
-    if (duration !== undefined && duration > 0) {
-      args.push(String(duration));
-    }
-    await this.run(args);
+    await timedInput(this.kind, 'swipe', deviceId, async () => {
+      const args = [
+        deviceId, 'swipe',
+        String(startX), String(startY),
+        String(endX), String(endY),
+      ];
+      if (duration !== undefined && duration > 0) {
+        args.push(String(duration));
+      }
+      await this.run(args);
+    });
   }
 
   async typeText(deviceId: string, text: string): Promise<void> {
-    // PoC: ASCII-only. Each character is converted to a HID usage and sent
-    // as an independent `key` event. Non-ASCII characters are rejected until
-    // the Swift bridge gains a text-composition path.
-    for (const ch of text) {
-      const usage = asciiToHidUsage(ch);
-      if (usage === null) {
+    await timedInput(this.kind, 'typeText', deviceId, async () => {
+      // PoC: ASCII-only. Each character is converted to a HID usage and sent
+      // as an independent `key` event. Non-ASCII characters are rejected until
+      // the Swift bridge gains a text-composition path.
+      for (const ch of text) {
+        const usage = asciiToHidUsage(ch);
+        if (usage === null) {
+          throw new InputBackendError(
+            `SimulatorKitHIDInputBackend.typeText: non-ASCII character '${ch}' ` +
+              'is not supported in the PoC. Track follow-up in issue #483.',
+            'BAD_ARGS',
+          );
+        }
+        await this.run([deviceId, 'key', String(usage)]);
+      }
+    });
+  }
+
+  async keypress(deviceId: string, keyCode: string): Promise<void> {
+    await timedInput(this.kind, 'keypress', deviceId, async () => {
+      // Accept either a decimal HID usage code or a key name known to our map.
+      const parsed = Number.parseInt(keyCode, 10);
+      const usage = Number.isNaN(parsed) ? KEY_NAME_TO_HID_USAGE[keyCode] : parsed;
+      if (usage === undefined) {
         throw new InputBackendError(
-          `SimulatorKitHIDInputBackend.typeText: non-ASCII character '${ch}' ` +
-            'is not supported in the PoC. Track follow-up in issue #483.',
+          `SimulatorKitHIDInputBackend.keypress: unknown HID key code "${keyCode}"`,
           'BAD_ARGS',
         );
       }
       await this.run([deviceId, 'key', String(usage)]);
-    }
-  }
-
-  async keypress(deviceId: string, keyCode: string): Promise<void> {
-    // Accept either a decimal HID usage code or a key name known to our map.
-    const parsed = Number.parseInt(keyCode, 10);
-    const usage = Number.isNaN(parsed) ? KEY_NAME_TO_HID_USAGE[keyCode] : parsed;
-    if (usage === undefined) {
-      throw new InputBackendError(
-        `SimulatorKitHIDInputBackend.keypress: unknown HID key code "${keyCode}"`,
-        'BAD_ARGS',
-      );
-    }
-    await this.run([deviceId, 'key', String(usage)]);
+    });
   }
 
   async sendKey(deviceId: string, keyName: string): Promise<void> {
-    await this.pressKey(deviceId, keyName);
+    await timedInput(this.kind, 'sendKey', deviceId, async () => {
+      const usage = KEY_NAME_TO_HID_USAGE[keyName];
+      if (usage === undefined) {
+        throw new InputBackendError(
+          `SimulatorKitHIDInputBackend.pressKey: unknown key "${keyName}". ` +
+            `Supported: ${Object.keys(KEY_NAME_TO_HID_USAGE).join(', ')}`,
+          'BAD_ARGS',
+        );
+      }
+      await this.run([deviceId, 'key', String(usage)]);
+    });
   }
 
   /** Convenience alias: resolve a symbolic key name to its HID usage. */
   async pressKey(deviceId: string, key: string): Promise<void> {
-    const usage = KEY_NAME_TO_HID_USAGE[key];
-    if (usage === undefined) {
-      throw new InputBackendError(
-        `SimulatorKitHIDInputBackend.pressKey: unknown key "${key}". ` +
-          `Supported: ${Object.keys(KEY_NAME_TO_HID_USAGE).join(', ')}`,
-        'BAD_ARGS',
-      );
-    }
-    await this.run([deviceId, 'key', String(usage)]);
+    await this.sendKey(deviceId, key);
   }
 
   /**

--- a/tests/unit/flutter-vm-input-backend.test.ts
+++ b/tests/unit/flutter-vm-input-backend.test.ts
@@ -12,6 +12,10 @@ import {
   FlutterVMInputBackendError,
 } from '../../src/tools/flutter-vm-input-backend';
 import { FlutterVMError } from '../../src/flutter';
+import {
+  __setInputTelemetrySinkForTest,
+  type InputTelemetryEvent,
+} from '../../src/metrics/input-telemetry';
 
 const DEVICE = 'TEST-DEVICE-UDID';
 
@@ -272,6 +276,66 @@ describe('FlutterVMInputBackend', () => {
       } catch (err) {
         expect((err as FlutterVMInputBackendError).op).toBe('typeText');
       }
+    });
+  });
+
+  // ── telemetry (#502) ─────────────────────────────────────────────────────
+
+  describe('telemetry', () => {
+    let events: InputTelemetryEvent[];
+
+    beforeEach(() => {
+      events = [];
+      __setInputTelemetrySinkForTest((e) => events.push(e));
+    });
+
+    afterEach(() => {
+      __setInputTelemetrySinkForTest(null);
+    });
+
+    test('tap emits one flutter-vm telemetry event with the device id', async () => {
+      const client = makeMockClient();
+      const backend = new FlutterVMInputBackend(client as any);
+
+      await backend.tap(DEVICE, 10, 20);
+
+      expect(events).toHaveLength(1);
+      const ev = events[0];
+      expect(ev.backendKind).toBe('flutter-vm');
+      expect(ev.operation).toBe('tap');
+      expect(ev.deviceId).toBe(DEVICE);
+      expect(ev.ok).toBe(true);
+      expect(ev.elapsed_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    test('swipe / typeText / keypress / sendKey all emit with the right operation label', async () => {
+      const client = makeMockClient();
+      const backend = new FlutterVMInputBackend(client as any);
+
+      await backend.swipe(DEVICE, 10, 10, 20, 20);
+      await backend.typeText(DEVICE, 'hello');
+      await backend.keypress(DEVICE, '40'); // Enter
+      await backend.sendKey(DEVICE, 'Tab');
+
+      expect(events.map((e) => e.operation)).toEqual([
+        'swipe', 'typeText', 'keypress', 'sendKey',
+      ]);
+      expect(events.every((e) => e.backendKind === 'flutter-vm')).toBe(true);
+      expect(events.every((e) => e.deviceId === DEVICE && e.ok === true)).toBe(true);
+    });
+
+    test('failure still emits an event with ok=false before re-throwing', async () => {
+      const client = makeMockClient();
+      client.evaluate.mockRejectedValueOnce(new Error('dart boom'));
+      const backend = new FlutterVMInputBackend(client as any);
+
+      await expect(backend.tap(DEVICE, 1, 2)).rejects.toBeInstanceOf(
+        FlutterVMInputBackendError,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0].ok).toBe(false);
+      expect(events[0].operation).toBe('tap');
+      expect(events[0].error).toMatch(/dart boom/);
     });
   });
 });

--- a/tests/unit/input-telemetry.test.ts
+++ b/tests/unit/input-telemetry.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the input-backend latency telemetry wrapper (issue #502).
+ *
+ * Covers the three checklist items:
+ *   - `timedInput` emits `elapsed_ms > 0` on success
+ *   - `timedInput` still emits an event on failure and re-throws
+ *   - the emitted event carries `backendKind`, `operation`, `elapsed_ms`, `deviceId`
+ *   - structured JSON sink lands on `console.error` in a grep/jq-friendly shape
+ */
+
+import {
+  timedInput,
+  emitInputTelemetry,
+  __setInputTelemetrySinkForTest,
+  OPENSAFARI_INPUT_TELEMETRY_ENV,
+  type InputTelemetryEvent,
+} from '../../src/metrics/input-telemetry';
+
+describe('input-telemetry / timedInput', () => {
+  let events: InputTelemetryEvent[] = [];
+
+  beforeEach(() => {
+    events = [];
+    __setInputTelemetrySinkForTest((e) => events.push(e));
+  });
+
+  afterEach(() => {
+    __setInputTelemetrySinkForTest(null);
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  });
+
+  test('emits a success event with elapsed_ms >= 0 and required fields', async () => {
+    const deviceId = 'UDID-A';
+    const result = await timedInput('webkit', 'tap', deviceId, async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.backendKind).toBe('webkit');
+    expect(ev.operation).toBe('tap');
+    expect(ev.deviceId).toBe(deviceId);
+    expect(ev.ok).toBe(true);
+    expect(typeof ev.elapsed_ms).toBe('number');
+    expect(ev.elapsed_ms).toBeGreaterThanOrEqual(0);
+    // Sanity: sleep was 5ms so the timing should not be absurdly high.
+    expect(ev.elapsed_ms).toBeLessThan(5000);
+    expect(ev.error).toBeUndefined();
+  });
+
+  test('emits a failure event and re-throws the original error', async () => {
+    const boom = new Error('backend exploded');
+    const deviceId = 'UDID-B';
+
+    await expect(
+      timedInput('simctl', 'swipe', deviceId, async () => {
+        await new Promise((r) => setTimeout(r, 2));
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.backendKind).toBe('simctl');
+    expect(ev.operation).toBe('swipe');
+    expect(ev.deviceId).toBe(deviceId);
+    expect(ev.ok).toBe(false);
+    expect(ev.error).toBe('backend exploded');
+    expect(typeof ev.elapsed_ms).toBe('number');
+    expect(ev.elapsed_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  test('stringifies non-Error thrown values into the error field', async () => {
+    await expect(
+      timedInput('applescript', 'keypress', 'UDID-C', async () => {
+        throw 'plain-string-rejection';
+      }),
+    ).rejects.toBe('plain-string-rejection');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].ok).toBe(false);
+    expect(events[0].error).toBe('plain-string-rejection');
+  });
+
+  test('covers every operation label with its backendKind', async () => {
+    const ops: Array<InputTelemetryEvent['operation']> = [
+      'tap', 'swipe', 'typeText', 'keypress', 'sendKey',
+    ];
+    for (const op of ops) {
+      await timedInput('simhid', op, 'UDID-D', async () => undefined);
+    }
+    expect(events.map((e) => e.operation)).toEqual(ops);
+    expect(events.every((e) => e.backendKind === 'simhid')).toBe(true);
+  });
+
+  test('telemetry emission never masks the original error when the sink throws', async () => {
+    __setInputTelemetrySinkForTest(() => {
+      throw new Error('sink is broken');
+    });
+    const boom = new Error('backend exploded');
+    await expect(
+      timedInput('webkit', 'tap', 'UDID-E', async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+  });
+});
+
+describe('input-telemetry / console sink', () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    __setInputTelemetrySinkForTest(null); // restore default console sink
+    spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  });
+
+  test('emits one [input-telemetry] line per event in structured JSON shape', () => {
+    emitInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID-F',
+      elapsed_ms: 42,
+      ok: true,
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const line = spy.mock.calls[0][0] as string;
+    expect(line.startsWith('[input-telemetry] ')).toBe(true);
+    const payload = JSON.parse(line.slice('[input-telemetry] '.length));
+    expect(payload).toEqual({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID-F',
+      elapsed_ms: 42,
+      ok: true,
+    });
+  });
+
+  test.each(['0', 'false'])(
+    'is silenced when OPENSAFARI_INPUT_TELEMETRY=%s',
+    (value) => {
+      process.env[OPENSAFARI_INPUT_TELEMETRY_ENV] = value;
+      emitInputTelemetry({
+        backendKind: 'simctl',
+        operation: 'tap',
+        deviceId: 'UDID-G',
+        elapsed_ms: 1,
+        ok: true,
+      });
+      expect(spy).not.toHaveBeenCalled();
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Stacks on top of #521 (telemetry foundation). Applies the shared `timedInput` wrapper to **Tier-0 FlutterVMInputBackend** so every tier of `getInputBackend()` — native AND Flutter — now emits `[input-telemetry]` events with `elapsed_ms`, `backendKind: 'flutter-vm'`, `operation`, `deviceId`, and `ok`.

Each public verb (`tap`/`swipe`/`typeText`/`keypress`/`sendKey`) delegates to a new private `<op>Internal` helper so the wrapper stays a single-purpose timing/emission boundary and the Dart-expression assembly logic is unchanged.

## Issue #502 checkboxes covered (in addition to #521)

### Unit Tests
- [x] telemetry event fields covered for `flutter-vm` backend across all five operations
- [x] failure-path `ok: false` re-throw contract verified via existing Dart-error mock

New describe block in `tests/unit/flutter-vm-input-backend.test.ts`:
- `tap emits one flutter-vm telemetry event with the device id`
- `swipe / typeText / keypress / sendKey all emit with the right operation label`
- `failure still emits an event with ok=false before re-throwing`

## Test plan

- [x] `npm test` → 1521 / 1521 pass (up from 1518 in #521)
- [x] `npm run build` → clean
- [x] No change to Dart-expression payloads — existing `tap()` / `swipe()` / `typeText()` / `keypress()` / `sendKey()` assertions remain untouched

## Dependencies

- Depends on #521 (`feat/502-telemetry-foundation` → must merge first)

Towards: #502, #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)