### PR TITLE
ci(sentinel): harmonize sim-hid-sentinel alerts with probe name + error

### DIFF
--- a/.github/workflows/sim-hid-sentinel.yml
+++ b/.github/workflows/sim-hid-sentinel.yml
@@ -64,7 +64,20 @@ jobs:
         run: npm run build
 
       - name: Run sentinel tests
-        run: npx jest --config jest.config.js tests/ci/sim-hid-sentinel.test.ts --runTestsByPath --passWithNoTests
+        run: |
+          # jest.config.js testPathIgnorePatterns ignores `/tests/ci/` for
+          # `npm test`; override with only `/node_modules/` here so the
+          # scheduled sentinel actually executes instead of silently
+          # reporting "No tests found, exiting with code 0".
+          #
+          # Capture --json output so the alert step can surface the failing
+          # probe name + stderr instead of a generic "sentinel failed".
+          set -o pipefail
+          npx jest --config jest.config.js tests/ci/sim-hid-sentinel.test.ts \
+            --runTestsByPath \
+            --testPathIgnorePatterns=/node_modules/ \
+            --json --outputFile=sim-hid-sentinel-report.json \
+            2>&1 | tee sim-hid-sentinel.log
         env:
           # The sentinel probes the bridge directly — it does not need the
           # focus-stealing fallback, and accidentally enabling it would mask
@@ -72,18 +85,66 @@ jobs:
           OPENSAFARI_ALLOW_FOCUS_INPUT: ''
           OPENSAFARI_HEADLESS_ONLY: '1'
 
+      - name: Upload sentinel artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-hid-sentinel-${{ matrix.runner }}
+          path: |
+            sim-hid-sentinel.log
+            sim-hid-sentinel-report.json
+          if-no-files-found: warn
+
       - name: Open / update tracking issue on failure
         if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const title = `[sentinel] SimulatorKit HID BC-break suspected (${context.job})`;
+            const fs = require('fs');
+            const runner = process.env.RUNNER_LABEL;
+
+            // Extract failing probes from the jest JSON report so the on-call
+            // engineer sees the exact failing assertion and error in the
+            // created issue, not just a "sentinel failed" placeholder.
+            let failing = [];
+            try {
+              const raw = fs.readFileSync('sim-hid-sentinel-report.json', 'utf8');
+              const report = JSON.parse(raw);
+              for (const suite of report.testResults ?? []) {
+                for (const tc of suite.assertionResults ?? []) {
+                  if (tc.status === 'failed') {
+                    failing.push({
+                      name: [...(tc.ancestorTitles ?? []), tc.title].join(' › '),
+                      messages: (tc.failureMessages ?? []).map(m =>
+                        m.split('\n').slice(0, 8).join('\n'),
+                      ),
+                    });
+                  }
+                }
+              }
+            } catch (err) {
+              core.warning(`Could not parse sim-hid-sentinel-report.json: ${err.message}`);
+            }
+
+            const title = `[sentinel] SimulatorKit HID BC-break suspected (${runner})`;
+            const failureBlock = failing.length
+              ? failing.map(f =>
+                  `### ${f.name}\n\n\`\`\`\n${f.messages.join('\n---\n')}\n\`\`\``,
+                ).join('\n\n')
+              : '_Could not parse jest report — see attached `sim-hid-sentinel.log` artifact._';
+
             const body = [
               '`sim-hid-sentinel` failed on the scheduled run.',
               '',
-              `Runner: \`${{ matrix.runner }}\``,
-              `Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `- Runner: \`${runner}\``,
+              `- Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              '## Failing probes',
+              '',
+              failureBlock,
+              '',
+              '## Triage checklist',
               '',
               'Apple may have moved or removed a private framework symbol that',
               '`sim-hid-bridge` depends on. Verify:',
@@ -121,3 +182,5 @@ jobs:
                 labels: ['sentinel', 'bug'],
               });
             }
+        env:
+          RUNNER_LABEL: ${{ matrix.runner }}

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -852,6 +852,9 @@ export async function getInputBackend(
     }
   }
   // SimHID tap/swipe broken on Xcode 26+ (locks screen). TODO(#491): re-enable.
+  // Read guard — the cache is kept populated so re-activation is a one-line
+  // change; without the read, eslint flags the probe as dead code.
+  void cachedSimHidBackend;
   // if (cachedSimHidBackend) {
   //   return cachedSimHidBackend;
   // }

--- a/tests/integration/issue-423-native.live.test.ts
+++ b/tests/integration/issue-423-native.live.test.ts
@@ -37,7 +37,6 @@ const DEVICE_ID =
 const BUNDLE = 'com.apple.Preferences';
 
 const SETTINGS_GENERAL_ID = 'com.apple.settings.general';
-const SETTINGS_GENERAL_LABEL = process.env.SETTINGS_GENERAL ?? 'General';
 const SETTINGS_ABOUT_LABEL = process.env.SETTINGS_ABOUT ?? 'About';
 
 jest.setTimeout(120_000);


### PR DESCRIPTION
## Summary

- Brings the legacy `sim-hid-sentinel` workflow to parity with the new `private-api-sentinel` (#541) so both produce actionable tracking issues that name the failing probe.
- Fixes a silent no-op bug where the scheduled sentinel was exiting "No tests found, exiting with code 0" because `jest.config.js` ignores `/tests/ci/` for the default `npm test` run.
- Adds `jest --json` capture + artifact upload so post-hoc triage has the full report and stderr.

## Why the no-op bug mattered

`jest.config.js` declares:

```js
testPathIgnorePatterns: [..., '/tests/ci/', ...]
```

so the workflow's prior command silently matched no tests on every daily cron — reporting green even if `sim-hid-bridge` was broken. Reproduced locally:

```
$ npx jest --config jest.config.js tests/ci/sim-hid-sentinel.test.ts --runTestsByPath --passWithNoTests --json
No tests found, exiting with code 0
```

Overriding the ignore list at the CLI restores execution:

```
$ npx jest --config jest.config.js tests/ci/sim-hid-sentinel.test.ts \
    --runTestsByPath --testPathIgnorePatterns=/node_modules/
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

## Alert body — before vs. after

**Before** — generic placeholder regardless of which probe failed:

> `sim-hid-sentinel` failed on the scheduled run.
> Apple may have moved or removed a private framework symbol…

**After** — names the failing probe + first 8 lines of its error:

> ## Failing probes
> ### SimulatorKit HID Sentinel › SimulatorKit.framework is loadable (exit != 78 SIMULATORKIT_MISSING)
> ```
> Error: SimulatorKit.framework could not be loaded.
> stderr: …
> ```

## Test plan

- [x] `yaml.safe_load` parses the updated workflow
- [x] `npx jest --config jest.config.js tests/ci/sim-hid-sentinel.test.ts --runTestsByPath --testPathIgnorePatterns=/node_modules/` passes locally (5/5)
- [x] `jest --json` output parsed with the same extraction logic the script uses (validated against a synthetic failure report)
- [ ] Post-merge: watch the next scheduled run to confirm artifacts upload and that a failing probe would surface cleanly

Towards: #503
Related: #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)