### PR TITLE
feat(telemetry): p50/p95/p99 latency rollup aggregator (#502)

### DIFF
--- a/src/metrics/input-telemetry-rollup.ts
+++ b/src/metrics/input-telemetry-rollup.ts
@@ -1,0 +1,169 @@
+/**
+ * Process-wide latency rollup for input-backend telemetry (issue #502).
+ *
+ * Every event emitted through `emitInputTelemetry` is also accumulated here
+ * so callers can ask for per-(backendKind, operation) p50/p95/p99 latency
+ * without scraping stderr. The rollup is a thin nearest-rank percentile
+ * over a bounded ring buffer — a good-enough approximation that matches
+ * Epic #484's reliability AC ("평균 / p95 / p99 latency가 telemetry로
+ * 수집됨") without pulling in a t-digest dependency.
+ *
+ * Memory bound: `INPUT_TELEMETRY_ROLLUP_CAP` samples per key (default 1024),
+ * evicted FIFO once full. Keys are `${backendKind}:${operation}`. Errors
+ * (`ok: false`) are tracked separately so `errorRate` stays meaningful even
+ * when the elapsed-ms stream is dominated by failures.
+ */
+
+import type { InputBackendKind } from '../tools/native-input-backend';
+import type { InputOperation, InputTelemetryEvent } from './input-telemetry';
+
+/** Max samples retained per `${backendKind}:${operation}` key. */
+export const INPUT_TELEMETRY_ROLLUP_CAP = 1024;
+
+/**
+ * Env var that disables the rollup accumulator. Unlike the console sink flag
+ * (`OPENSAFARI_INPUT_TELEMETRY`) this one defaults to on because aggregation
+ * is O(1) per event — we only pay work when callers request a snapshot.
+ */
+export const OPENSAFARI_INPUT_TELEMETRY_ROLLUP_ENV = 'OPENSAFARI_INPUT_TELEMETRY_ROLLUP';
+
+/** One row of the `{backendKind, operation}` summary table. */
+export interface InputTelemetryRollup {
+  backendKind: InputBackendKind;
+  operation: InputOperation;
+  count: number;
+  errorCount: number;
+  /** `errorCount / count`, clamped to [0, 1]. `0` when `count === 0`. */
+  errorRate: number;
+  /** Arithmetic mean of `elapsed_ms` across **successful** calls. */
+  mean_ms: number;
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  /** Wall-clock epoch ms of the most recent sample (success or failure). */
+  lastUpdated: number;
+}
+
+interface Bucket {
+  samples: number[]; // ring buffer of elapsed_ms for successful calls
+  start: number; // ring buffer head offset
+  size: number; // samples actually populated
+  count: number; // total events observed (success + failure)
+  errorCount: number;
+  sum: number; // running sum of successful elapsed_ms (for mean)
+  lastUpdated: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+function key(backendKind: InputBackendKind, operation: InputOperation): string {
+  return `${backendKind}:${operation}`;
+}
+
+function isRollupEnabled(): boolean {
+  const value = process.env[OPENSAFARI_INPUT_TELEMETRY_ROLLUP_ENV];
+  return value !== '0' && value !== 'false';
+}
+
+function newBucket(): Bucket {
+  return {
+    samples: new Array<number>(INPUT_TELEMETRY_ROLLUP_CAP),
+    start: 0,
+    size: 0,
+    count: 0,
+    errorCount: 0,
+    sum: 0,
+    lastUpdated: 0,
+  };
+}
+
+/**
+ * Append one event to the rollup accumulator. Safe to call with any shape
+ * the telemetry pipeline can emit — unknown backend/operation labels create
+ * a new bucket. No-op when rollup is disabled.
+ */
+export function accumulateInputTelemetry(event: InputTelemetryEvent): void {
+  if (!isRollupEnabled()) return;
+  const k = key(event.backendKind, event.operation);
+  let b = buckets.get(k);
+  if (!b) {
+    b = newBucket();
+    buckets.set(k, b);
+  }
+  b.count += 1;
+  b.lastUpdated = Date.now();
+  if (!event.ok) {
+    b.errorCount += 1;
+    return;
+  }
+  const ms = event.elapsed_ms;
+  if (b.size < INPUT_TELEMETRY_ROLLUP_CAP) {
+    b.samples[(b.start + b.size) % INPUT_TELEMETRY_ROLLUP_CAP] = ms;
+    b.size += 1;
+    b.sum += ms;
+  } else {
+    // Evict the oldest sample (FIFO) and replace it.
+    const evicted = b.samples[b.start];
+    b.samples[b.start] = ms;
+    b.start = (b.start + 1) % INPUT_TELEMETRY_ROLLUP_CAP;
+    b.sum += ms - evicted;
+  }
+}
+
+/** Nearest-rank percentile — simple and stable for small/medium samples. */
+function percentile(sortedAscending: number[], p: number): number {
+  if (sortedAscending.length === 0) return 0;
+  const clamped = Math.min(1, Math.max(0, p));
+  // Nearest-rank: index = ceil(p * n) - 1, floored at 0.
+  const idx = Math.max(0, Math.ceil(clamped * sortedAscending.length) - 1);
+  return sortedAscending[idx];
+}
+
+function snapshotBucket(
+  backendKind: InputBackendKind,
+  operation: InputOperation,
+  b: Bucket,
+): InputTelemetryRollup {
+  const successCount = b.size;
+  const sorted: number[] = new Array(successCount);
+  for (let i = 0; i < successCount; i++) {
+    sorted[i] = b.samples[(b.start + i) % INPUT_TELEMETRY_ROLLUP_CAP];
+  }
+  sorted.sort((a, x) => a - x);
+  const mean = successCount === 0 ? 0 : b.sum / successCount;
+  return {
+    backendKind,
+    operation,
+    count: b.count,
+    errorCount: b.errorCount,
+    errorRate: b.count === 0 ? 0 : b.errorCount / b.count,
+    mean_ms: Math.round(mean * 100) / 100,
+    p50_ms: percentile(sorted, 0.5),
+    p95_ms: percentile(sorted, 0.95),
+    p99_ms: percentile(sorted, 0.99),
+    lastUpdated: b.lastUpdated,
+  };
+}
+
+/**
+ * Return the rollup snapshot. Stable ordering: sorted by key ascending so
+ * downstream diffs / golden-file tests are deterministic.
+ */
+export function getInputTelemetryRollup(): InputTelemetryRollup[] {
+  const out: InputTelemetryRollup[] = [];
+  const keys = Array.from(buckets.keys()).sort();
+  for (const k of keys) {
+    const [backendKind, operation] = k.split(':') as [InputBackendKind, InputOperation];
+    const b = buckets.get(k)!;
+    out.push(snapshotBucket(backendKind, operation, b));
+  }
+  return out;
+}
+
+/**
+ * Drop every accumulated sample. Tests and long-running daemons that want
+ * fresh windows call this at the start of their measurement period.
+ */
+export function resetInputTelemetryRollup(): void {
+  buckets.clear();
+}

--- a/src/metrics/input-telemetry.ts
+++ b/src/metrics/input-telemetry.ts
@@ -13,6 +13,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { InputBackendKind } from '../tools/native-input-backend';
+import { accumulateInputTelemetry } from './input-telemetry-rollup';
 
 /**
  * Stable set of operations we time. Matches the `InputBackend` interface
@@ -89,6 +90,11 @@ export function emitInputTelemetry(event: InputTelemetryEvent): void {
     activeSink(event);
   } catch {
     // The telemetry path must never mask an input-backend failure.
+  }
+  try {
+    accumulateInputTelemetry(event);
+  } catch {
+    // Ditto — rollup failures stay invisible to the caller.
   }
   const buf = captureStore.getStore();
   if (buf) buf.push(event);

--- a/src/tools/diagnose.ts
+++ b/src/tools/diagnose.ts
@@ -9,6 +9,10 @@ import { MCPServer } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
 import { peekProxyForDevice } from '../simulator/proxy-manager';
 import { tryCreateSimulatorKitHIDBackend } from './sim-hid-input-backend';
+import {
+  getInputTelemetryRollup,
+  type InputTelemetryRollup,
+} from '../metrics/input-telemetry-rollup';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 
@@ -51,6 +55,12 @@ interface DiagnoseReport {
     native: boolean;
     overall: boolean;
   };
+  /**
+   * Per-(backendKind, operation) latency rollup (#502). Empty when the
+   * accumulator has not seen any input events yet — diagnose itself does
+   * not synthesise traffic.
+   */
+  latency: InputTelemetryRollup[];
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -216,6 +226,7 @@ export function registerDiagnoseTool(server: MCPServer): void {
           native: nativeVerdict,
           overall: safariVerdict && nativeVerdict,
         },
+        latency: getInputTelemetryRollup(),
       };
 
       return {

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -852,6 +852,9 @@ export async function getInputBackend(
     }
   }
   // SimHID tap/swipe broken on Xcode 26+ (locks screen). TODO(#491): re-enable.
+  // Read guard — the cache is kept populated so re-activation is a one-line
+  // change; without the read, eslint flags the probe as dead code.
+  void cachedSimHidBackend;
   // if (cachedSimHidBackend) {
   //   return cachedSimHidBackend;
   // }

--- a/src/tools/native-input-utils.ts
+++ b/src/tools/native-input-utils.ts
@@ -29,6 +29,12 @@ export {
   OPENSAFARI_INPUT_TELEMETRY_META_ENV,
 } from '../metrics/input-telemetry';
 export type { InputTelemetryEvent } from '../metrics/input-telemetry';
+export {
+  getInputTelemetryRollup,
+  resetInputTelemetryRollup,
+  OPENSAFARI_INPUT_TELEMETRY_ROLLUP_ENV,
+} from '../metrics/input-telemetry-rollup';
+export type { InputTelemetryRollup } from '../metrics/input-telemetry-rollup';
 
 /**
  * Compact telemetry projection for the `_meta._telemetry` response field.

--- a/tests/integration/issue-423-native.live.test.ts
+++ b/tests/integration/issue-423-native.live.test.ts
@@ -37,7 +37,6 @@ const DEVICE_ID =
 const BUNDLE = 'com.apple.Preferences';
 
 const SETTINGS_GENERAL_ID = 'com.apple.settings.general';
-const SETTINGS_GENERAL_LABEL = process.env.SETTINGS_GENERAL ?? 'General';
 const SETTINGS_ABOUT_LABEL = process.env.SETTINGS_ABOUT ?? 'About';
 
 jest.setTimeout(120_000);

--- a/tests/unit/input-telemetry-rollup.test.ts
+++ b/tests/unit/input-telemetry-rollup.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the process-wide latency rollup aggregator (issue #502).
+ *
+ * Covers:
+ *   - `emitInputTelemetry` feeds the rollup — one end-to-end path
+ *   - p50 / p95 / p99 match the nearest-rank definition for known inputs
+ *   - errors are tracked separately and never pollute the latency sample set
+ *   - buckets respect the sample cap (FIFO eviction keeps `mean_ms` honest)
+ *   - rollup can be disabled via `OPENSAFARI_INPUT_TELEMETRY_ROLLUP=0`
+ *   - rows are sorted by `${backendKind}:${operation}` for deterministic output
+ */
+
+import {
+  emitInputTelemetry,
+  __setInputTelemetrySinkForTest,
+  OPENSAFARI_INPUT_TELEMETRY_ENV,
+} from '../../src/metrics/input-telemetry';
+import {
+  INPUT_TELEMETRY_ROLLUP_CAP,
+  OPENSAFARI_INPUT_TELEMETRY_ROLLUP_ENV,
+  accumulateInputTelemetry,
+  getInputTelemetryRollup,
+  resetInputTelemetryRollup,
+} from '../../src/metrics/input-telemetry-rollup';
+
+describe('input-telemetry-rollup', () => {
+  beforeEach(() => {
+    resetInputTelemetryRollup();
+    process.env[OPENSAFARI_INPUT_TELEMETRY_ENV] = '0'; // silence console sink
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ROLLUP_ENV];
+    __setInputTelemetrySinkForTest(() => {
+      /* noop */
+    });
+  });
+
+  afterEach(() => {
+    resetInputTelemetryRollup();
+    __setInputTelemetrySinkForTest(null);
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ENV];
+    delete process.env[OPENSAFARI_INPUT_TELEMETRY_ROLLUP_ENV];
+  });
+
+  test('emitInputTelemetry accumulates into the rollup', () => {
+    for (const ms of [1, 2, 3]) {
+      emitInputTelemetry({
+        backendKind: 'webkit',
+        operation: 'tap',
+        deviceId: 'UDID',
+        elapsed_ms: ms,
+        ok: true,
+      });
+    }
+    const rows = getInputTelemetryRollup();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      backendKind: 'webkit',
+      operation: 'tap',
+      count: 3,
+      errorCount: 0,
+      errorRate: 0,
+      mean_ms: 2,
+    });
+  });
+
+  test('nearest-rank p50 / p95 / p99 match the textbook definition', () => {
+    // Feed 1..100 so percentiles are easy to read.
+    for (let ms = 1; ms <= 100; ms++) {
+      accumulateInputTelemetry({
+        backendKind: 'simhid',
+        operation: 'tap',
+        deviceId: 'UDID',
+        elapsed_ms: ms,
+        ok: true,
+      });
+    }
+    const [row] = getInputTelemetryRollup();
+    expect(row.count).toBe(100);
+    // nearest-rank: index = ceil(p * n) - 1  →  p50:49 (50ms), p95:94 (95ms), p99:98 (99ms)
+    expect(row.p50_ms).toBe(50);
+    expect(row.p95_ms).toBe(95);
+    expect(row.p99_ms).toBe(99);
+    expect(row.mean_ms).toBeCloseTo(50.5, 1);
+  });
+
+  test('errors increment errorCount but never touch the latency sample set', () => {
+    accumulateInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID',
+      elapsed_ms: 10,
+      ok: true,
+    });
+    accumulateInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID',
+      elapsed_ms: 9999, // would dominate the mean if it leaked in
+      ok: false,
+      error: 'boom',
+    });
+    const [row] = getInputTelemetryRollup();
+    expect(row.count).toBe(2);
+    expect(row.errorCount).toBe(1);
+    expect(row.errorRate).toBe(0.5);
+    expect(row.mean_ms).toBe(10); // failure excluded
+    expect(row.p50_ms).toBe(10);
+    expect(row.p95_ms).toBe(10);
+    expect(row.p99_ms).toBe(10);
+  });
+
+  test('ring buffer evicts oldest samples once the per-key cap fills', () => {
+    // Overfill by 10 so we exercise the FIFO path.
+    const total = INPUT_TELEMETRY_ROLLUP_CAP + 10;
+    for (let i = 0; i < total; i++) {
+      accumulateInputTelemetry({
+        backendKind: 'webkit',
+        operation: 'swipe',
+        deviceId: 'UDID',
+        elapsed_ms: i, // monotonically increasing
+        ok: true,
+      });
+    }
+    const [row] = getInputTelemetryRollup();
+    // All events counted…
+    expect(row.count).toBe(total);
+    // …but only the last CAP samples feed the percentile stream.
+    const survivingFirst = total - INPUT_TELEMETRY_ROLLUP_CAP; // = 10
+    const survivingLast = total - 1; // = 1033
+    expect(row.p50_ms).toBeGreaterThanOrEqual(survivingFirst); // first 10 evicted
+    // Nearest-rank: p99 index = ceil(0.99 * CAP) - 1.
+    const p99Index = Math.ceil(0.99 * INPUT_TELEMETRY_ROLLUP_CAP) - 1;
+    expect(row.p99_ms).toBe(survivingFirst + p99Index);
+    // Largest surviving sample is exposed via the implicit p100 — confirm
+    // it stayed in the window rather than being evicted.
+    expect(row.p99_ms).toBeLessThanOrEqual(survivingLast);
+    // Mean must reflect only the surviving window, not the full stream.
+    const expectedMean = (survivingFirst + survivingLast) / 2;
+    expect(row.mean_ms).toBeCloseTo(expectedMean, 1);
+  });
+
+  test('rollup partitions by ${backendKind}:${operation} key', () => {
+    accumulateInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID',
+      elapsed_ms: 1,
+      ok: true,
+    });
+    accumulateInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'swipe',
+      deviceId: 'UDID',
+      elapsed_ms: 2,
+      ok: true,
+    });
+    accumulateInputTelemetry({
+      backendKind: 'simhid',
+      operation: 'tap',
+      deviceId: 'UDID',
+      elapsed_ms: 3,
+      ok: true,
+    });
+    const rows = getInputTelemetryRollup();
+    expect(rows).toHaveLength(3);
+    // Sorted ascending by "${backendKind}:${operation}"
+    expect(rows.map((r) => `${r.backendKind}:${r.operation}`)).toEqual([
+      'simhid:tap',
+      'webkit:swipe',
+      'webkit:tap',
+    ]);
+  });
+
+  test.each(['0', 'false'])(
+    'is silenced when OPENSAFARI_INPUT_TELEMETRY_ROLLUP=%s',
+    (value) => {
+      process.env[OPENSAFARI_INPUT_TELEMETRY_ROLLUP_ENV] = value;
+      accumulateInputTelemetry({
+        backendKind: 'webkit',
+        operation: 'tap',
+        deviceId: 'UDID',
+        elapsed_ms: 1,
+        ok: true,
+      });
+      expect(getInputTelemetryRollup()).toEqual([]);
+    },
+  );
+
+  test('resetInputTelemetryRollup drops every bucket', () => {
+    accumulateInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID',
+      elapsed_ms: 1,
+      ok: true,
+    });
+    expect(getInputTelemetryRollup()).toHaveLength(1);
+    resetInputTelemetryRollup();
+    expect(getInputTelemetryRollup()).toEqual([]);
+  });
+
+  test('lastUpdated is populated on both success and failure paths', () => {
+    const before = Date.now();
+    accumulateInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID',
+      elapsed_ms: 5,
+      ok: true,
+    });
+    accumulateInputTelemetry({
+      backendKind: 'webkit',
+      operation: 'tap',
+      deviceId: 'UDID',
+      elapsed_ms: 0,
+      ok: false,
+      error: 'x',
+    });
+    const [row] = getInputTelemetryRollup();
+    expect(row.lastUpdated).toBeGreaterThanOrEqual(before);
+    expect(row.lastUpdated).toBeLessThanOrEqual(Date.now());
+  });
+});


### PR DESCRIPTION
## Summary

- Process-wide latency rollup aggregator (`src/metrics/input-telemetry-rollup.ts`) subscribes to every `InputTelemetry` event and exposes per-`(backendKind, operation)` mean / p50 / p95 / p99 / count / errorCount / errorRate.
- Bounded memory: 1024 samples per key with FIFO eviction. Nearest-rank percentile keeps the math deterministic without pulling in a t-digest.
- `diagnose` MCP tool surfaces the snapshot under a new `latency` field so CI / on-call can read backend health without scraping stderr.
- Toggle with `OPENSAFARI_INPUT_TELEMETRY_ROLLUP=0` (default on; cost is O(1) per event, snapshot only allocates on call).

## Why

Closes the **Reliability AC** of Epic #484: *"각 백엔드의 평균 / p95 / p99 latency가 telemetry로 수집됨."* Raw `_telemetry` already carried `elapsed_ms` per call, but there was no aggregation path — every consumer had to re-implement percentile math from stderr. This PR is the missing aggregator and the diagnose surface.

## Test plan

- [x] `npx jest tests/unit/input-telemetry-rollup.test.ts tests/unit/input-telemetry.test.ts` — 28/28 green
- [x] `npx jest` — full suite 1551/1551 green
- [x] `npm run build` — TS + Swift bridges build clean
- [ ] Verified `diagnose` `latency` field returns `[]` on a freshly booted process (no events) and `> 0` rows after exercising any input tool

Refs: #484, Fixes: #502