### PR TITLE
test(integration): screenshot-on-failure reporter for live suites (#491)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist-test/
 # Coverage
 coverage/
 
+# Integration-test failure artifacts (screenshot-failure-reporter, etc.)
+test-output/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "node dist/index.js",
     "test": "jest --config jest.config.js",
     "test:unit": "jest --config jest.config.js",
-    "test:integration": "jest --preset ts-jest --testEnvironment node --roots tests/integration --testPathIgnorePatterns '/node_modules/' --testPathIgnorePatterns 'webkit-connection' --testTimeout=120000 --runInBand",
+    "test:integration": "jest --preset ts-jest --testEnvironment node --roots tests/integration --testPathIgnorePatterns '/node_modules/' --testPathIgnorePatterns 'webkit-connection' --testTimeout=120000 --runInBand --reporters=default --reporters=<rootDir>/tests/integration/screenshot-failure-reporter.cjs",
     "test:ci": "jest --config jest.ci.config.js",
     "test:sentinel": "jest --config jest.sentinel.config.js",
     "test:coverage": "jest --coverage",

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -852,6 +852,9 @@ export async function getInputBackend(
     }
   }
   // SimHID tap/swipe broken on Xcode 26+ (locks screen). TODO(#491): re-enable.
+  // Read guard — the cache is kept populated so re-activation is a one-line
+  // change; without the read, eslint flags the probe as dead code.
+  void cachedSimHidBackend;
   // if (cachedSimHidBackend) {
   //   return cachedSimHidBackend;
   // }

--- a/tests/integration/issue-423-native.live.test.ts
+++ b/tests/integration/issue-423-native.live.test.ts
@@ -37,7 +37,6 @@ const DEVICE_ID =
 const BUNDLE = 'com.apple.Preferences';
 
 const SETTINGS_GENERAL_ID = 'com.apple.settings.general';
-const SETTINGS_GENERAL_LABEL = process.env.SETTINGS_GENERAL ?? 'General';
 const SETTINGS_ABOUT_LABEL = process.env.SETTINGS_ABOUT ?? 'About';
 
 jest.setTimeout(120_000);

--- a/tests/integration/screenshot-failure-reporter.cjs
+++ b/tests/integration/screenshot-failure-reporter.cjs
@@ -1,0 +1,93 @@
+/**
+ * Custom Jest reporter — captures an iOS Simulator screenshot whenever a test
+ * case fails, so live integration runs leave behind a debuggable artifact
+ * showing the simulator state at the failure moment.
+ *
+ * Activation:
+ *   - Pass `--reporters=default --reporters=<path>/screenshot-failure-reporter.cjs`
+ *     to jest. The `npm run test:integration` script wires this up by default.
+ *   - The reporter no-ops when `OSF_DEVICE_ID` is unset (CI without a booted
+ *     simulator) or when the booted device cannot be probed.
+ *
+ * Output:
+ *   - Default: `<repo>/test-output/screenshots/<ISO-timestamp>_<sanitised-test-name>.png`
+ *   - Override base directory via the `outputDir` reporter option or the
+ *     `OSF_SCREENSHOT_DIR` environment variable.
+ *
+ * Why a custom reporter (not afterEach):
+ *   - Reusable across every integration suite without per-file boilerplate.
+ *   - Runs even when the test throws synchronously inside `beforeEach` /
+ *     `beforeAll`, where afterEach hooks are skipped.
+ *   - Stays quiet for skipped / passed cases.
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+
+class ScreenshotOnFailureReporter {
+  constructor(globalConfig, options = {}) {
+    const cwd = (globalConfig && globalConfig.rootDir) || process.cwd();
+    this.outputDir =
+      options.outputDir ||
+      process.env.OSF_SCREENSHOT_DIR ||
+      path.resolve(cwd, 'test-output', 'screenshots');
+    this.deviceId = process.env.OSF_DEVICE_ID || null;
+    this.captures = 0;
+  }
+
+  /**
+   * Sanitise an arbitrary jest test name into a filesystem-safe slug.
+   * Limits to 120 characters so we do not blow past PATH_MAX even when
+   * combined with timestamp + base directory.
+   */
+  static slugify(name) {
+    return String(name)
+      .replace(/[^A-Za-z0-9_]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 120) || 'unnamed';
+  }
+
+  onTestCaseResult(_test, testCaseResult) {
+    if (!testCaseResult || testCaseResult.status !== 'failed') return;
+    if (!this.deviceId) return;
+    const ancestors = (testCaseResult.ancestorTitles || []).join(' › ');
+    const fullName = ancestors
+      ? `${ancestors} › ${testCaseResult.title}`
+      : testCaseResult.title;
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const target = path.join(
+      this.outputDir,
+      `${ts}_${ScreenshotOnFailureReporter.slugify(fullName)}.png`,
+    );
+    try {
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      execFileSync(
+        'xcrun',
+        ['simctl', 'io', this.deviceId, 'screenshot', target],
+        { stdio: 'pipe', timeout: 10_000 },
+      );
+      this.captures += 1;
+      // eslint-disable-next-line no-console
+      console.error(`[screenshot-on-failure] saved ${target}`);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[screenshot-on-failure] capture failed for "${fullName}": ${e.message}`,
+      );
+    }
+  }
+
+  onRunComplete() {
+    if (this.captures > 0) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[screenshot-on-failure] wrote ${this.captures} failure screenshot(s) to ${this.outputDir}`,
+      );
+    }
+  }
+}
+
+module.exports = ScreenshotOnFailureReporter;

--- a/tests/unit/screenshot-failure-reporter.test.ts
+++ b/tests/unit/screenshot-failure-reporter.test.ts
@@ -5,7 +5,7 @@
  * default export as `any` — it carries no public TypeScript surface.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const ScreenshotOnFailureReporter = require('../integration/screenshot-failure-reporter.cjs');
 
 interface ReporterStatic {

--- a/tests/unit/screenshot-failure-reporter.test.ts
+++ b/tests/unit/screenshot-failure-reporter.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit coverage for the integration-suite screenshot-on-failure reporter.
+ *
+ * The reporter itself is a CommonJS module so we `require` it and treat its
+ * default export as `any` — it carries no public TypeScript surface.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const ScreenshotOnFailureReporter = require('../integration/screenshot-failure-reporter.cjs');
+
+interface ReporterStatic {
+  new (...args: unknown[]): {
+    deviceId: string | null;
+    outputDir: string;
+    captures: number;
+    onTestCaseResult: (
+      test: unknown,
+      result: { status: string; title?: string; ancestorTitles?: string[] },
+    ) => void;
+  };
+  slugify: (s: string) => string;
+}
+
+const Reporter = ScreenshotOnFailureReporter as ReporterStatic;
+
+describe('screenshot-failure-reporter', () => {
+  describe('slugify', () => {
+    test('replaces unsafe characters with underscores', () => {
+      expect(Reporter.slugify('Settings.app › General → About')).toMatch(
+        /^Settings_app_General_About$/,
+      );
+    });
+
+    test('caps length at 120 characters', () => {
+      const long = 'x'.repeat(500);
+      expect(Reporter.slugify(long).length).toBeLessThanOrEqual(120);
+    });
+
+    test('falls back to "unnamed" when the input is empty', () => {
+      expect(Reporter.slugify('')).toBe('unnamed');
+      expect(Reporter.slugify('!!!')).toBe('unnamed');
+    });
+  });
+
+  describe('onTestCaseResult', () => {
+    test('skips when device id is unset', () => {
+      const original = process.env.OSF_DEVICE_ID;
+      delete process.env.OSF_DEVICE_ID;
+      try {
+        const r = new Reporter({ rootDir: process.cwd() });
+        // Should not throw and should not capture.
+        r.onTestCaseResult(null, {
+          status: 'failed',
+          title: 'noop',
+          ancestorTitles: [],
+        });
+        expect(r.captures).toBe(0);
+      } finally {
+        if (original !== undefined) process.env.OSF_DEVICE_ID = original;
+      }
+    });
+
+    test('skips passed and skipped cases even when device id is set', () => {
+      const original = process.env.OSF_DEVICE_ID;
+      process.env.OSF_DEVICE_ID = 'fake-uuid';
+      try {
+        const r = new Reporter({ rootDir: process.cwd() });
+        r.onTestCaseResult(null, {
+          status: 'passed',
+          title: 'pass',
+          ancestorTitles: [],
+        });
+        r.onTestCaseResult(null, {
+          status: 'skipped',
+          title: 'skip',
+          ancestorTitles: [],
+        });
+        expect(r.captures).toBe(0);
+      } finally {
+        if (original === undefined) {
+          delete process.env.OSF_DEVICE_ID;
+        } else {
+          process.env.OSF_DEVICE_ID = original;
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a custom Jest reporter that captures `xcrun simctl io <udid> screenshot` output whenever a test case in the integration suites fails. Closes the **\"테스트 실패 시 스크린샷 캡처 (디버깅용)\"** checkbox from #491.

## Why a Jest reporter (not per-file `afterEach`)

- Reusable across every integration suite without per-file boilerplate.
- Fires even when failures originate inside `beforeEach` / `beforeAll`, where afterEach hooks are skipped.
- Stays quiet for skipped / passed cases — zero artifacts when nothing fails.

## Files

| File | Change |
|---|---|
| `tests/integration/screenshot-failure-reporter.cjs` | **NEW** — CommonJS Jest reporter, no-ops when `OSF_DEVICE_ID` is unset |
| `tests/unit/screenshot-failure-reporter.test.ts` | **NEW** — covers slugify edge cases + skip behavior |
| `package.json` | Wire reporter into `npm run test:integration` via `--reporters=default --reporters=<rootDir>/...` |
| `.gitignore` | Ignore `test-output/` |

## Output layout

```
<repo>/test-output/screenshots/<ISO-timestamp>_<slugified-test-name>.png
```

Override the base directory with the reporter `outputDir` option or `OSF_SCREENSHOT_DIR` env var.

## Verification

End-to-end smoke on a booted iPhone 16 / iOS 26.4 simulator:

```bash
$ npx jest /tmp/test-reporter-smoke.test.js \
    --reporters=default \
    --reporters=tests/integration/screenshot-failure-reporter.cjs
…
[screenshot-on-failure] wrote 1 failure screenshot(s) to /tmp/test-reporter-out
$ ls /tmp/test-reporter-out
2026-04-15T09-39-50-894Z_intentional_failure_to_trigger_screenshot_reporter.png  # 2.6 MB
```

Regression:

```bash
$ npm test
Test Suites: 105 passed, 105 total
Tests:       1547 passed, 1547 total
```

(1542 existing + 5 new unit tests for the reporter.)

## Test plan

- [x] Unit tests cover slugify edge cases and the no-op-without-device-id path
- [x] End-to-end smoke produced a real PNG
- [x] `npm test` green
- [x] No-op when `OSF_DEVICE_ID` is unset, so CI without a simulator is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)