### PR TITLE
feat(input): add 'simhid-gated' reason when Tier-1 is cached but gated (#491)

### DIFF
--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -595,7 +595,12 @@ function isHeadlessOnly(): boolean {
 export class HeadlessInputUnavailableError extends Error {
   readonly name = 'HeadlessInputUnavailableError' as const;
   readonly deviceId: string;
-  readonly reason: 'no-simctl' | 'no-webkit' | 'webkit-disconnected' | 'headless-only';
+  readonly reason:
+    | 'no-simctl'
+    | 'no-webkit'
+    | 'webkit-disconnected'
+    | 'headless-only'
+    | 'simhid-gated';
   readonly remediation: readonly string[];
 
   constructor(
@@ -609,11 +614,23 @@ export class HeadlessInputUnavailableError extends Error {
             'Ensure a headless backend (simctl, webkit, flutter-vm, simhid) is available.',
             `To allow focus-stealing input, unset ${OPENSAFARI_HEADLESS_ONLY_ENV}.`,
           ] as const)
-        : ([
-            "Safari QA: call `set_active_context({ context: 'safari' })` to enable WebKitInputBackend",
-            `Native apps: opt in to the CGEvent fallback by setting ${OPENSAFARI_ALLOW_FOCUS_INPUT_ENV}=1 ` +
-              '(WARNING: will move the mouse cursor and bring Simulator.app to the foreground)',
-          ] as const);
+        : reason === 'simhid-gated'
+          ? ([
+              'SimulatorKitHID (Tier 1) is probed and cached on this host, but the ' +
+                'tap/swipe return path in `getInputBackend()` is commented out while ' +
+                'issue #491 fixes `IndigoHIDMessageForMouseNSEvent` locking the Simulator ' +
+                'screen on Xcode 26+.',
+              'Track progress: https://github.com/shaun0927/opensafari/issues/491',
+              'Hardware buttons and keyboard input via simhid are unaffected — only ' +
+                'tap/swipe are gated.',
+              `Temporary workaround: set ${OPENSAFARI_ALLOW_FOCUS_INPUT_ENV}=1 to route ` +
+                'tap/swipe through the focus-stealing AppleScript/CGEvent backend until #491 ships.',
+            ] as const)
+          : ([
+              "Safari QA: call `set_active_context({ context: 'safari' })` to enable WebKitInputBackend",
+              `Native apps: opt in to the CGEvent fallback by setting ${OPENSAFARI_ALLOW_FOCUS_INPUT_ENV}=1 ` +
+                '(WARNING: will move the mouse cursor and bring Simulator.app to the foreground)',
+            ] as const);
     const message =
       `No headless input backend available for device ${deviceId} (reason: ${reason}).\n` +
       remediation.map((line) => `  - ${line}`).join('\n');
@@ -852,9 +869,8 @@ export async function getInputBackend(
     }
   }
   // SimHID tap/swipe broken on Xcode 26+ (locks screen). TODO(#491): re-enable.
-  // Read guard — the cache is kept populated so re-activation is a one-line
-  // change; without the read, eslint flags the probe as dead code.
-  void cachedSimHidBackend;
+  // `cachedSimHidBackend` is read below when picking the error reason, so the
+  // probe is not dead code even while the return path is commented out.
   // if (cachedSimHidBackend) {
   //   return cachedSimHidBackend;
   // }
@@ -899,9 +915,17 @@ export async function getInputBackend(
   // Without explicit opt-in, refuse to return a backend that would move the
   // mouse cursor or steal Simulator focus. See issue #405.
   if (!isFocusInputAllowed()) {
-    const reason: HeadlessInputUnavailableError['reason'] = !webkitClient
-      ? 'no-webkit'
-      : 'webkit-disconnected';
+    // Prefer the 'simhid-gated' reason when the Tier-1 probe succeeded on
+    // this host — pointing users at #491 is more actionable than the
+    // WebKit-oriented 'no-webkit' reason for a native-app call site.
+    let reason: HeadlessInputUnavailableError['reason'];
+    if (cachedSimHidBackend) {
+      reason = 'simhid-gated';
+    } else if (!webkitClient) {
+      reason = 'no-webkit';
+    } else {
+      reason = 'webkit-disconnected';
+    }
     const err = new HeadlessInputUnavailableError(deviceId, reason);
     console.error(`[input-backend] ${err.message}`);
     throw err;

--- a/tests/unit/native-input-backend.test.ts
+++ b/tests/unit/native-input-backend.test.ts
@@ -640,6 +640,64 @@ describe('getInputBackend', () => {
     }
   });
 
+  // ── simhid-gated reason (issue #491) ────────────────────────────────────
+  //
+  // When the Tier-1 SimHID probe succeeds but the return path in
+  // `getInputBackend()` is commented out (see TODO(#491) referencing the
+  // Xcode 26+ screen-lock regression), the thrown error should surface the
+  // #491 link instead of the WebKit-oriented 'no-webkit' reason. We drive
+  // the probe to a non-null backend by enabling the Swift-source candidate
+  // path — that affordance is already gated behind
+  // OPENSAFARI_ALLOW_SWIFT_INTERPRETER=1 and resolves to the in-tree
+  // `src/native/sim-hid-bridge.swift`, so no build step is required.
+
+  describe('simhid-gated reason (issue #491)', () => {
+    const ALLOW_SWIFT = 'OPENSAFARI_ALLOW_SWIFT_INTERPRETER';
+    let originalAllowSwift: string | undefined;
+
+    beforeEach(() => {
+      originalAllowSwift = process.env[ALLOW_SWIFT];
+      process.env[ALLOW_SWIFT] = '1';
+      resetInputBackend();
+    });
+
+    afterEach(() => {
+      if (originalAllowSwift === undefined) {
+        delete process.env[ALLOW_SWIFT];
+      } else {
+        process.env[ALLOW_SWIFT] = originalAllowSwift;
+      }
+      resetInputBackend();
+    });
+
+    test('reason is simhid-gated when SimHID probe succeeds and no webkitClient', async () => {
+      execMock.mockRejectedValueOnce(new Error('not supported'));
+      try {
+        await getInputBackend(DEVICE);
+        fail('expected HeadlessInputUnavailableError');
+      } catch (err) {
+        const hErr = err as HeadlessInputUnavailableError;
+        expect(hErr.reason).toBe('simhid-gated');
+      }
+    });
+
+    test('remediation references issue #491 and mentions the ALLOW_FOCUS_INPUT workaround', async () => {
+      execMock.mockRejectedValueOnce(new Error('not supported'));
+      try {
+        await getInputBackend(DEVICE);
+        fail('expected HeadlessInputUnavailableError');
+      } catch (err) {
+        const hErr = err as HeadlessInputUnavailableError;
+        expect(hErr.message).toContain('#491');
+        expect(hErr.message).toContain('IndigoHIDMessageForMouseNSEvent');
+        expect(hErr.message).toContain(OPENSAFARI_ALLOW_FOCUS_INPUT_ENV);
+        // The simhid-gated remediation is deliberately longer than the
+        // two-line webkit fallback; assert the minimum shape.
+        expect(hErr.remediation.length).toBeGreaterThanOrEqual(4);
+      }
+    });
+  });
+
   // ── WebKit reconnect retry (issue #405) ─────────────────────────────────
 
   test('attempts a one-shot WebKit reconnect when client is disconnected', async () => {


### PR DESCRIPTION
## Summary

Before this change, `app_tap_element` on a native app returned `HeadlessInputUnavailableError(no-webkit)` on Xcode 26 hosts — even though the real blocker is that Tier-1 `SimulatorKitHIDInputBackend` is *available* but gated by #491 (IndigoHIDMessageForMouseNSEvent locks the Simulator screen). MCP clients followed the `no-webkit` remediation and either tried to configure Safari (irrelevant for a native-app call) or flipped `OPENSAFARI_ALLOW_FOCUS_INPUT=1` without knowing why SimHID wouldn't kick in.

This PR adds a dedicated `'simhid-gated'` reason so the thrown error points directly at #491 and the temporary workaround, and exercises the reason via two unit tests.

### Changes
- **`HeadlessInputUnavailableError.reason`** — extends the union with `'simhid-gated'`.
- **Remediation text** — four actionable lines including the #491 link, a note that keyboard/button paths are unaffected, and the `OPENSAFARI_ALLOW_FOCUS_INPUT=1` escape hatch.
- **Reason picker in `getInputBackend()`** — prefers `'simhid-gated'` when `cachedSimHidBackend` is populated; falls back to the WebKit-oriented reasons when SimHID was not available on the host.
- **Tests** — two new tests under `describe('simhid-gated reason (issue #491)')` drive the probe to a non-null cache via `OPENSAFARI_ALLOW_SWIFT_INTERPRETER=1` (resolves `src/native/sim-hid-bridge.swift`; requires no build).
- Removes the now-redundant `void cachedSimHidBackend;` guard that #543 added — the cache is a real read now.

### Behaviour change
Routing is unchanged — tap/swipe still fall through to the next tier, and the SimHID return block remains commented until #491 ships the `IndigoHIDMessageForMouseNSEvent` fix. Only the *error* surfaced when no tier can serve the request is affected, and only on hosts where the SimHID probe succeeds.

## Test plan
- [x] `npx jest tests/unit/native-input-backend.test.ts` — 76/76 green (74 existing + 2 new).
- [x] `npm run lint` — exit 0 after the piggy-backed `SETTINGS_GENERAL_LABEL` lint fix.
- [x] `npx tsc --noEmit` — clean.
- [ ] CI green.
- [ ] MCP smoke: `app_tap_element({ label: '일반' })` on Xcode 26 surfaces `reason='simhid-gated'` in the error payload.

## Dependencies
Rebases on #543 (`fix/491-lint-cached-simhid-unused`) — both commits are cherry-picked into this branch so it lints cleanly on its own; merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)