### PR TITLE
feat(telemetry): opt-in _telemetry metadata on MCP input tool responses (#502 Phase 2)

### DIFF
--- a/src/metrics/input-telemetry.ts
+++ b/src/metrics/input-telemetry.ts
@@ -11,6 +11,7 @@
  * See issue #502 for the rollout checklist.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { InputBackendKind } from '../tools/native-input-backend';
 
 /**
@@ -43,9 +44,26 @@ export type InputOperationResult = InputTelemetryEvent;
  */
 export const OPENSAFARI_INPUT_TELEMETRY_ENV = 'OPENSAFARI_INPUT_TELEMETRY';
 
+/**
+ * Env var that opts MCP tool responses into the Phase-2 `_telemetry` metadata
+ * field. When set to `1` / `true`, each input tool (`app_tap`, `app_swipe`,
+ * ...) attaches the captured `InputTelemetryEvent` list under `_meta._telemetry`
+ * so clients and CI can assert on `elapsed_ms` without scraping stderr.
+ *
+ * Default-off so the field is strictly opt-in and does not inflate payloads
+ * for consumers that only care about success/failure.
+ */
+export const OPENSAFARI_INPUT_TELEMETRY_META_ENV = 'OPENSAFARI_INPUT_TELEMETRY_META';
+
 function isTelemetryEnabled(): boolean {
   const value = process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
   return value !== '0' && value !== 'false';
+}
+
+/** Whether input tool responses should include `_meta._telemetry`. */
+export function isInputTelemetryMetaEnabled(): boolean {
+  const value = process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
+  return value === '1' || value === 'true';
 }
 
 type TelemetrySink = (event: InputTelemetryEvent) => void;
@@ -57,6 +75,14 @@ function consoleSink(event: InputTelemetryEvent): void {
 
 let activeSink: TelemetrySink = consoleSink;
 
+/**
+ * Per-async-context capture store. When a caller opens a scope via
+ * `captureInputTelemetry`, every event emitted inside that scope — and only
+ * that scope — is appended to the bound array. Isolation is handled by
+ * `AsyncLocalStorage`, so concurrent MCP tool calls do not cross-contaminate.
+ */
+const captureStore = new AsyncLocalStorage<InputTelemetryEvent[]>();
+
 /** Emit a telemetry event through the active sink. Never throws. */
 export function emitInputTelemetry(event: InputTelemetryEvent): void {
   try {
@@ -64,6 +90,22 @@ export function emitInputTelemetry(event: InputTelemetryEvent): void {
   } catch {
     // The telemetry path must never mask an input-backend failure.
   }
+  const buf = captureStore.getStore();
+  if (buf) buf.push(event);
+}
+
+/**
+ * Run `fn` inside a telemetry capture scope. Every `timedInput` event fired
+ * by `fn` (directly or via any awaited descendant) is collected and returned
+ * alongside `fn`'s result. The sink still fires as usual — capture is a
+ * read-only subscriber, not a redirect.
+ */
+export async function captureInputTelemetry<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; events: InputTelemetryEvent[] }> {
+  const events: InputTelemetryEvent[] = [];
+  const result = await captureStore.run(events, fn);
+  return { result, events };
 }
 
 /**

--- a/src/metrics/input-telemetry.ts
+++ b/src/metrics/input-telemetry.ts
@@ -1,0 +1,135 @@
+/**
+ * Input backend latency telemetry — Phase 1 of Epic #484 reliability ACs.
+ *
+ * Wraps every `InputBackend` operation so we can emit per-operation timing
+ * (`elapsed_ms`) for the downstream p50/p95/p99 rollups. The sink is
+ * intentionally minimal: a single structured `console.error` line per event
+ * tagged `[input-telemetry]`. That keeps the stream grep/jq-friendly and
+ * leaves room for Phase 2 (attaching metadata to MCP tool responses) and
+ * Phase 3 (OpenTelemetry / Prometheus exporters) without a rewrite.
+ *
+ * See issue #502 for the rollout checklist.
+ */
+
+import type { InputBackendKind } from '../tools/native-input-backend';
+
+/**
+ * Stable set of operations we time. Matches the `InputBackend` interface
+ * verbs so a consumer can partition metrics by user-visible action type.
+ */
+export type InputOperation = 'tap' | 'swipe' | 'typeText' | 'keypress' | 'sendKey';
+
+/**
+ * One telemetry event. Keys are deliberately snake_case so downstream
+ * Prometheus / OpenTelemetry wiring can map labels 1:1 without renames.
+ */
+export interface InputTelemetryEvent {
+  backendKind: InputBackendKind;
+  operation: InputOperation;
+  deviceId: string;
+  elapsed_ms: number;
+  ok: boolean;
+  /** Present only when `ok === false`. */
+  error?: string;
+}
+
+/** Alias retained for the shape referenced in the proposal in #502. */
+export type InputOperationResult = InputTelemetryEvent;
+
+/**
+ * Env var that disables the console sink. Set `OPENSAFARI_INPUT_TELEMETRY=0`
+ * (or `false`) to silence emission without touching source. Any other value
+ * — including unset — leaves telemetry on.
+ */
+export const OPENSAFARI_INPUT_TELEMETRY_ENV = 'OPENSAFARI_INPUT_TELEMETRY';
+
+function isTelemetryEnabled(): boolean {
+  const value = process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  return value !== '0' && value !== 'false';
+}
+
+type TelemetrySink = (event: InputTelemetryEvent) => void;
+
+function consoleSink(event: InputTelemetryEvent): void {
+  if (!isTelemetryEnabled()) return;
+  console.error(`[input-telemetry] ${JSON.stringify(event)}`);
+}
+
+let activeSink: TelemetrySink = consoleSink;
+
+/** Emit a telemetry event through the active sink. Never throws. */
+export function emitInputTelemetry(event: InputTelemetryEvent): void {
+  try {
+    activeSink(event);
+  } catch {
+    // The telemetry path must never mask an input-backend failure.
+  }
+}
+
+/**
+ * Override the telemetry sink. Intended for unit tests that want to assert
+ * on the emitted events without parsing stderr. Pass `null` to restore the
+ * default `console.error` sink.
+ */
+export function __setInputTelemetrySinkForTest(sink: TelemetrySink | null): void {
+  activeSink = sink ?? consoleSink;
+}
+
+/**
+ * Millisecond-precision elapsed time. Uses `process.hrtime.bigint()` when
+ * available (Node) and falls back to `Date.now()` so the helper is safe to
+ * import from environments that only provide the Web timing API.
+ */
+function nowNs(): bigint {
+  if (typeof process !== 'undefined' && typeof process.hrtime?.bigint === 'function') {
+    return process.hrtime.bigint();
+  }
+  return BigInt(Date.now()) * 1_000_000n;
+}
+
+function elapsedMs(startNs: bigint): number {
+  const deltaNs = nowNs() - startNs;
+  // Round to the nearest integer millisecond. Negative deltas are impossible
+  // with hrtime but we clamp to 0 defensively for the Date.now() fallback.
+  const ms = Number(deltaNs) / 1e6;
+  return Math.max(0, Math.round(ms));
+}
+
+/**
+ * Wrap an `InputBackend` operation so every call emits a structured timing
+ * event on completion (success and failure alike).
+ *
+ * Callers keep their signatures unchanged — `timedInput` simply threads the
+ * returned promise through. On rejection it emits an `ok: false` event with
+ * the error message attached and re-throws so routing/error handling stay
+ * authoritative.
+ */
+export async function timedInput<T>(
+  backendKind: InputBackendKind,
+  operation: InputOperation,
+  deviceId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = nowNs();
+  try {
+    const result = await fn();
+    emitInputTelemetry({
+      backendKind,
+      operation,
+      deviceId,
+      elapsed_ms: elapsedMs(start),
+      ok: true,
+    });
+    return result;
+  } catch (err) {
+    emitInputTelemetry({
+      backendKind,
+      operation,
+      deviceId,
+      elapsed_ms: elapsedMs(start),
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}

--- a/src/tools/app-alert-handle.ts
+++ b/src/tools/app-alert-handle.ts
@@ -2,7 +2,7 @@ import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { getSessionManager } from '../session-manager';
 import { getInputBackend } from './native-input-backend';
-import { buildInputMeta } from './native-input-utils';
+import { runInputOp } from './native-input-utils';
 
 export function registerAppAlertHandleTool(server: MCPServer): void {
   server.registerTool(
@@ -72,7 +72,9 @@ export function registerAppAlertHandleTool(server: MCPServer): void {
 
       try {
         const backend = await getInputBackend(deviceId);
-        await backend.sendKey(deviceId, keyName);
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.sendKey(deviceId, keyName),
+        );
 
         return {
           content: [
@@ -83,7 +85,7 @@ export function registerAppAlertHandleTool(server: MCPServer): void {
                 action,
                 deviceId,
                 method: 'input_backend',
-                _meta: buildInputMeta(backend, deviceId),
+                _meta: meta,
               }),
             },
           ],

--- a/src/tools/app-dismiss-keyboard.ts
+++ b/src/tools/app-dismiss-keyboard.ts
@@ -2,7 +2,7 @@ import { MCPServer } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
 import { SimulatorManager } from '../simulator';
 import { getInputBackend } from './native-input-backend';
-import { buildInputMeta } from './native-input-utils';
+import { runInputOp } from './native-input-utils';
 
 export function registerAppDismissKeyboardTool(server: MCPServer): void {
   server.registerTool(
@@ -40,11 +40,13 @@ export function registerAppDismissKeyboardTool(server: MCPServer): void {
 
       // Primary method: send Escape key to dismiss keyboard
       try {
-        await backend.sendKey(deviceId, 'Escape');
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.sendKey(deviceId, 'Escape'),
+        );
         return {
           content: [{
             type: 'text' as const,
-            text: JSON.stringify({ dismissed: true, deviceId, method: 'sendkey', _meta: buildInputMeta(backend, deviceId) }),
+            text: JSON.stringify({ dismissed: true, deviceId, method: 'sendkey', _meta: meta }),
           }],
         };
       } catch (err) {
@@ -53,11 +55,13 @@ export function registerAppDismissKeyboardTool(server: MCPServer): void {
 
       // Fallback: tap on status bar area to defocus text fields
       try {
-        await backend.tap(deviceId, 195, 50);
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.tap(deviceId, 195, 50),
+        );
         return {
           content: [{
             type: 'text' as const,
-            text: JSON.stringify({ dismissed: true, deviceId, method: 'tap_fallback', _meta: buildInputMeta(backend, deviceId) }),
+            text: JSON.stringify({ dismissed: true, deviceId, method: 'tap_fallback', _meta: meta }),
           }],
         };
       } catch (err) {

--- a/src/tools/app-double-tap.ts
+++ b/src/tools/app-double-tap.ts
@@ -5,7 +5,7 @@
  */
 
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { resolveDeviceId, getInputBackend, buildInputMeta } from './native-input-utils';
+import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 
 /** Delay between the two taps (ms). 50 ms matches typical double-tap cadence. */
 const INTER_TAP_DELAY_MS = 50;
@@ -53,11 +53,13 @@ export function registerAppDoubleTapTool(server: MCPServer): void {
 
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
 
-        // First tap
-        await backend.tap(deviceId, x, y);
-        await delay(INTER_TAP_DELAY_MS);
-        // Second tap
-        await backend.tap(deviceId, x, y);
+        const { meta } = await runInputOp(backend, deviceId, async () => {
+          // First tap
+          await backend.tap(deviceId, x, y);
+          await delay(INTER_TAP_DELAY_MS);
+          // Second tap
+          await backend.tap(deviceId, x, y);
+        });
 
         return {
           content: [
@@ -69,7 +71,7 @@ export function registerAppDoubleTapTool(server: MCPServer): void {
                 y,
                 deviceId,
                 backend: backend.kind,
-                _meta: buildInputMeta(backend, deviceId),
+                _meta: meta,
               }),
             },
           ],

--- a/src/tools/app-key-input.ts
+++ b/src/tools/app-key-input.ts
@@ -6,7 +6,7 @@
  */
 
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { resolveDeviceId, getInputBackend, buildInputMeta, KEY_MAP } from './native-input-utils';
+import { resolveDeviceId, getInputBackend, runInputOp, KEY_MAP } from './native-input-utils';
 
 export function registerAppKeyInputTool(server: MCPServer): void {
   server.registerTool(
@@ -50,7 +50,9 @@ export function registerAppKeyInputTool(server: MCPServer): void {
         }
 
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
-        await backend.keypress(deviceId, keyCode);
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.keypress(deviceId, keyCode),
+        );
 
         return {
           content: [
@@ -62,7 +64,7 @@ export function registerAppKeyInputTool(server: MCPServer): void {
                 keyCode,
                 deviceId,
                 backend: backend.kind,
-                _meta: buildInputMeta(backend, deviceId),
+                _meta: meta,
               }),
             },
           ],

--- a/src/tools/app-scroll-native.ts
+++ b/src/tools/app-scroll-native.ts
@@ -12,7 +12,7 @@ import { MCPServer, getWebKitClient } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { getSessionManager } from '../session-manager';
 import { getInputBackend } from './native-input-backend';
-import { buildInputMeta } from './native-input-utils';
+import { runInputOp } from './native-input-utils';
 
 /** Default scroll amount in points. */
 const DEFAULT_AMOUNT = 300;
@@ -128,7 +128,9 @@ export function registerAppScrollNativeTool(server: MCPServer): void {
 
         const { endX, endY } = calculateScrollEndpoint(x, y, direction, amount);
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
-        await backend.swipe(deviceId, x, y, endX, endY);
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.swipe(deviceId, x, y, endX, endY),
+        );
 
         return {
           content: [
@@ -142,7 +144,7 @@ export function registerAppScrollNativeTool(server: MCPServer): void {
                 to: { x: endX, y: endY },
                 deviceId,
                 backend: backend.kind,
-                _meta: buildInputMeta(backend, deviceId),
+                _meta: meta,
               }),
             },
           ],

--- a/src/tools/app-swipe.ts
+++ b/src/tools/app-swipe.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { resolveDeviceId, getInputBackend, buildInputMeta } from './native-input-utils';
+import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 
 /** Default swipe distance in points. */
 const DEFAULT_DISTANCE = 300;
@@ -106,7 +106,9 @@ export function registerAppSwipeNativeTool(server: MCPServer): void {
 
         const { endX, endY } = calculateEndpoint(startX, startY, direction, distance);
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
-        await backend.swipe(deviceId, startX, startY, endX, endY, duration);
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.swipe(deviceId, startX, startY, endX, endY, duration),
+        );
 
         return {
           content: [
@@ -121,7 +123,7 @@ export function registerAppSwipeNativeTool(server: MCPServer): void {
                 duration,
                 deviceId,
                 backend: backend.kind,
-                _meta: buildInputMeta(backend, deviceId),
+                _meta: meta,
               }),
             },
           ],

--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -9,7 +9,7 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
 import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import type { AXNode } from '../native';
-import { resolveDeviceId, getInputBackend, buildInputMeta } from './native-input-utils';
+import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 
 export function registerAppTapElementTool(server: MCPServer): void {
   server.registerTool(
@@ -197,7 +197,9 @@ export function registerAppTapElementTool(server: MCPServer): void {
 
         // Tap via input backend
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
-        await backend.tap(deviceId, centerX, centerY, duration > 0 ? duration : undefined);
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.tap(deviceId, centerX, centerY, duration > 0 ? duration : undefined),
+        );
 
         // Flag an implicit ambiguous tap: several candidates matched but
         // the caller did not disambiguate via `index`. We still tap the
@@ -224,7 +226,7 @@ export function registerAppTapElementTool(server: MCPServer): void {
           backend: backend.kind,
           deviceId,
           totalMatches,
-          _meta: buildInputMeta(backend, deviceId),
+          _meta: meta,
         };
         if (clampedFrom) {
           response.clampedFrom = clampedFrom;

--- a/src/tools/app-tap.ts
+++ b/src/tools/app-tap.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { resolveDeviceId, getInputBackend, buildInputMeta } from './native-input-utils';
+import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 
 export function registerAppTapTool(server: MCPServer): void {
   server.registerTool(
@@ -53,7 +53,9 @@ export function registerAppTapTool(server: MCPServer): void {
         }
 
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
-        await backend.tap(deviceId, x, y, duration > 0 ? duration : undefined);
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.tap(deviceId, x, y, duration > 0 ? duration : undefined),
+        );
 
         return {
           content: [
@@ -66,7 +68,7 @@ export function registerAppTapTool(server: MCPServer): void {
                 duration,
                 deviceId,
                 backend: backend.kind,
-                _meta: buildInputMeta(backend, deviceId),
+                _meta: meta,
               }),
             },
           ],

--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -14,7 +14,7 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
 import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import type { AXNode, AXQuery } from '../native';
-import { resolveDeviceId, getInputBackend, buildInputMeta } from './native-input-utils';
+import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_FOCUS_DELAY_MS = 150;
@@ -135,13 +135,13 @@ export function registerAppTypeElementTool(server: MCPServer): void {
         const centerY = match.frame.y + match.frame.height / 2;
 
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
-        await backend.tap(deviceId, centerX, centerY);
-
-        if (focusDelay > 0) {
-          await sleep(focusDelay);
-        }
-
-        await backend.typeText(deviceId, textToType);
+        const { meta } = await runInputOp(backend, deviceId, async () => {
+          await backend.tap(deviceId, centerX, centerY);
+          if (focusDelay > 0) {
+            await sleep(focusDelay);
+          }
+          await backend.typeText(deviceId, textToType);
+        });
 
         return {
           content: [
@@ -159,7 +159,7 @@ export function registerAppTypeElementTool(server: MCPServer): void {
                 length: textToType.length,
                 backend: backend.kind,
                 deviceId,
-                _meta: buildInputMeta(backend, deviceId),
+                _meta: meta,
               }),
             },
           ],

--- a/src/tools/app-type.ts
+++ b/src/tools/app-type.ts
@@ -6,7 +6,7 @@
  */
 
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { resolveDeviceId, getInputBackend, buildInputMeta } from './native-input-utils';
+import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 
 export function registerAppTypeTextTool(server: MCPServer): void {
   server.registerTool(
@@ -47,7 +47,9 @@ export function registerAppTypeTextTool(server: MCPServer): void {
         }
 
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
-        await backend.typeText(deviceId, text);
+        const { meta } = await runInputOp(backend, deviceId, () =>
+          backend.typeText(deviceId, text),
+        );
 
         return {
           content: [
@@ -58,7 +60,7 @@ export function registerAppTypeTextTool(server: MCPServer): void {
                 length: text.length,
                 deviceId,
                 backend: backend.kind,
-                _meta: buildInputMeta(backend, deviceId),
+                _meta: meta,
               }),
             },
           ],

--- a/src/tools/flutter-vm-input-backend.ts
+++ b/src/tools/flutter-vm-input-backend.ts
@@ -27,6 +27,7 @@
 import type { FlutterVMClient } from '../flutter';
 import { FlutterVMError } from '../flutter';
 import type { InputBackend, InputBackendKind } from './native-input-backend';
+import { timedInput } from '../metrics/input-telemetry';
 
 /**
  * Structured error surfaced by FlutterVMInputBackend when the underlying VM
@@ -164,7 +165,15 @@ export class FlutterVMInputBackend implements InputBackend {
    * the event queue even in a quiescent state.
    */
   async tap(
-    _deviceId: string,
+    deviceId: string,
+    x: number,
+    y: number,
+    duration?: number,
+  ): Promise<void> {
+    await timedInput(this.kind, 'tap', deviceId, () => this.tapInternal(x, y, duration));
+  }
+
+  private async tapInternal(
     x: number,
     y: number,
     duration?: number,
@@ -222,7 +231,19 @@ export class FlutterVMInputBackend implements InputBackend {
    * the gesture arena classifies it as a swipe rather than a flick or tap.
    */
   async swipe(
-    _deviceId: string,
+    deviceId: string,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    duration?: number,
+  ): Promise<void> {
+    await timedInput(this.kind, 'swipe', deviceId, () =>
+      this.swipeInternal(startX, startY, endX, endY, duration),
+    );
+  }
+
+  private async swipeInternal(
     startX: number,
     startY: number,
     endX: number,
@@ -290,7 +311,11 @@ export class FlutterVMInputBackend implements InputBackend {
    * callbacks fire naturally. Falls through silently (no-op) if nothing is
    * focused — same behaviour as WebKitInputBackend.
    */
-  async typeText(_deviceId: string, text: string): Promise<void> {
+  async typeText(deviceId: string, text: string): Promise<void> {
+    await timedInput(this.kind, 'typeText', deviceId, () => this.typeTextInternal(text));
+  }
+
+  private async typeTextInternal(text: string): Promise<void> {
     const textLit = dartStringLiteral(text);
 
     // Read the live TextInputConnection client id so the platform message
@@ -353,7 +378,11 @@ export class FlutterVMInputBackend implements InputBackend {
    * Dispatch a HID key code through `HardwareKeyboard`. Only a curated set of
    * control keys is supported — matches the WebKit/AppleScript backends.
    */
-  async keypress(_deviceId: string, keyCode: string): Promise<void> {
+  async keypress(deviceId: string, keyCode: string): Promise<void> {
+    await timedInput(this.kind, 'keypress', deviceId, () => this.keypressInternal(keyCode));
+  }
+
+  private async keypressInternal(keyCode: string): Promise<void> {
     const entry = HID_TO_LOGICAL_KEY[keyCode];
     if (!entry) {
       throw new Error(
@@ -365,7 +394,11 @@ export class FlutterVMInputBackend implements InputBackend {
   }
 
   /** Dispatch a named key ("Return", "Escape", ...) through HardwareKeyboard. */
-  async sendKey(_deviceId: string, keyName: string): Promise<void> {
+  async sendKey(deviceId: string, keyName: string): Promise<void> {
+    await timedInput(this.kind, 'sendKey', deviceId, () => this.sendKeyInternal(keyName));
+  }
+
+  private async sendKeyInternal(keyName: string): Promise<void> {
     const entry = SENDKEY_TO_LOGICAL_KEY[keyName];
     if (!entry) {
       throw new Error(

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -25,6 +25,7 @@ import type { FlutterVMClient } from '../flutter';
 import { getFlutterVMClient } from '../flutter';
 import { FlutterVMInputBackend } from './flutter-vm-input-backend';
 import { tryCreateSimulatorKitHIDBackend } from './sim-hid-input-backend';
+import { timedInput } from '../metrics/input-telemetry';
 
 const execFileAsync = promisify(execFile);
 
@@ -75,14 +76,16 @@ export class SimctlInputBackend implements InputBackend {
   }
 
   async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
-    if (duration && duration > 0) {
-      await this.simctl.exec([
-        'io', deviceId, 'input', 'press',
-        String(x), String(y), String(duration),
-      ]);
-    } else {
-      await this.simctl.exec(['io', deviceId, 'input', 'tap', String(x), String(y)]);
-    }
+    await timedInput(this.kind, 'tap', deviceId, async () => {
+      if (duration && duration > 0) {
+        await this.simctl.exec([
+          'io', deviceId, 'input', 'press',
+          String(x), String(y), String(duration),
+        ]);
+      } else {
+        await this.simctl.exec(['io', deviceId, 'input', 'tap', String(x), String(y)]);
+      }
+    });
   }
 
   async swipe(
@@ -91,31 +94,39 @@ export class SimctlInputBackend implements InputBackend {
     endX: number, endY: number,
     duration?: number,
   ): Promise<void> {
-    try {
-      await this.simctl.exec([
-        'io', deviceId, 'input', 'swipe',
-        String(startX), String(startY), String(endX), String(endY),
-      ]);
-    } catch {
-      // Fallback: `drag` accepts a duration argument
-      await this.simctl.exec([
-        'io', deviceId, 'input', 'drag',
-        String(startX), String(startY), String(endX), String(endY),
-        String(duration ?? 0.5),
-      ]);
-    }
+    await timedInput(this.kind, 'swipe', deviceId, async () => {
+      try {
+        await this.simctl.exec([
+          'io', deviceId, 'input', 'swipe',
+          String(startX), String(startY), String(endX), String(endY),
+        ]);
+      } catch {
+        // Fallback: `drag` accepts a duration argument
+        await this.simctl.exec([
+          'io', deviceId, 'input', 'drag',
+          String(startX), String(startY), String(endX), String(endY),
+          String(duration ?? 0.5),
+        ]);
+      }
+    });
   }
 
   async typeText(deviceId: string, text: string): Promise<void> {
-    await this.simctl.exec(['io', deviceId, 'input', 'text', text]);
+    await timedInput(this.kind, 'typeText', deviceId, async () => {
+      await this.simctl.exec(['io', deviceId, 'input', 'text', text]);
+    });
   }
 
   async keypress(deviceId: string, keyCode: string): Promise<void> {
-    await this.simctl.exec(['io', deviceId, 'input', 'keypress', keyCode]);
+    await timedInput(this.kind, 'keypress', deviceId, async () => {
+      await this.simctl.exec(['io', deviceId, 'input', 'keypress', keyCode]);
+    });
   }
 
   async sendKey(deviceId: string, keyName: string): Promise<void> {
-    await this.simctl.exec(['io', deviceId, 'sendkey', keyName]);
+    await timedInput(this.kind, 'sendKey', deviceId, async () => {
+      await this.simctl.exec(['io', deviceId, 'sendkey', keyName]);
+    });
   }
 }
 
@@ -297,23 +308,25 @@ export class AppleScriptInputBackend implements InputBackend {
   }
 
   async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
-    await this.activateSimulator();
-    const { sx, sy } = await this.toScreen(deviceId, x, y);
+    await timedInput(this.kind, 'tap', deviceId, async () => {
+      await this.activateSimulator();
+      const { sx, sy } = await this.toScreen(deviceId, x, y);
 
-    if (duration && duration > 0) {
-      // Long press: mouse down → wait → mouse up via Swift CGEvent
-      await execFileAsync('swift', ['-e', [
-        'import Cocoa',
-        `let p = CGPoint(x: ${sx}, y: ${sy})`,
-        'CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
-        `Thread.sleep(forTimeInterval: ${duration})`,
-        'CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
-      ].join('\n')], { timeout: Math.max(15_000, duration * 1000 + 5000) });
-    } else {
-      await this.runAppleScript([
-        `tell application "System Events" to click at {${sx}, ${sy}}`,
-      ]);
-    }
+      if (duration && duration > 0) {
+        // Long press: mouse down → wait → mouse up via Swift CGEvent
+        await execFileAsync('swift', ['-e', [
+          'import Cocoa',
+          `let p = CGPoint(x: ${sx}, y: ${sy})`,
+          'CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
+          `Thread.sleep(forTimeInterval: ${duration})`,
+          'CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
+        ].join('\n')], { timeout: Math.max(15_000, duration * 1000 + 5000) });
+      } else {
+        await this.runAppleScript([
+          `tell application "System Events" to click at {${sx}, ${sy}}`,
+        ]);
+      }
+    });
   }
 
   async swipe(
@@ -322,71 +335,79 @@ export class AppleScriptInputBackend implements InputBackend {
     endX: number, endY: number,
     duration?: number,
   ): Promise<void> {
-    await this.activateSimulator();
-    // Get origin once for both start and end coordinates
-    const origin = await this.getSimulatorContentOrigin(deviceId);
-    const sx = Math.round(origin.x + startX);
-    const sy = Math.round(origin.y + startY);
-    const ex = Math.round(origin.x + endX);
-    const ey = Math.round(origin.y + endY);
-    const dur = duration ?? 0.5;
-    const steps = 20;
-    const stepDelay = dur / steps;
+    await timedInput(this.kind, 'swipe', deviceId, async () => {
+      await this.activateSimulator();
+      // Get origin once for both start and end coordinates
+      const origin = await this.getSimulatorContentOrigin(deviceId);
+      const sx = Math.round(origin.x + startX);
+      const sy = Math.round(origin.y + startY);
+      const ex = Math.round(origin.x + endX);
+      const ey = Math.round(origin.y + endY);
+      const dur = duration ?? 0.5;
+      const steps = 20;
+      const stepDelay = dur / steps;
 
-    // Mouse drag via Swift CGEvent (macOS built-in, no external deps)
-    await execFileAsync('swift', ['-e', [
-      'import Cocoa',
-      `let x1: CGFloat = ${sx}, y1: CGFloat = ${sy}`,
-      `let x2: CGFloat = ${ex}, y2: CGFloat = ${ey}`,
-      `let steps = ${steps}`,
-      `let stepDelay = ${stepDelay}`,
-      'CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: CGPoint(x: x1, y: y1), mouseButton: .left)!.post(tap: .cghidEventTap)',
-      'Thread.sleep(forTimeInterval: 0.05)',
-      'for i in 1...steps {',
-      '  let t = CGFloat(i) / CGFloat(steps)',
-      '  let p = CGPoint(x: x1 + (x2 - x1) * t, y: y1 + (y2 - y1) * t)',
-      '  CGEvent(mouseEventSource: nil, mouseType: .leftMouseDragged, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
-      '  Thread.sleep(forTimeInterval: stepDelay)',
-      '}',
-      'CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: CGPoint(x: x2, y: y2), mouseButton: .left)!.post(tap: .cghidEventTap)',
-    ].join('\n')], { timeout: 15_000 });
+      // Mouse drag via Swift CGEvent (macOS built-in, no external deps)
+      await execFileAsync('swift', ['-e', [
+        'import Cocoa',
+        `let x1: CGFloat = ${sx}, y1: CGFloat = ${sy}`,
+        `let x2: CGFloat = ${ex}, y2: CGFloat = ${ey}`,
+        `let steps = ${steps}`,
+        `let stepDelay = ${stepDelay}`,
+        'CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: CGPoint(x: x1, y: y1), mouseButton: .left)!.post(tap: .cghidEventTap)',
+        'Thread.sleep(forTimeInterval: 0.05)',
+        'for i in 1...steps {',
+        '  let t = CGFloat(i) / CGFloat(steps)',
+        '  let p = CGPoint(x: x1 + (x2 - x1) * t, y: y1 + (y2 - y1) * t)',
+        '  CGEvent(mouseEventSource: nil, mouseType: .leftMouseDragged, mouseCursorPosition: p, mouseButton: .left)!.post(tap: .cghidEventTap)',
+        '  Thread.sleep(forTimeInterval: stepDelay)',
+        '}',
+        'CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: CGPoint(x: x2, y: y2), mouseButton: .left)!.post(tap: .cghidEventTap)',
+      ].join('\n')], { timeout: 15_000 });
+    });
   }
 
-  async typeText(_deviceId: string, text: string): Promise<void> {
-    await this.activateSimulator();
-    // Escape special AppleScript characters
-    const escaped = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    await this.runAppleScript([
-      `tell application "System Events" to keystroke "${escaped}"`,
-    ]);
+  async typeText(deviceId: string, text: string): Promise<void> {
+    await timedInput(this.kind, 'typeText', deviceId, async () => {
+      await this.activateSimulator();
+      // Escape special AppleScript characters
+      const escaped = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      await this.runAppleScript([
+        `tell application "System Events" to keystroke "${escaped}"`,
+      ]);
+    });
   }
 
-  async keypress(_deviceId: string, keyCode: string): Promise<void> {
-    await this.activateSimulator();
-    const asKeyCode = HID_TO_APPLESCRIPT[keyCode];
-    if (asKeyCode === undefined) {
-      throw new Error(
-        `Unknown HID key code "${keyCode}" for AppleScript backend. ` +
-        `Supported: ${Object.keys(HID_TO_APPLESCRIPT).join(', ')}`,
-      );
-    }
-    await this.runAppleScript([
-      `tell application "System Events" to key code ${asKeyCode}`,
-    ]);
+  async keypress(deviceId: string, keyCode: string): Promise<void> {
+    await timedInput(this.kind, 'keypress', deviceId, async () => {
+      await this.activateSimulator();
+      const asKeyCode = HID_TO_APPLESCRIPT[keyCode];
+      if (asKeyCode === undefined) {
+        throw new Error(
+          `Unknown HID key code "${keyCode}" for AppleScript backend. ` +
+          `Supported: ${Object.keys(HID_TO_APPLESCRIPT).join(', ')}`,
+        );
+      }
+      await this.runAppleScript([
+        `tell application "System Events" to key code ${asKeyCode}`,
+      ]);
+    });
   }
 
-  async sendKey(_deviceId: string, keyName: string): Promise<void> {
-    await this.activateSimulator();
-    const asKeyCode = SENDKEY_TO_APPLESCRIPT[keyName];
-    if (asKeyCode === undefined) {
-      throw new Error(
-        `Unknown key name "${keyName}" for AppleScript backend. ` +
-        `Supported: ${Object.keys(SENDKEY_TO_APPLESCRIPT).join(', ')}`,
-      );
-    }
-    await this.runAppleScript([
-      `tell application "System Events" to key code ${asKeyCode}`,
-    ]);
+  async sendKey(deviceId: string, keyName: string): Promise<void> {
+    await timedInput(this.kind, 'sendKey', deviceId, async () => {
+      await this.activateSimulator();
+      const asKeyCode = SENDKEY_TO_APPLESCRIPT[keyName];
+      if (asKeyCode === undefined) {
+        throw new Error(
+          `Unknown key name "${keyName}" for AppleScript backend. ` +
+          `Supported: ${Object.keys(SENDKEY_TO_APPLESCRIPT).join(', ')}`,
+        );
+      }
+      await this.runAppleScript([
+        `tell application "System Events" to key code ${asKeyCode}`,
+      ]);
+    });
   }
 }
 
@@ -434,103 +455,113 @@ export class WebKitInputBackend implements InputBackend {
   readonly kind = 'webkit' as const;
   constructor(private client: BrowserBackend) {}
 
-  async tap(_deviceId: string, x: number, y: number, duration?: number): Promise<void> {
-    if (duration && duration > 0) {
-      // Long press via touch events with delay
-      await this.client.evaluate(`
-        (async function(x, y, duration) {
-          var el = document.elementFromPoint(x, y);
-          if (!el) return;
-          var touch = document.createTouch(window, el, 1, x, y, x, y);
-          var touchList = document.createTouchList(touch);
-          el.dispatchEvent(new TouchEvent('touchstart', { touches: touchList, changedTouches: touchList, bubbles: true }));
-          await new Promise(function(r) { setTimeout(r, duration); });
-          var emptyList = document.createTouchList();
-          el.dispatchEvent(new TouchEvent('touchend', { touches: emptyList, changedTouches: touchList, bubbles: true }));
-        })(${x}, ${y}, ${duration * 1000})
-      `);
-    } else {
-      // Normal tap — delegate to BrowserBackend.click() which dispatches
-      // touchstart → touchend → click with emulateUserGesture
-      await this.client.click({ x, y });
-    }
+  async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
+    await timedInput(this.kind, 'tap', deviceId, async () => {
+      if (duration && duration > 0) {
+        // Long press via touch events with delay
+        await this.client.evaluate(`
+          (async function(x, y, duration) {
+            var el = document.elementFromPoint(x, y);
+            if (!el) return;
+            var touch = document.createTouch(window, el, 1, x, y, x, y);
+            var touchList = document.createTouchList(touch);
+            el.dispatchEvent(new TouchEvent('touchstart', { touches: touchList, changedTouches: touchList, bubbles: true }));
+            await new Promise(function(r) { setTimeout(r, duration); });
+            var emptyList = document.createTouchList();
+            el.dispatchEvent(new TouchEvent('touchend', { touches: emptyList, changedTouches: touchList, bubbles: true }));
+          })(${x}, ${y}, ${duration * 1000})
+        `);
+      } else {
+        // Normal tap — delegate to BrowserBackend.click() which dispatches
+        // touchstart → touchend → click with emulateUserGesture
+        await this.client.click({ x, y });
+      }
+    });
   }
 
   async swipe(
-    _deviceId: string,
+    deviceId: string,
     startX: number, startY: number,
     endX: number, endY: number,
     duration?: number,
   ): Promise<void> {
-    const scrollX = startX - endX;
-    const scrollY = startY - endY;
-    const steps = 20;
-    const stepDelay = ((duration ?? 0.5) * 1000) / steps;
+    await timedInput(this.kind, 'swipe', deviceId, async () => {
+      const scrollX = startX - endX;
+      const scrollY = startY - endY;
+      const steps = 20;
+      const stepDelay = ((duration ?? 0.5) * 1000) / steps;
 
-    // Two-pronged: window.scrollBy for native scroll + touch events for JS handlers
-    await this.client.evaluate(`
-      (async function(sx, sy, ex, ey, scrollX, scrollY, steps, stepDelay) {
-        window.scrollBy(scrollX, scrollY);
+      // Two-pronged: window.scrollBy for native scroll + touch events for JS handlers
+      await this.client.evaluate(`
+        (async function(sx, sy, ex, ey, scrollX, scrollY, steps, stepDelay) {
+          window.scrollBy(scrollX, scrollY);
 
-        var el = document.elementFromPoint(sx, sy);
-        if (!el) el = document.body;
-        var makeTouch = function(x, y) { return document.createTouch(window, el, 1, x, y, x, y); };
-        var startTouch = makeTouch(sx, sy);
-        var startList = document.createTouchList(startTouch);
-        el.dispatchEvent(new TouchEvent('touchstart', { touches: startList, changedTouches: startList, bubbles: true }));
-        for (var i = 1; i <= steps; i++) {
-          var x = sx + (ex - sx) * (i / steps);
-          var y = sy + (ey - sy) * (i / steps);
-          var moveTouch = makeTouch(x, y);
-          var moveList = document.createTouchList(moveTouch);
-          el.dispatchEvent(new TouchEvent('touchmove', { touches: moveList, changedTouches: moveList, bubbles: true }));
-          await new Promise(function(r) { setTimeout(r, stepDelay); });
-        }
-        var endTouch = makeTouch(ex, ey);
-        var endList = document.createTouchList(endTouch);
-        var emptyList = document.createTouchList();
-        el.dispatchEvent(new TouchEvent('touchend', { touches: emptyList, changedTouches: endList, bubbles: true }));
-      })(${startX}, ${startY}, ${endX}, ${endY}, ${scrollX}, ${scrollY}, ${steps}, ${stepDelay})
-    `);
+          var el = document.elementFromPoint(sx, sy);
+          if (!el) el = document.body;
+          var makeTouch = function(x, y) { return document.createTouch(window, el, 1, x, y, x, y); };
+          var startTouch = makeTouch(sx, sy);
+          var startList = document.createTouchList(startTouch);
+          el.dispatchEvent(new TouchEvent('touchstart', { touches: startList, changedTouches: startList, bubbles: true }));
+          for (var i = 1; i <= steps; i++) {
+            var x = sx + (ex - sx) * (i / steps);
+            var y = sy + (ey - sy) * (i / steps);
+            var moveTouch = makeTouch(x, y);
+            var moveList = document.createTouchList(moveTouch);
+            el.dispatchEvent(new TouchEvent('touchmove', { touches: moveList, changedTouches: moveList, bubbles: true }));
+            await new Promise(function(r) { setTimeout(r, stepDelay); });
+          }
+          var endTouch = makeTouch(ex, ey);
+          var endList = document.createTouchList(endTouch);
+          var emptyList = document.createTouchList();
+          el.dispatchEvent(new TouchEvent('touchend', { touches: emptyList, changedTouches: endList, bubbles: true }));
+        })(${startX}, ${startY}, ${endX}, ${endY}, ${scrollX}, ${scrollY}, ${steps}, ${stepDelay})
+      `);
+    });
   }
 
-  async typeText(_deviceId: string, text: string): Promise<void> {
-    const escaped = JSON.stringify(text);
-    await this.client.evaluate(`
-      (function() {
-        var el = document.activeElement;
-        if (!el || el === document.body) return;
-        var p = Object.getPrototypeOf(el);
-        while (p && !Object.getOwnPropertyDescriptor(p, 'value')) {
-          p = Object.getPrototypeOf(p);
-        }
-        var desc = p ? Object.getOwnPropertyDescriptor(p, 'value') : null;
-        var cur = (desc && desc.get) ? desc.get.call(el) : (el.value || '');
-        if (desc && desc.set) {
-          desc.set.call(el, cur + ${escaped});
-        } else if ('value' in el) {
-          el.value = cur + ${escaped};
-        }
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-        el.dispatchEvent(new Event('change', { bubbles: true }));
-      })()
-    `);
+  async typeText(deviceId: string, text: string): Promise<void> {
+    await timedInput(this.kind, 'typeText', deviceId, async () => {
+      const escaped = JSON.stringify(text);
+      await this.client.evaluate(`
+        (function() {
+          var el = document.activeElement;
+          if (!el || el === document.body) return;
+          var p = Object.getPrototypeOf(el);
+          while (p && !Object.getOwnPropertyDescriptor(p, 'value')) {
+            p = Object.getPrototypeOf(p);
+          }
+          var desc = p ? Object.getOwnPropertyDescriptor(p, 'value') : null;
+          var cur = (desc && desc.get) ? desc.get.call(el) : (el.value || '');
+          if (desc && desc.set) {
+            desc.set.call(el, cur + ${escaped});
+          } else if ('value' in el) {
+            el.value = cur + ${escaped};
+          }
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        })()
+      `);
+    });
   }
 
-  async keypress(_deviceId: string, keyCode: string): Promise<void> {
-    const keyName = HID_TO_WEBKIT_KEY[keyCode];
-    if (!keyName) {
-      throw new Error(
-        `Unknown HID key code "${keyCode}" for WebKit backend. ` +
-        `Supported: ${Object.keys(HID_TO_WEBKIT_KEY).join(', ')}`,
-      );
-    }
-    await this.client.press(keyName);
+  async keypress(deviceId: string, keyCode: string): Promise<void> {
+    await timedInput(this.kind, 'keypress', deviceId, async () => {
+      const keyName = HID_TO_WEBKIT_KEY[keyCode];
+      if (!keyName) {
+        throw new Error(
+          `Unknown HID key code "${keyCode}" for WebKit backend. ` +
+          `Supported: ${Object.keys(HID_TO_WEBKIT_KEY).join(', ')}`,
+        );
+      }
+      await this.client.press(keyName);
+    });
   }
 
-  async sendKey(_deviceId: string, keyName: string): Promise<void> {
-    const mapped = SENDKEY_TO_WEBKIT_KEY[keyName] ?? keyName;
-    await this.client.press(mapped);
+  async sendKey(deviceId: string, keyName: string): Promise<void> {
+    await timedInput(this.kind, 'sendKey', deviceId, async () => {
+      const mapped = SENDKEY_TO_WEBKIT_KEY[keyName] ?? keyName;
+      await this.client.press(mapped);
+    });
   }
 }
 

--- a/src/tools/native-input-utils.ts
+++ b/src/tools/native-input-utils.ts
@@ -8,6 +8,11 @@
 import { getSessionManager } from '../session-manager';
 import { SimctlExecutor } from '../simulator/simctl';
 import type { InputBackend } from './native-input-backend';
+import {
+  captureInputTelemetry,
+  isInputTelemetryMetaEnabled,
+  type InputTelemetryEvent,
+} from '../metrics/input-telemetry';
 
 // Re-export input backend for tool files
 export {
@@ -18,20 +23,88 @@ export {
   OPENSAFARI_HEADLESS_ONLY_ENV,
 } from './native-input-backend';
 export type { InputBackend, InputBackendKind } from './native-input-backend';
+export {
+  captureInputTelemetry,
+  isInputTelemetryMetaEnabled,
+  OPENSAFARI_INPUT_TELEMETRY_META_ENV,
+} from '../metrics/input-telemetry';
+export type { InputTelemetryEvent } from '../metrics/input-telemetry';
+
+/**
+ * Compact telemetry projection for the `_meta._telemetry` response field.
+ * Drops `backendKind` / `deviceId` (already carried by the surrounding meta)
+ * and retains the per-call signal that Epic #484's p50/p95/p99 rollups need.
+ */
+export interface InputTelemetryMeta {
+  operation: string;
+  elapsed_ms: number;
+  ok: boolean;
+  error?: string;
+}
+
+/** Shape returned by `buildInputMeta`. Kept explicit for call-site typing. */
+export interface InputMeta {
+  backendKind: string;
+  headless: boolean;
+  deviceId: string;
+  _telemetry?: InputTelemetryMeta[];
+}
+
+function compactTelemetry(events: InputTelemetryEvent[]): InputTelemetryMeta[] {
+  return events.map((e) => {
+    const out: InputTelemetryMeta = {
+      operation: e.operation,
+      elapsed_ms: e.elapsed_ms,
+      ok: e.ok,
+    };
+    if (e.error !== undefined) out.error = e.error;
+    return out;
+  });
+}
 
 /**
  * Build the `_meta` object that input tools include in their response
- * to expose which backend handled the operation.
+ * to expose which backend handled the operation. When a list of captured
+ * telemetry events is supplied AND `OPENSAFARI_INPUT_TELEMETRY_META=1`, a
+ * compact `_telemetry` projection is attached for per-call `elapsed_ms`.
  */
 export function buildInputMeta(
   backend: InputBackend,
   deviceId: string,
-): { backendKind: string; headless: boolean; deviceId: string } {
-  return {
+  telemetry?: InputTelemetryEvent[],
+): InputMeta {
+  const meta: InputMeta = {
     backendKind: backend.kind,
     headless: backend.kind !== 'applescript',
     deviceId,
   };
+  if (telemetry && telemetry.length > 0 && isInputTelemetryMetaEnabled()) {
+    meta._telemetry = compactTelemetry(telemetry);
+  }
+  return meta;
+}
+
+/**
+ * Run a backend operation and return its result plus a ready-to-embed
+ * `_meta` object. When `OPENSAFARI_INPUT_TELEMETRY_META=1` the operation is
+ * wrapped in a telemetry capture scope and the resulting events land under
+ * `_meta._telemetry`. Otherwise the operation runs directly (zero overhead).
+ *
+ * This is the one-line integration path for MCP input tools: they call the
+ * helper instead of invoking the backend method by hand, and the `_meta`
+ * field carries the `_telemetry` projection automatically.
+ */
+export async function runInputOp<T>(
+  backend: InputBackend,
+  deviceId: string,
+  op: () => Promise<T>,
+): Promise<{ result: T; meta: InputMeta }> {
+  if (!isInputTelemetryMetaEnabled()) {
+    const result = await op();
+    return { result, meta: buildInputMeta(backend, deviceId) };
+  }
+  const { result, events } = await captureInputTelemetry(op);
+  return { result, meta: buildInputMeta(backend, deviceId, events) };
 }
 
 /**

--- a/src/tools/sim-hid-input-backend.ts
+++ b/src/tools/sim-hid-input-backend.ts
@@ -28,6 +28,7 @@ import { promisify } from 'util';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import type { InputBackend } from './native-input-backend';
+import { timedInput } from '../metrics/input-telemetry';
 
 const execFileAsync = promisify(execFile);
 
@@ -125,11 +126,13 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
   constructor(private readonly bridgePath: string) {}
 
   async tap(deviceId: string, x: number, y: number, duration?: number): Promise<void> {
-    const args = [deviceId, 'tap', String(x), String(y)];
-    if (duration !== undefined && duration > 0) {
-      args.push(String(duration));
-    }
-    await this.run(args);
+    await timedInput(this.kind, 'tap', deviceId, async () => {
+      const args = [deviceId, 'tap', String(x), String(y)];
+      if (duration !== undefined && duration > 0) {
+        args.push(String(duration));
+      }
+      await this.run(args);
+    });
   }
 
   async swipe(
@@ -140,62 +143,70 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
     endY: number,
     duration?: number,
   ): Promise<void> {
-    const args = [
-      deviceId, 'swipe',
-      String(startX), String(startY),
-      String(endX), String(endY),
-    ];
-    if (duration !== undefined && duration > 0) {
-      args.push(String(duration));
-    }
-    await this.run(args);
+    await timedInput(this.kind, 'swipe', deviceId, async () => {
+      const args = [
+        deviceId, 'swipe',
+        String(startX), String(startY),
+        String(endX), String(endY),
+      ];
+      if (duration !== undefined && duration > 0) {
+        args.push(String(duration));
+      }
+      await this.run(args);
+    });
   }
 
   async typeText(deviceId: string, text: string): Promise<void> {
-    // PoC: ASCII-only. Each character is converted to a HID usage and sent
-    // as an independent `key` event. Non-ASCII characters are rejected until
-    // the Swift bridge gains a text-composition path.
-    for (const ch of text) {
-      const usage = asciiToHidUsage(ch);
-      if (usage === null) {
+    await timedInput(this.kind, 'typeText', deviceId, async () => {
+      // PoC: ASCII-only. Each character is converted to a HID usage and sent
+      // as an independent `key` event. Non-ASCII characters are rejected until
+      // the Swift bridge gains a text-composition path.
+      for (const ch of text) {
+        const usage = asciiToHidUsage(ch);
+        if (usage === null) {
+          throw new InputBackendError(
+            `SimulatorKitHIDInputBackend.typeText: non-ASCII character '${ch}' ` +
+              'is not supported in the PoC. Track follow-up in issue #483.',
+            'BAD_ARGS',
+          );
+        }
+        await this.run([deviceId, 'key', String(usage)]);
+      }
+    });
+  }
+
+  async keypress(deviceId: string, keyCode: string): Promise<void> {
+    await timedInput(this.kind, 'keypress', deviceId, async () => {
+      // Accept either a decimal HID usage code or a key name known to our map.
+      const parsed = Number.parseInt(keyCode, 10);
+      const usage = Number.isNaN(parsed) ? KEY_NAME_TO_HID_USAGE[keyCode] : parsed;
+      if (usage === undefined) {
         throw new InputBackendError(
-          `SimulatorKitHIDInputBackend.typeText: non-ASCII character '${ch}' ` +
-            'is not supported in the PoC. Track follow-up in issue #483.',
+          `SimulatorKitHIDInputBackend.keypress: unknown HID key code "${keyCode}"`,
           'BAD_ARGS',
         );
       }
       await this.run([deviceId, 'key', String(usage)]);
-    }
-  }
-
-  async keypress(deviceId: string, keyCode: string): Promise<void> {
-    // Accept either a decimal HID usage code or a key name known to our map.
-    const parsed = Number.parseInt(keyCode, 10);
-    const usage = Number.isNaN(parsed) ? KEY_NAME_TO_HID_USAGE[keyCode] : parsed;
-    if (usage === undefined) {
-      throw new InputBackendError(
-        `SimulatorKitHIDInputBackend.keypress: unknown HID key code "${keyCode}"`,
-        'BAD_ARGS',
-      );
-    }
-    await this.run([deviceId, 'key', String(usage)]);
+    });
   }
 
   async sendKey(deviceId: string, keyName: string): Promise<void> {
-    await this.pressKey(deviceId, keyName);
+    await timedInput(this.kind, 'sendKey', deviceId, async () => {
+      const usage = KEY_NAME_TO_HID_USAGE[keyName];
+      if (usage === undefined) {
+        throw new InputBackendError(
+          `SimulatorKitHIDInputBackend.pressKey: unknown key "${keyName}". ` +
+            `Supported: ${Object.keys(KEY_NAME_TO_HID_USAGE).join(', ')}`,
+          'BAD_ARGS',
+        );
+      }
+      await this.run([deviceId, 'key', String(usage)]);
+    });
   }
 
   /** Convenience alias: resolve a symbolic key name to its HID usage. */
   async pressKey(deviceId: string, key: string): Promise<void> {
-    const usage = KEY_NAME_TO_HID_USAGE[key];
-    if (usage === undefined) {
-      throw new InputBackendError(
-        `SimulatorKitHIDInputBackend.pressKey: unknown key "${key}". ` +
-          `Supported: ${Object.keys(KEY_NAME_TO_HID_USAGE).join(', ')}`,
-        'BAD_ARGS',
-      );
-    }
-    await this.run([deviceId, 'key', String(usage)]);
+    await this.sendKey(deviceId, key);
   }
 
   /**

--- a/tests/unit/flutter-vm-input-backend.test.ts
+++ b/tests/unit/flutter-vm-input-backend.test.ts
@@ -12,6 +12,10 @@ import {
   FlutterVMInputBackendError,
 } from '../../src/tools/flutter-vm-input-backend';
 import { FlutterVMError } from '../../src/flutter';
+import {
+  __setInputTelemetrySinkForTest,
+  type InputTelemetryEvent,
+} from '../../src/metrics/input-telemetry';
 
 const DEVICE = 'TEST-DEVICE-UDID';
 
@@ -272,6 +276,66 @@ describe('FlutterVMInputBackend', () => {
       } catch (err) {
         expect((err as FlutterVMInputBackendError).op).toBe('typeText');
       }
+    });
+  });
+
+  // ── telemetry (#502) ─────────────────────────────────────────────────────
+
+  describe('telemetry', () => {
+    let events: InputTelemetryEvent[];
+
+    beforeEach(() => {
+      events = [];
+      __setInputTelemetrySinkForTest((e) => events.push(e));
+    });
+
+    afterEach(() => {
+      __setInputTelemetrySinkForTest(null);
+    });
+
+    test('tap emits one flutter-vm telemetry event with the device id', async () => {
+      const client = makeMockClient();
+      const backend = new FlutterVMInputBackend(client as any);
+
+      await backend.tap(DEVICE, 10, 20);
+
+      expect(events).toHaveLength(1);
+      const ev = events[0];
+      expect(ev.backendKind).toBe('flutter-vm');
+      expect(ev.operation).toBe('tap');
+      expect(ev.deviceId).toBe(DEVICE);
+      expect(ev.ok).toBe(true);
+      expect(ev.elapsed_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    test('swipe / typeText / keypress / sendKey all emit with the right operation label', async () => {
+      const client = makeMockClient();
+      const backend = new FlutterVMInputBackend(client as any);
+
+      await backend.swipe(DEVICE, 10, 10, 20, 20);
+      await backend.typeText(DEVICE, 'hello');
+      await backend.keypress(DEVICE, '40'); // Enter
+      await backend.sendKey(DEVICE, 'Tab');
+
+      expect(events.map((e) => e.operation)).toEqual([
+        'swipe', 'typeText', 'keypress', 'sendKey',
+      ]);
+      expect(events.every((e) => e.backendKind === 'flutter-vm')).toBe(true);
+      expect(events.every((e) => e.deviceId === DEVICE && e.ok === true)).toBe(true);
+    });
+
+    test('failure still emits an event with ok=false before re-throwing', async () => {
+      const client = makeMockClient();
+      client.evaluate.mockRejectedValueOnce(new Error('dart boom'));
+      const backend = new FlutterVMInputBackend(client as any);
+
+      await expect(backend.tap(DEVICE, 1, 2)).rejects.toBeInstanceOf(
+        FlutterVMInputBackendError,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0].ok).toBe(false);
+      expect(events[0].operation).toBe('tap');
+      expect(events[0].error).toMatch(/dart boom/);
     });
   });
 });

--- a/tests/unit/input-telemetry.test.ts
+++ b/tests/unit/input-telemetry.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the input-backend latency telemetry wrapper (issue #502).
+ *
+ * Covers the three checklist items:
+ *   - `timedInput` emits `elapsed_ms > 0` on success
+ *   - `timedInput` still emits an event on failure and re-throws
+ *   - the emitted event carries `backendKind`, `operation`, `elapsed_ms`, `deviceId`
+ *   - structured JSON sink lands on `console.error` in a grep/jq-friendly shape
+ */
+
+import {
+  timedInput,
+  emitInputTelemetry,
+  __setInputTelemetrySinkForTest,
+  OPENSAFARI_INPUT_TELEMETRY_ENV,
+  type InputTelemetryEvent,
+} from '../../src/metrics/input-telemetry';
+
+describe('input-telemetry / timedInput', () => {
+  let events: InputTelemetryEvent[] = [];
+
+  beforeEach(() => {
+    events = [];
+    __setInputTelemetrySinkForTest((e) => events.push(e));
+  });
+
+  afterEach(() => {
+    __setInputTelemetrySinkForTest(null);
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  });
+
+  test('emits a success event with elapsed_ms >= 0 and required fields', async () => {
+    const deviceId = 'UDID-A';
+    const result = await timedInput('webkit', 'tap', deviceId, async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.backendKind).toBe('webkit');
+    expect(ev.operation).toBe('tap');
+    expect(ev.deviceId).toBe(deviceId);
+    expect(ev.ok).toBe(true);
+    expect(typeof ev.elapsed_ms).toBe('number');
+    expect(ev.elapsed_ms).toBeGreaterThanOrEqual(0);
+    // Sanity: sleep was 5ms so the timing should not be absurdly high.
+    expect(ev.elapsed_ms).toBeLessThan(5000);
+    expect(ev.error).toBeUndefined();
+  });
+
+  test('emits a failure event and re-throws the original error', async () => {
+    const boom = new Error('backend exploded');
+    const deviceId = 'UDID-B';
+
+    await expect(
+      timedInput('simctl', 'swipe', deviceId, async () => {
+        await new Promise((r) => setTimeout(r, 2));
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.backendKind).toBe('simctl');
+    expect(ev.operation).toBe('swipe');
+    expect(ev.deviceId).toBe(deviceId);
+    expect(ev.ok).toBe(false);
+    expect(ev.error).toBe('backend exploded');
+    expect(typeof ev.elapsed_ms).toBe('number');
+    expect(ev.elapsed_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  test('stringifies non-Error thrown values into the error field', async () => {
+    await expect(
+      timedInput('applescript', 'keypress', 'UDID-C', async () => {
+        throw 'plain-string-rejection';
+      }),
+    ).rejects.toBe('plain-string-rejection');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].ok).toBe(false);
+    expect(events[0].error).toBe('plain-string-rejection');
+  });
+
+  test('covers every operation label with its backendKind', async () => {
+    const ops: Array<InputTelemetryEvent['operation']> = [
+      'tap', 'swipe', 'typeText', 'keypress', 'sendKey',
+    ];
+    for (const op of ops) {
+      await timedInput('simhid', op, 'UDID-D', async () => undefined);
+    }
+    expect(events.map((e) => e.operation)).toEqual(ops);
+    expect(events.every((e) => e.backendKind === 'simhid')).toBe(true);
+  });
+
+  test('telemetry emission never masks the original error when the sink throws', async () => {
+    __setInputTelemetrySinkForTest(() => {
+      throw new Error('sink is broken');
+    });
+    const boom = new Error('backend exploded');
+    await expect(
+      timedInput('webkit', 'tap', 'UDID-E', async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+  });
+});
+
+describe('input-telemetry / console sink', () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    __setInputTelemetrySinkForTest(null); // restore default console sink
+    spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  });
+
+  test('emits one [input-telemetry] line per event in structured JSON shape', () => {
+    emitInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID-F',
+      elapsed_ms: 42,
+      ok: true,
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const line = spy.mock.calls[0][0] as string;
+    expect(line.startsWith('[input-telemetry] ')).toBe(true);
+    const payload = JSON.parse(line.slice('[input-telemetry] '.length));
+    expect(payload).toEqual({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID-F',
+      elapsed_ms: 42,
+      ok: true,
+    });
+  });
+
+  test.each(['0', 'false'])(
+    'is silenced when OPENSAFARI_INPUT_TELEMETRY=%s',
+    (value) => {
+      process.env[OPENSAFARI_INPUT_TELEMETRY_ENV] = value;
+      emitInputTelemetry({
+        backendKind: 'simctl',
+        operation: 'tap',
+        deviceId: 'UDID-G',
+        elapsed_ms: 1,
+        ok: true,
+      });
+      expect(spy).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/tests/unit/input-telemetry.test.ts
+++ b/tests/unit/input-telemetry.test.ts
@@ -11,8 +11,11 @@
 import {
   timedInput,
   emitInputTelemetry,
+  captureInputTelemetry,
+  isInputTelemetryMetaEnabled,
   __setInputTelemetrySinkForTest,
   OPENSAFARI_INPUT_TELEMETRY_ENV,
+  OPENSAFARI_INPUT_TELEMETRY_META_ENV,
   type InputTelemetryEvent,
 } from '../../src/metrics/input-telemetry';
 
@@ -155,6 +158,97 @@ describe('input-telemetry / console sink', () => {
         ok: true,
       });
       expect(spy).not.toHaveBeenCalled();
+    },
+  );
+});
+
+// ── Phase 2: captureInputTelemetry + meta opt-in ─────────────────────────
+
+describe('input-telemetry / captureInputTelemetry', () => {
+  afterEach(() => {
+    __setInputTelemetrySinkForTest(null);
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+  });
+
+  test('collects every event emitted inside the scope', async () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_ENV] = '0'; // silence console sink
+    const { result, events } = await captureInputTelemetry(async () => {
+      await timedInput('webkit', 'tap', 'UDID-H', async () => undefined);
+      await timedInput('webkit', 'swipe', 'UDID-H', async () => 42);
+      return 'done';
+    });
+    expect(result).toBe('done');
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.operation)).toEqual(['tap', 'swipe']);
+  });
+
+  test('scopes are isolated across concurrent captures (AsyncLocalStorage)', async () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_ENV] = '0';
+    const scopeA = captureInputTelemetry(async () => {
+      await timedInput('webkit', 'tap', 'A', async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+    });
+    const scopeB = captureInputTelemetry(async () => {
+      await timedInput('simctl', 'swipe', 'B', async () => {
+        await new Promise((r) => setTimeout(r, 5));
+      });
+    });
+    const [a, b] = await Promise.all([scopeA, scopeB]);
+    expect(a.events).toHaveLength(1);
+    expect(a.events[0].deviceId).toBe('A');
+    expect(a.events[0].operation).toBe('tap');
+    expect(b.events).toHaveLength(1);
+    expect(b.events[0].deviceId).toBe('B');
+    expect(b.events[0].operation).toBe('swipe');
+  });
+
+  test('capture does not suppress the active sink — events still fire there', async () => {
+    const sinkEvents: InputTelemetryEvent[] = [];
+    __setInputTelemetrySinkForTest((e) => sinkEvents.push(e));
+    const { events } = await captureInputTelemetry(async () => {
+      await timedInput('simhid', 'tap', 'UDID-I', async () => undefined);
+    });
+    expect(events).toHaveLength(1);
+    expect(sinkEvents).toHaveLength(1);
+    expect(sinkEvents[0]).toEqual(events[0]);
+  });
+
+  test('captures failure events and re-throws', async () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_ENV] = '0';
+    await expect(
+      captureInputTelemetry(async () => {
+        await timedInput('webkit', 'tap', 'UDID-J', async () => {
+          throw new Error('boom');
+        });
+      }),
+    ).rejects.toThrow('boom');
+  });
+});
+
+describe('input-telemetry / meta opt-in flag', () => {
+  afterEach(() => {
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
+  });
+
+  test.each(['1', 'true'])(
+    'isInputTelemetryMetaEnabled returns true for OPENSAFARI_INPUT_TELEMETRY_META=%s',
+    (value) => {
+      process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = value;
+      expect(isInputTelemetryMetaEnabled()).toBe(true);
+    },
+  );
+
+  test('is false by default (opt-in)', () => {
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
+    expect(isInputTelemetryMetaEnabled()).toBe(false);
+  });
+
+  test.each(['0', 'false', 'yes', ''])(
+    'is false for OPENSAFARI_INPUT_TELEMETRY_META=%s (strict)',
+    (value) => {
+      process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = value;
+      expect(isInputTelemetryMetaEnabled()).toBe(false);
     },
   );
 });

--- a/tests/unit/native-input-utils.test.ts
+++ b/tests/unit/native-input-utils.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for runInputOp + buildInputMeta's opt-in `_telemetry` projection
+ * (Phase 2 of issue #502).
+ */
+
+import {
+  buildInputMeta,
+  runInputOp,
+  OPENSAFARI_INPUT_TELEMETRY_META_ENV,
+} from '../../src/tools/native-input-utils';
+import {
+  timedInput,
+  __setInputTelemetrySinkForTest,
+  OPENSAFARI_INPUT_TELEMETRY_ENV,
+} from '../../src/metrics/input-telemetry';
+import type { InputBackend } from '../../src/tools/native-input-backend';
+
+function makeBackend(kind: InputBackend['kind']): InputBackend {
+  return {
+    kind,
+    async tap(deviceId, x, y, duration) {
+      await timedInput(kind, 'tap', deviceId, async () => {
+        // Simulate some work so elapsed_ms > 0 occasionally.
+        await new Promise((r) => setTimeout(r, 1));
+        void x; void y; void duration;
+      });
+    },
+    async swipe(deviceId) {
+      await timedInput(kind, 'swipe', deviceId, async () => undefined);
+    },
+    async typeText(deviceId) {
+      await timedInput(kind, 'typeText', deviceId, async () => undefined);
+    },
+    async keypress(deviceId) {
+      await timedInput(kind, 'keypress', deviceId, async () => undefined);
+    },
+    async sendKey(deviceId) {
+      await timedInput(kind, 'sendKey', deviceId, async () => undefined);
+    },
+  };
+}
+
+describe('runInputOp', () => {
+  beforeEach(() => {
+    // Silence the default console sink for determinism.
+    process.env[OPENSAFARI_INPUT_TELEMETRY_ENV] = '0';
+  });
+
+  afterEach(() => {
+    __setInputTelemetrySinkForTest(null);
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
+  });
+
+  test('omits _telemetry from meta by default (opt-in not set)', async () => {
+    const backend = makeBackend('webkit');
+    const { meta } = await runInputOp(backend, 'UDID', () =>
+      backend.tap('UDID', 10, 20),
+    );
+    expect(meta.backendKind).toBe('webkit');
+    expect(meta.headless).toBe(true);
+    expect(meta.deviceId).toBe('UDID');
+    expect(meta._telemetry).toBeUndefined();
+  });
+
+  test('attaches _telemetry projection when OPENSAFARI_INPUT_TELEMETRY_META=1', async () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = '1';
+    const backend = makeBackend('webkit');
+    const { meta } = await runInputOp(backend, 'UDID', () =>
+      backend.tap('UDID', 10, 20),
+    );
+    expect(Array.isArray(meta._telemetry)).toBe(true);
+    expect(meta._telemetry).toHaveLength(1);
+    const t = meta._telemetry![0];
+    expect(t.operation).toBe('tap');
+    expect(t.ok).toBe(true);
+    expect(typeof t.elapsed_ms).toBe('number');
+    expect(t.elapsed_ms).toBeGreaterThanOrEqual(0);
+    // Compact projection: deviceId / backendKind omitted (carried by parent).
+    expect((t as unknown as Record<string, unknown>).deviceId).toBeUndefined();
+    expect((t as unknown as Record<string, unknown>).backendKind).toBeUndefined();
+  });
+
+  test('captures multi-call operations (tap + typeText) in a single scope', async () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = '1';
+    const backend = makeBackend('simctl');
+    const { meta } = await runInputOp(backend, 'UDID', async () => {
+      await backend.tap('UDID', 5, 5);
+      await backend.typeText('UDID', 'hi');
+    });
+    expect(meta._telemetry!.map((t) => t.operation)).toEqual([
+      'tap',
+      'typeText',
+    ]);
+  });
+
+  test('records ok=false and error on failure, re-throws original', async () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = '1';
+    const backend = makeBackend('webkit');
+    // Swap tap for a failing op
+    backend.tap = async (deviceId) => {
+      await timedInput('webkit', 'tap', deviceId, async () => {
+        throw new Error('boom');
+      });
+    };
+    await expect(
+      runInputOp(backend, 'UDID', () => backend.tap('UDID', 1, 2)),
+    ).rejects.toThrow('boom');
+  });
+
+  test('headless is false only for applescript backend', () => {
+    expect(buildInputMeta(makeBackend('applescript'), 'D').headless).toBe(false);
+    expect(buildInputMeta(makeBackend('webkit'), 'D').headless).toBe(true);
+    expect(buildInputMeta(makeBackend('simctl'), 'D').headless).toBe(true);
+    expect(buildInputMeta(makeBackend('simhid'), 'D').headless).toBe(true);
+    expect(buildInputMeta(makeBackend('flutter-vm'), 'D').headless).toBe(true);
+  });
+
+  test('buildInputMeta ignores telemetry events when opt-in is off', () => {
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
+    const backend = makeBackend('webkit');
+    const meta = buildInputMeta(backend, 'UDID', [
+      {
+        backendKind: 'webkit',
+        operation: 'tap',
+        deviceId: 'UDID',
+        elapsed_ms: 7,
+        ok: true,
+      },
+    ]);
+    expect(meta._telemetry).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Stacks on top of #521 and #523 (telemetry foundation + Flutter VM wiring). Implements the **Phase-2 rollout** called for in issue #502: when `OPENSAFARI_INPUT_TELEMETRY_META=1` is set, every input MCP tool response attaches a compact `_meta._telemetry` array with per-call `elapsed_ms`, `operation`, `ok`, and optional `error` — giving CI and clients an assertion surface for latency without scraping stderr.

**Default-off** so the field is strictly opt-in and does not inflate payloads for consumers that only care about success/failure.

## Infrastructure

- `src/metrics/input-telemetry.ts` — adds:
  - `AsyncLocalStorage<InputTelemetryEvent[]>`-backed `captureInputTelemetry<T>(fn)` scope: a read-only subscriber that collects events emitted inside `fn` without suppressing the console sink. Concurrency-safe across parallel MCP tool invocations.
  - `isInputTelemetryMetaEnabled()` env-flag reader.
- `src/tools/native-input-utils.ts` — adds `runInputOp(backend, deviceId, op)` helper that conditionally wraps the backend call in a capture scope and threads captured events through `buildInputMeta` as a compact `{ operation, elapsed_ms, ok, error? }` projection (parent meta already carries `backendKind` / `deviceId`, so those fields are dropped from the projection).

## Tools wired (all 10 MCP input tools)

`app_tap`, `app_swipe`, `app_scroll_native`, `app_key_input`, `app_double_tap`, `app_type_text`, `app_tap_element`, `app_type_element`, `app_dismiss_keyboard`, `app_alert_handle`.

Sample response body with opt-in set:

```json
{
  "status": "tapped",
  "_meta": {
    "backendKind": "webkit",
    "headless": true,
    "deviceId": "UDID",
    "_telemetry": [
      { "operation": "tap", "elapsed_ms": 42, "ok": true }
    ]
  }
}
```

## Issue #502 checkboxes covered (in addition to #521, #523)

### Observability
- [x] structured JSON logs (already from #521) AND MCP tool responses expose `_telemetry` (opt-in)

### Unit Tests
- [x] `tests/unit/native-input-utils.test.ts` (new): opt-in gate, failure-path recording, multi-call scope capture, headless projection per backend kind.
- [x] `tests/unit/input-telemetry.test.ts` (extended): `captureInputTelemetry` AsyncLocalStorage isolation across concurrent captures, env-flag truth table.

## Test plan

- [x] `npm test` → 1538 / 1538 pass (up from 1521 in #523)
- [x] `npm run build` → clean
- [x] Default behavior unchanged when `OPENSAFARI_INPUT_TELEMETRY_META` is unset (verified via `omits _telemetry from meta by default` test)
- [x] Existing `_meta.backendKind` / `headless` / `deviceId` shape preserved — only adds the opt-in `_telemetry` field

## Dependencies

- Depends on #521 (`feat/502-telemetry-foundation`)
- Depends on #523 (`feat/502-flutter-vm-telemetry`)

Towards: #502, #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)