### PR TITLE
feat(sim-hid): warn once on private API use + reference docs (#493)

### DIFF
--- a/src/tools/sim-hid-input-backend.ts
+++ b/src/tools/sim-hid-input-backend.ts
@@ -31,6 +31,20 @@ import type { InputBackend } from './native-input-backend';
 
 const execFileAsync = promisify(execFile);
 
+/** Reference appended to error messages for private-framework failures. */
+const PRIVATE_API_DOC_REF = 'See docs/private-apis.md';
+
+/** Latch so the private-API warning is emitted only once per process. */
+let warnedAboutPrivateAPI = false;
+
+/**
+ * Reset the private-API warning latch. Exported for unit tests only — do not
+ * call from production code.
+ */
+export function resetSimHidPrivateAPIWarning(): void {
+  warnedAboutPrivateAPI = false;
+}
+
 /** Spawn timeout for the Swift helper. Matches idb's default. */
 const SPAWN_TIMEOUT_MS = 10_000;
 
@@ -190,6 +204,15 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
    * structured `InputBackendError`.
    */
   private async run(args: string[]): Promise<unknown> {
+    if (!warnedAboutPrivateAPI) {
+      warnedAboutPrivateAPI = true;
+      console.error(
+        '[opensafari] SimulatorKitHIDInputBackend uses private Apple frameworks ' +
+          '(SimulatorKit.framework, CoreSimulator.framework) via dlopen. ' +
+          'These APIs are undocumented and Xcode updates may break them. ' +
+          PRIVATE_API_DOC_REF,
+      );
+    }
     const { cmd, cmdArgs } = this.resolveSpawn(args);
     let stdout = '';
     let stderr = '';
@@ -221,8 +244,9 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
       const exit = typeof e.code === 'number' ? e.code : undefined;
       const classified = codeForExit(exit);
       const hint = stderr.trim() || stdout.trim() || e.message;
+      const docSuffix = classified === 'SIMULATORKIT_UNAVAILABLE' ? ` (${PRIVATE_API_DOC_REF})` : '';
       throw new InputBackendError(
-        `sim-hid-bridge exited ${exit ?? '?'}: ${hint}`,
+        `sim-hid-bridge exited ${exit ?? '?'}: ${hint}${docSuffix}`,
         classified,
         stderr,
       );
@@ -236,9 +260,17 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
     try {
       const parsed = JSON.parse(stdout) as { ok?: boolean; error?: string; code?: string };
       if (parsed.ok === false) {
+        const okFalseCode = (parsed.code as InputBackendErrorCode | undefined) ?? 'UNKNOWN';
+        const frameworkFailureCodes = new Set<string>([
+          'SIMULATORKIT_MISSING',
+          'CORESIMULATOR_MISSING',
+          'HID_CLIENT_FAILED',
+          'HID_FUNCTIONS_MISSING',
+        ]);
+        const okFalseDocSuffix = frameworkFailureCodes.has(parsed.code ?? '') ? ` (${PRIVATE_API_DOC_REF})` : '';
         throw new InputBackendError(
-          parsed.error ?? 'sim-hid-bridge reported ok=false',
-          (parsed.code as InputBackendErrorCode | undefined) ?? 'UNKNOWN',
+          `${parsed.error ?? 'sim-hid-bridge reported ok=false'}${okFalseDocSuffix}`,
+          okFalseCode,
           stderr,
         );
       }

--- a/tests/unit/sim-hid-input-backend.test.ts
+++ b/tests/unit/sim-hid-input-backend.test.ts
@@ -13,6 +13,7 @@ import {
   SimulatorKitHIDInputBackend,
   InputBackendError,
   tryCreateSimulatorKitHIDBackend,
+  resetSimHidPrivateAPIWarning,
 } from '../../src/tools/sim-hid-input-backend';
 
 /* eslint-disable no-var */
@@ -68,6 +69,7 @@ describe('SimulatorKitHIDInputBackend', () => {
 
   beforeEach(() => {
     execFileMock.mockReset();
+    resetSimHidPrivateAPIWarning();
     backend = new SimulatorKitHIDInputBackend(BRIDGE);
   });
 
@@ -254,6 +256,81 @@ describe('SimulatorKitHIDInputBackend', () => {
     await expect(backend.tap(DEVICE, 1, 2)).rejects.toMatchObject({
       code: 'NOT_IMPLEMENTED',
     });
+  });
+
+  // ── Private-API warning latch ────────────────────────────────────────────
+
+  test('first run() emits exactly one warning mentioning SimulatorKit and docs/private-apis.md', async () => {
+    execFileMock.mockResolvedValue({
+      stdout: '{"ok":true,"kind":"tap","udid":"x","elapsed_ms":1}',
+      stderr: '',
+    });
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await backend.tap(DEVICE, 1, 2);
+      const calls = spy.mock.calls.filter((c) => {
+        const msg = String(c[0]);
+        return msg.includes('SimulatorKit') && msg.includes('docs/private-apis.md');
+      });
+      expect(calls).toHaveLength(1);
+
+      // Second run must NOT emit an additional warning.
+      spy.mockClear();
+      await backend.tap(DEVICE, 3, 4);
+      const calls2 = spy.mock.calls.filter((c) => {
+        const msg = String(c[0]);
+        return msg.includes('SimulatorKit') && msg.includes('docs/private-apis.md');
+      });
+      expect(calls2).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('exit 78 → thrown message contains "See docs/private-apis.md"', async () => {
+    execFileMock.mockRejectedValueOnce(execError({
+      code: 78,
+      stderr: 'dlopen failed',
+    }));
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(backend.tap(DEVICE, 1, 2)).rejects.toMatchObject({
+        code: 'SIMULATORKIT_UNAVAILABLE',
+        message: expect.stringContaining('See docs/private-apis.md'),
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('{ok:false, code:"SIMULATORKIT_MISSING"} → thrown message contains "See docs/private-apis.md"', async () => {
+    execFileMock.mockResolvedValueOnce({
+      stdout: '{"ok":false,"error":"framework missing","code":"SIMULATORKIT_MISSING"}',
+      stderr: '',
+    });
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(backend.tap(DEVICE, 1, 2)).rejects.toMatchObject({
+        message: expect.stringContaining('See docs/private-apis.md'),
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('{ok:false, code:"NOT_IMPLEMENTED"} → thrown message does NOT contain "docs/private-apis.md"', async () => {
+    execFileMock.mockResolvedValueOnce({
+      stdout: '{"ok":false,"error":"stub","code":"NOT_IMPLEMENTED"}',
+      stderr: '',
+    });
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(backend.tap(DEVICE, 1, 2)).rejects.toMatchObject({
+        message: expect.not.stringContaining('docs/private-apis.md'),
+      });
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   // ── Bridge resolution via swift interpreter ──────────────────────────────


### PR DESCRIPTION
## Summary

- Add a module-level latch (`warnedAboutPrivateAPI`) that emits a single `console.error` warning on the first bridge spawn, naming `SimulatorKit.framework` and `CoreSimulator.framework` and pointing to `docs/private-apis.md`. A `resetSimHidPrivateAPIWarning()` helper is exported for unit tests.
- Centralize a `PRIVATE_API_DOC_REF` constant and append `(See docs/private-apis.md)` to `InputBackendError` messages for framework/symbol resolution failures: exit 78 (`SIMULATORKIT_UNAVAILABLE`) and `ok=false` codes `SIMULATORKIT_MISSING`, `CORESIMULATOR_MISSING`, `HID_CLIENT_FAILED`, `HID_FUNCTIONS_MISSING`.

Towards: #493

## Test plan

- [ ] `first run() emits exactly one warning mentioning SimulatorKit and docs/private-apis.md` — latch fires once, second call emits zero additional warnings
- [ ] `exit 78 → thrown message contains "See docs/private-apis.md"`
- [ ] `{ok:false, code:"SIMULATORKIT_MISSING"} → thrown message contains "See docs/private-apis.md"`
- [ ] `{ok:false, code:"NOT_IMPLEMENTED"} → thrown message does NOT contain "docs/private-apis.md"` (suffix is scoped to framework failures only)
- [ ] All 25 existing tests continue to pass: `npx jest --config jest.config.js tests/unit/sim-hid-input-backend.test.ts`
- [ ] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)