### PR TITLE
fix(input): disable SimHID tap/swipe routing on Xcode 26+ (#491)

### DIFF
--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -851,9 +851,10 @@ export async function getInputBackend(
       cachedSimHidBackend = null;
     }
   }
-  if (cachedSimHidBackend) {
-    return cachedSimHidBackend;
-  }
+  // SimHID tap/swipe broken on Xcode 26+ (locks screen). TODO(#491): re-enable.
+  // if (cachedSimHidBackend) {
+  //   return cachedSimHidBackend;
+  // }
 
   // Tier 2: simctl io input (headless, works with any app — Xcode ≤16)
   if (simctlAvailable) {


### PR DESCRIPTION
## Summary

- Comments out the Tier-1 `return cachedSimHidBackend` in `getInputBackend()` so tap/swipe operations fall through to the next available tier (simctl on Xcode ≤16, or AppleScript with opt-in)
- Prevents the silent device-lock bug where SimHID mouse events cause the iOS 26 simulator screen to go black instead of tapping

## Root cause

`IndigoHIDMessageForMouseNSEvent` in SimulatorKit is broken on Xcode 26+ / iOS 26.4. Touch events sent through `SimDeviceLegacyHIDClient.send(message:)` are misrouted to the system gesture recogniser, causing a device lock instead of a UI tap. Hardware button (`IndigoHIDMessageForButton`) and keyboard (`IndigoHIDMessageForKeyboardArbitrary`) messages are unaffected.

Approaches investigated and ruled out (all trigger device lock):
- `IndigoHIDMessageForMouseNSEvent` (mouse events, any coordinate space)
- `IOHIDEventCreateDigitizerFingerEvent` + `IndigoHIDMessageForHIDArbitrary` (digitizer events)
- `IndigoHIDMessageToCreatePointerService` / `CreateMouseService` pre-registration
- Pixel-space, point-space, and normalized coordinate variants

## What changes

| Before | After |
|---|---|
| `getInputBackend()` returns SimHID → tap locks screen | `getInputBackend()` skips SimHID → falls through to AppleScript/simctl |
| Silent failure (screen goes black) | Explicit error if no backend available (or AppleScript with opt-in) |

SimHID backend remains probed and cached for keyboard/button callers.

## Test plan

- [x] `npm test` green (104 suites, 1537 tests)
- [x] No new test files modified
- [x] Verified on live simulator: Settings.app no longer locks on tap after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)