### PR TITLE
feat(sim-hid-bridge): tap-ps subcommand — pointer-service bracket investigation (#491)

### DIFF
--- a/src/native/sim-hid-bridge.swift
+++ b/src/native/sim-hid-bridge.swift
@@ -7,6 +7,7 @@
 //
 // Usage:
 //   sim-hid-bridge <udid> tap    <x> <y> [duration]
+//   sim-hid-bridge <udid> tap-ps <x> <y> [duration] — experimental iOS 26 path
 //   sim-hid-bridge <udid> swipe  <x1> <y1> <x2> <y2> [duration]
 //   sim-hid-bridge <udid> key    <hidUsage> [duration]
 //   sim-hid-bridge <udid> button <home|lock|sound-up|sound-down> [duration]
@@ -66,6 +67,13 @@ func loadCoreSimulator() -> UnsafeMutableRawPointer? {
 // MARK: - Command parsing
 enum Command {
     case tap(x: Double, y: Double, duration: Double?)
+    // tap-ps: experimental path for iOS 26+ — wraps the mouse-down/up
+    // messages with IndigoHIDMessageToCreatePointerService /
+    // IndigoHIDMessageToRemovePointerService. See #491 for the hypothesis
+    // that the screen-lock symptom is caused by iOS 26 no longer routing
+    // mouse NSEvents into UIKit touches unless a pointer HID service has
+    // been registered first.
+    case tapPS(x: Double, y: Double, duration: Double?)
     case swipe(x1: Double, y1: Double, x2: Double, y2: Double, duration: Double?)
     case key(hidUsage: Int, duration: Double?)
     case button(name: String, duration: Double?)
@@ -73,13 +81,17 @@ enum Command {
 enum ParseError: Error { case usage(String) }
 
 func parseCommand(_ argv: [String]) throws -> (udid: String, command: Command) {
-    guard argv.count >= 3 else { throw ParseError.usage("usage: sim-hid-bridge <udid> <tap|swipe|key|button> <args...>\n       sim-hid-bridge diag [udid]") }
+    guard argv.count >= 3 else { throw ParseError.usage("usage: sim-hid-bridge <udid> <tap|tap-ps|swipe|key|button> <args...>\n       sim-hid-bridge diag [udid]") }
     let udid = argv[1], kind = argv[2], rest = Array(argv.dropFirst(3))
     switch kind {
     case "tap":
         guard rest.count >= 2, let x = Double(rest[0]), let y = Double(rest[1]) else {
             throw ParseError.usage("usage: sim-hid-bridge <udid> tap <x> <y> [duration]") }
         return (udid, .tap(x: x, y: y, duration: rest.count >= 3 ? Double(rest[2]) : nil))
+    case "tap-ps":
+        guard rest.count >= 2, let x = Double(rest[0]), let y = Double(rest[1]) else {
+            throw ParseError.usage("usage: sim-hid-bridge <udid> tap-ps <x> <y> [duration]") }
+        return (udid, .tapPS(x: x, y: y, duration: rest.count >= 3 ? Double(rest[2]) : nil))
     case "swipe":
         guard rest.count >= 4, let x1 = Double(rest[0]), let y1 = Double(rest[1]),
               let x2 = Double(rest[2]), let y2 = Double(rest[3]) else {
@@ -95,11 +107,17 @@ func parseCommand(_ argv: [String]) throws -> (udid: String, command: Command) {
         let ok = ["home", "lock", "sound-up", "sound-down"]
         guard ok.contains(rest[0]) else { throw ParseError.usage("unknown button '\(rest[0])'. Allowed: \(ok.joined(separator: ", "))") }
         return (udid, .button(name: rest[0], duration: rest.count >= 2 ? Double(rest[1]) : nil))
-    default: throw ParseError.usage("unknown command '\(kind)'. Allowed: tap, swipe, key, button")
+    default: throw ParseError.usage("unknown command '\(kind)'. Allowed: tap, tap-ps, swipe, key, button")
     }
 }
 func kindString(_ c: Command) -> String {
-    switch c { case .tap: return "tap"; case .swipe: return "swipe"; case .key: return "key"; case .button: return "button" }
+    switch c {
+    case .tap: return "tap"
+    case .tapPS: return "tap-ps"
+    case .swipe: return "swipe"
+    case .key: return "key"
+    case .button: return "button"
+    }
 }
 
 // MARK: - Device Resolution (CoreSimulator private API)
@@ -206,6 +224,48 @@ func execTap(_ h: HID, x: Double, y: Double, dur: Double?, sz: CGSize) -> Bool {
     guard let up = h.mouseMsg(&sp2, &wp2, 0, kMouseUp, sz, 0) else { return false }
     send(h, up); return true
 }
+
+// MARK: - tap-ps: experimental pointer-service-bracketed tap (#491)
+//
+// Hypothesis: iOS 26 stopped synthesising UITouches from bare mouse HID
+// messages unless a pointer service is first registered against the
+// SimDeviceLegacyHIDClient. `IndigoHIDMessageToCreatePointerService` and
+// `IndigoHIDMessageToRemovePointerService` exist in SimulatorKit's
+// exported C surface (confirmed via `sim-hid-bridge diag`) but are not
+// called by the current production bridge.
+//
+// This function best-effort brackets the existing mouse-down/up pair with
+// the pointer-service create/remove messages. Signatures of the C
+// functions are not in any public header; we try the most common shape
+// — `() -> UnsafeMutableRawPointer?` — which matches every other
+// IndigoHIDMessage*For* helper we already resolve. If the real signature
+// differs, the worst case is a benign no-op message and we fall through
+// to the existing mouse path, which is what the unmodified `tap` does
+// anyway.
+typealias NoArgMsgFn = @convention(c) () -> UnsafeMutableRawPointer?
+
+func resolveNoArg(_ handle: UnsafeMutableRawPointer, _ name: String) -> NoArgMsgFn? {
+    guard let sym = dlsym(handle, name) else { return nil }
+    return unsafeBitCast(sym, to: NoArgMsgFn.self)
+}
+
+func execTapPS(_ h: HID, x: Double, y: Double, dur: Double?, sz: CGSize,
+               skHandle: UnsafeMutableRawPointer) -> Bool {
+    let createPS = resolveNoArg(skHandle, "IndigoHIDMessageToCreatePointerService")
+    let removePS = resolveNoArg(skHandle, "IndigoHIDMessageToRemovePointerService")
+    if createPS == nil || removePS == nil {
+        fputs("[sim-hid] tap-ps: pointer-service symbols missing, falling back to bare tap\n", stderr)
+        return execTap(h, x: x, y: y, dur: dur, sz: sz)
+    }
+    if let msg = createPS?() { send(h, msg) }
+    // Give the simulator a moment to wire up the freshly-registered service
+    // before we hand it the first touch. 20ms matches idb's default.
+    Thread.sleep(forTimeInterval: 0.02)
+    let tapped = execTap(h, x: x, y: y, dur: dur, sz: sz)
+    if let msg = removePS?() { send(h, msg) }
+    return tapped
+}
+
 
 func execSwipe(_ h: HID, x1: Double, y1: Double, x2: Double, y2: Double, dur: Double?, sz: CGSize) -> Bool {
     let total = dur ?? 0.3; let steps = 10; let delay = total / Double(steps + 2)
@@ -413,6 +473,7 @@ func run() -> Int32 {
     let ok: Bool
     switch parsed.command {
     case .tap(let x, let y, let d):       ok = execTap(hid, x: x, y: y, dur: d, sz: sz)
+    case .tapPS(let x, let y, let d):     ok = execTapPS(hid, x: x, y: y, dur: d, sz: sz, skHandle: skH)
     case .swipe(let a, let b, let c, let d, let e): ok = execSwipe(hid, x1: a, y1: b, x2: c, y2: d, dur: e, sz: sz)
     case .key(let u, let d):              ok = execKey(hid, usage: u, dur: d)
     case .button(let n, let d):           ok = execButton(hid, name: n, dur: d)


### PR DESCRIPTION
## Summary

Adds an experimental `tap-ps` subcommand to `sim-hid-bridge` that wraps the existing mouse-down/up pair with `IndigoHIDMessageToCreatePointerService` / `IndigoHIDMessageToRemovePointerService` — idb's historical shape for registering a pointer HID service before mouse-synthesised touches.

**The hypothesis under test has been empirically FALSIFIED.** This PR ships the probe tool + the negative-result evidence so follow-up work can skip this avenue.

## Hypothesis

iOS 26 stopped routing bare `IndigoHIDMessageForMouseNSEvent` messages into UITouches unless a pointer service is first registered against `SimDeviceLegacyHIDClient`. If true, bracketing the existing mouse-down/up with pointer-service create/remove should restore taps.

## Empirical result

Live test on iPhone 16 / iOS 26.4 / Xcode 26:
1. `xcrun simctl launch … com.apple.Preferences` → Settings renders (설정 with 일반, 손쉬운 사용, …).
2. `sim-hid-bridge tap-ps <udid> 196 316` → exit 0, JSON `{"ok":true,"kind":"tap-ps",…}`.
3. Simulator state: Settings dismissed, home screen shown — same home-gesture symptom as bare `tap`.

A follow-up A/B with **pixel-in-pixel coordinates** (user points × scale, `sz` = pixels) was also run via an ad-hoc binary — same home-gesture symptom. Both of the "obvious" fixes fail:

| Variant | Result |
|---|---|
| Point input + point sz (post-#551) | ❌ home gesture |
| Pixel input + pixel sz (pre-#551) | ❌ home gesture |
| Point input + point sz + CreatePointerService bracket (this PR) | ❌ home gesture |

**Conclusion**: the Xcode 26 regression is in `IndigoHIDMessageForMouseNSEvent` itself — mouse-NSEvent → UITouch synthesis no longer works regardless of coord units or service-registration bracketing.

## Why ship the probe anyway

`tap-ps` stays in the binary so:
- Future investigators can A/B against production `tap` without rebuilding.
- The symbol-resolution + fall-through scaffolding (`resolveNoArg`, `NoArgMsgFn`) is reusable for the next candidate (`IndigoHIDMessageForPointerEventFromHIDEventRef`).
- The negative-result commit message + this PR are a search-hit for anyone who rediscovers the same hypothesis later.

No production routing change — `getInputBackend()` Tier-1 return stays commented; only `tap-ps` (new subcommand) calls the bracketed path.

## Next step (separate PR)

Switch the tap/swipe path to **`IndigoHIDMessageForPointerEventFromHIDEventRef`** with a manually-constructed `IOHIDEventCreateDigitizerEventWithChildren` payload. That's idb's current (post-Xcode-26) production shape and the only remaining C-symbol candidate that `sim-hid-bridge diag` reports as resolvable on this host. Implementation requires IOKit IOHIDEvent construction, which is a larger delta — scoped as a follow-up rather than mixed in here.

## Test plan

- [x] `swiftc -O src/native/sim-hid-bridge.swift` — clean compile.
- [x] `dist/sim-hid-bridge tap-ps <udid> 196 316` — exit 0, JSON ok:true.
- [x] `dist/sim-hid-bridge tap-ps <udid> 196 316` leaves Settings dismissed (reproduced twice, documented in commit message + this PR body).
- [x] `dist/sim-hid-bridge tap <udid> 196 316` unchanged from current develop (same home-gesture symptom) — the probe does not regress the existing path.

## Depends on

Stacks on #543 / #547 / #551. Commits are cherry-picked so this branch lints + compiles standalone; merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)