### PR TITLE
fix(lint): unblock CI by adding void-read for cachedSimHidBackend (#491)

### DIFF
--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -852,6 +852,9 @@ export async function getInputBackend(
     }
   }
   // SimHID tap/swipe broken on Xcode 26+ (locks screen). TODO(#491): re-enable.
+  // Read guard — the cache is kept populated so re-activation is a one-line
+  // change; without the read, eslint flags the probe as dead code.
+  void cachedSimHidBackend;
   // if (cachedSimHidBackend) {
   //   return cachedSimHidBackend;
   // }

--- a/tests/integration/issue-423-native.live.test.ts
+++ b/tests/integration/issue-423-native.live.test.ts
@@ -37,7 +37,6 @@ const DEVICE_ID =
 const BUNDLE = 'com.apple.Preferences';
 
 const SETTINGS_GENERAL_ID = 'com.apple.settings.general';
-const SETTINGS_GENERAL_LABEL = process.env.SETTINGS_GENERAL ?? 'General';
 const SETTINGS_ABOUT_LABEL = process.env.SETTINGS_ABOUT ?? 'About';
 
 jest.setTimeout(120_000);


### PR DESCRIPTION
## Summary

Current `src/tools/native-input-backend.ts:854-857` keeps the Tier-1 SimHID return block commented out while #491 investigates the Xcode 26+ screen-lock regression in `IndigoHIDMessageForMouseNSEvent`. The probe still runs and populates `cachedSimHidBackend`, but with the `return` block commented the variable becomes write-only — `@typescript-eslint/no-unused-vars` raises it as an **error** (not a warning), which breaks `npm run lint` on CI for every PR against `develop`.

Observed impact: [PR #538 lint job](https://github.com/shaun0927/opensafari/actions/runs/24446461707/job/71424016757) fails with `639:5  error  'cachedSimHidBackend' is assigned a value but never used`, blocking #492 docs PRs from merging.

This PR adds a minimal `void cachedSimHidBackend;` read guard right where the return block sits, with an inline comment pointing to #491. Keeps the cache/probe intact so re-activation stays a one-line uncomment after #491 ships the real fix.

### Alternatives considered
- **Delete the probe + cache** — loses the re-activation affordance and forces #491 to relitigate Tier-1 ordering.
- **`// eslint-disable-next-line @typescript-eslint/no-unused-vars`** — hides the intent inside a rule comment.
- **Rename to `_cachedSimHidBackend`** — churns four unrelated call sites (assignments + reset) just to satisfy the rule.

## Test plan
- [x] `npx eslint src/tools/native-input-backend.ts` — clean
- [x] `npm run lint` — exit 0 locally
- [x] `npx jest tests/unit/native-input-backend.test.ts tests/unit/sim-hid-input-backend.test.ts` — green
- [ ] CI lint job green (unblocks #538 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)