### PR TITLE
fix(input): re-enable SimulatorKit HID tap/swipe after #491 resolution

### DIFF
--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -599,8 +599,7 @@ export class HeadlessInputUnavailableError extends Error {
     | 'no-simctl'
     | 'no-webkit'
     | 'webkit-disconnected'
-    | 'headless-only'
-    | 'simhid-gated';
+    | 'headless-only';
   readonly remediation: readonly string[];
 
   constructor(
@@ -614,19 +613,7 @@ export class HeadlessInputUnavailableError extends Error {
             'Ensure a headless backend (simctl, webkit, flutter-vm, simhid) is available.',
             `To allow focus-stealing input, unset ${OPENSAFARI_HEADLESS_ONLY_ENV}.`,
           ] as const)
-        : reason === 'simhid-gated'
-          ? ([
-              'SimulatorKitHID (Tier 1) is probed and cached on this host, but the ' +
-                'tap/swipe return path in `getInputBackend()` is commented out while ' +
-                'issue #491 fixes `IndigoHIDMessageForMouseNSEvent` locking the Simulator ' +
-                'screen on Xcode 26+.',
-              'Track progress: https://github.com/shaun0927/opensafari/issues/491',
-              'Hardware buttons and keyboard input via simhid are unaffected — only ' +
-                'tap/swipe are gated.',
-              `Temporary workaround: set ${OPENSAFARI_ALLOW_FOCUS_INPUT_ENV}=1 to route ` +
-                'tap/swipe through the focus-stealing AppleScript/CGEvent backend until #491 ships.',
-            ] as const)
-          : ([
+        : ([
               "Safari QA: call `set_active_context({ context: 'safari' })` to enable WebKitInputBackend",
               `Native apps: opt in to the CGEvent fallback by setting ${OPENSAFARI_ALLOW_FOCUS_INPUT_ENV}=1 ` +
                 '(WARNING: will move the mouse cursor and bring Simulator.app to the foreground)',
@@ -895,12 +882,12 @@ export async function getInputBackend(
       cachedSimHidBackend = null;
     }
   }
-  // SimHID tap/swipe broken on Xcode 26+ (locks screen). TODO(#491): re-enable.
-  // `cachedSimHidBackend` is read below when picking the error reason, so the
-  // probe is not dead code even while the return path is commented out.
-  // if (cachedSimHidBackend) {
-  //   return cachedSimHidBackend;
-  // }
+  // Tier 1: SimulatorKit HID — re-enabled after #491 resolved the Xcode 26
+  // gesture-recognizer regression. Provides headless coordinate-based
+  // tap/swipe/scroll for any app (native, Flutter, Safari).
+  if (cachedSimHidBackend) {
+    return cachedSimHidBackend;
+  }
 
   // Tier 2: simctl io input (headless, works with any app — Xcode ≤16)
   if (simctlAvailable) {
@@ -942,13 +929,8 @@ export async function getInputBackend(
   // Without explicit opt-in, refuse to return a backend that would move the
   // mouse cursor or steal Simulator focus. See issue #405.
   if (!isFocusInputAllowed()) {
-    // Prefer the 'simhid-gated' reason when the Tier-1 probe succeeded on
-    // this host — pointing users at #491 is more actionable than the
-    // WebKit-oriented 'no-webkit' reason for a native-app call site.
     let reason: HeadlessInputUnavailableError['reason'];
-    if (cachedSimHidBackend) {
-      reason = 'simhid-gated';
-    } else if (!webkitClient) {
+    if (!webkitClient) {
       reason = 'no-webkit';
     } else {
       reason = 'webkit-disconnected';

--- a/tests/unit/native-input-backend.test.ts
+++ b/tests/unit/native-input-backend.test.ts
@@ -640,18 +640,16 @@ describe('getInputBackend', () => {
     }
   });
 
-  // ── simhid-gated reason (issue #491) ────────────────────────────────────
+  // ── SimHID Tier-1 return path (re-enabled after #491 resolution) ───────────
   //
-  // When the Tier-1 SimHID probe succeeds but the return path in
-  // `getInputBackend()` is commented out (see TODO(#491) referencing the
-  // Xcode 26+ screen-lock regression), the thrown error should surface the
-  // #491 link instead of the WebKit-oriented 'no-webkit' reason. We drive
-  // the probe to a non-null backend by enabling the Swift-source candidate
-  // path — that affordance is already gated behind
-  // OPENSAFARI_ALLOW_SWIFT_INTERPRETER=1 and resolves to the in-tree
-  // `src/native/sim-hid-bridge.swift`, so no build step is required.
+  // After #491 resolved the Xcode 26+ gesture-recognizer regression, the
+  // SimHID return path is unconditionally enabled. When the probe succeeds,
+  // `getInputBackend()` must return the SimHID backend directly rather than
+  // falling through to lower tiers or throwing. We drive the probe by enabling
+  // the Swift-source candidate path via OPENSAFARI_ALLOW_SWIFT_INTERPRETER=1,
+  // which resolves to `src/native/sim-hid-bridge.swift` in the source tree.
 
-  describe('simhid-gated reason (issue #491)', () => {
+  describe('SimHID Tier-1 return path (re-enabled after #491)', () => {
     const ALLOW_SWIFT = 'OPENSAFARI_ALLOW_SWIFT_INTERPRETER';
     let originalAllowSwift: string | undefined;
 
@@ -670,31 +668,20 @@ describe('getInputBackend', () => {
       resetInputBackend();
     });
 
-    test('reason is simhid-gated when SimHID probe succeeds and no webkitClient', async () => {
+    test('returns SimHID backend when probe succeeds (no webkitClient)', async () => {
       execMock.mockRejectedValueOnce(new Error('not supported'));
-      try {
-        await getInputBackend(DEVICE);
-        fail('expected HeadlessInputUnavailableError');
-      } catch (err) {
-        const hErr = err as HeadlessInputUnavailableError;
-        expect(hErr.reason).toBe('simhid-gated');
-      }
+      const backend = await getInputBackend(DEVICE);
+      expect(backend.kind).toBe('simhid');
     });
 
-    test('remediation references issue #491 and mentions the ALLOW_FOCUS_INPUT workaround', async () => {
+    test('returns SimHID backend ahead of WebKit when probe succeeds', async () => {
       execMock.mockRejectedValueOnce(new Error('not supported'));
-      try {
-        await getInputBackend(DEVICE);
-        fail('expected HeadlessInputUnavailableError');
-      } catch (err) {
-        const hErr = err as HeadlessInputUnavailableError;
-        expect(hErr.message).toContain('#491');
-        expect(hErr.message).toContain('IndigoHIDMessageForMouseNSEvent');
-        expect(hErr.message).toContain(OPENSAFARI_ALLOW_FOCUS_INPUT_ENV);
-        // The simhid-gated remediation is deliberately longer than the
-        // two-line webkit fallback; assert the minimum shape.
-        expect(hErr.remediation.length).toBeGreaterThanOrEqual(4);
-      }
+      const mockClient = {
+        isConnected: jest.fn().mockReturnValue(true),
+        connect: jest.fn().mockResolvedValue(undefined),
+      } as any;
+      const backend = await getInputBackend(DEVICE, mockClient);
+      expect(backend.kind).toBe('simhid');
     });
   });
 


### PR DESCRIPTION
## Summary

- Re-enables the Tier-1 SimulatorKit HID return path in `getInputBackend()` that was commented out pending the Xcode 26+ gesture-recognizer regression tracked in #491 (now closed)
- Removes the dead `simhid-gated` error-reason branch and its `'simhid-gated'` member from the `HeadlessInputUnavailableError` reason union type, since `cachedSimHidBackend` is now returned before the error path is ever reached
- Updates unit tests: replaces the `simhid-gated` describe block with tests asserting that `getInputBackend()` returns the SimHID backend (kind `'simhid'`) when the probe succeeds, both with and without a WebKit client

Refs: #483, #491, #540

## Test plan

- [x] `npm run build` passes with no new errors
- [x] `npm test` — 1582 tests pass across 108 suites
- [x] `tests/unit/native-input-backend.test.ts` — 76/76 pass, including two new assertions that SimHID is returned as Tier-1 when the probe succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)