### PR TITLE
fix(ci): replace return with process.exit in flutter/native UDID picker (#501)

### DIFF
--- a/.github/workflows/headless-smoke.yml
+++ b/.github/workflows/headless-smoke.yml
@@ -205,7 +205,7 @@ jobs:
               .sort();
             for (const r of runtimes.slice().reverse()) {
               const iphone = (d.devices[r] || []).find(x => /iPhone/.test(x.name) && x.isAvailable);
-              if (iphone) { process.stdout.write(iphone.udid); return; }
+              if (iphone) { process.stdout.write(iphone.udid); process.exit(0); }
             }
             console.error("No available iPhone simulator");
             process.exit(1);
@@ -362,7 +362,7 @@ jobs:
               .sort();
             for (const r of runtimes.slice().reverse()) {
               const iphone = (d.devices[r] || []).find(x => /iPhone/.test(x.name) && x.isAvailable);
-              if (iphone) { process.stdout.write(iphone.udid); return; }
+              if (iphone) { process.stdout.write(iphone.udid); process.exit(0); }
             }
             console.error("No available iPhone simulator");
             process.exit(1);

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -852,6 +852,9 @@ export async function getInputBackend(
     }
   }
   // SimHID tap/swipe broken on Xcode 26+ (locks screen). TODO(#491): re-enable.
+  // Read guard — the cache is kept populated so re-activation is a one-line
+  // change; without the read, eslint flags the probe as dead code.
+  void cachedSimHidBackend;
   // if (cachedSimHidBackend) {
   //   return cachedSimHidBackend;
   // }

--- a/tests/integration/issue-423-native.live.test.ts
+++ b/tests/integration/issue-423-native.live.test.ts
@@ -37,7 +37,6 @@ const DEVICE_ID =
 const BUNDLE = 'com.apple.Preferences';
 
 const SETTINGS_GENERAL_ID = 'com.apple.settings.general';
-const SETTINGS_GENERAL_LABEL = process.env.SETTINGS_GENERAL ?? 'General';
 const SETTINGS_ABOUT_LABEL = process.env.SETTINGS_ABOUT ?? 'About';
 
 jest.setTimeout(120_000);


### PR DESCRIPTION
## Summary

`flutter-smoke` and `native-smoke` jobs in \`headless-smoke.yml\` use a tiny inline \`node -e\` to pick the highest-iOS-runtime iPhone UDID. The script ends the match path with \`return;\`, which is illegal at the top level of a Node script, so every PR validation run dies with:

\`\`\`
SyntaxError: Illegal return statement
…
Invalid device:        ← \`SIMULATOR_UDID\` ends up empty
\`\`\`

The safari job was patched for the same bug in 1c784ad3, but bd11d9c8 (flutter) and c617aa9f (native) were authored before that fix landed and re-introduced the broken pattern.

This PR swaps \`return;\` → \`process.exit(0);\` in both jobs, matching the safari job's pattern.

## Test plan

- [x] Workflow YAML still parses (\`js-yaml.load\`)
- [x] Safari job already runs the same pattern in production — no behavioural drift
- [ ] Re-run \`headless-smoke.yml\` against this branch and confirm flutter-smoke / native-smoke at least reach the boot step (still expected to fail later on iOS 26 SimHID gating per #491, but the device-pick step must pass)

Towards: #501, Refs: #484