### PR TITLE
refactor(ci): extract AppleScript audit-log assertion into a shared script (#540)

### DIFF
--- a/.github/workflows/headless-smoke.yml
+++ b/.github/workflows/headless-smoke.yml
@@ -401,19 +401,7 @@ jobs:
 
       - name: Verify no AppleScript fallback was loaded
         if: always()
-        run: |
-          set -euo pipefail
-          LOG="$HOME/.opensafari/audit.log"
-          if [ ! -f "$LOG" ]; then
-            echo "audit log not present — HEADLESS_ONLY=1 blocks the AppleScript backend at construction time."
-            exit 0
-          fi
-          if grep -q -i 'applescript' "$LOG"; then
-            echo "::error::audit.log references applescript — headless posture violated."
-            grep -n -i 'applescript' "$LOG" | head -20
-            exit 1
-          fi
-          echo "audit log free of applescript references"
+        run: node scripts/assert-no-applescript.js
 
       - name: Capture screenshot on failure
         if: failure()
@@ -560,19 +548,7 @@ jobs:
 
       - name: Verify no AppleScript fallback was loaded
         if: always()
-        run: |
-          set -euo pipefail
-          LOG="$HOME/.opensafari/audit.log"
-          if [ ! -f "$LOG" ]; then
-            echo "audit log not present — HEADLESS_ONLY=1 blocks the AppleScript backend at construction time."
-            exit 0
-          fi
-          if grep -q -i 'applescript' "$LOG"; then
-            echo "::error::audit.log references applescript — headless posture violated."
-            grep -n -i 'applescript' "$LOG" | head -20
-            exit 1
-          fi
-          echo "audit log free of applescript references"
+        run: node scripts/assert-no-applescript.js
 
       - name: Capture screenshot on failure
         if: failure()
@@ -746,19 +722,7 @@ jobs:
 
       - name: Verify no AppleScript fallback was loaded
         if: always()
-        run: |
-          set -euo pipefail
-          LOG="$HOME/.opensafari/audit.log"
-          if [ ! -f "$LOG" ]; then
-            echo "audit log not present — HEADLESS_ONLY=1 blocks the AppleScript backend at construction time."
-            exit 0
-          fi
-          if grep -q -i 'applescript' "$LOG"; then
-            echo "::error::audit.log references applescript — headless posture violated."
-            grep -n -i 'applescript' "$LOG" | head -20
-            exit 1
-          fi
-          echo "audit log free of applescript references"
+        run: node scripts/assert-no-applescript.js
 
       - name: Capture screenshot on failure
         if: failure()

--- a/scripts/assert-no-applescript.js
+++ b/scripts/assert-no-applescript.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Assert that the opensafari audit log does not reference the AppleScript
+// fallback backend. Called from `.github/workflows/headless-smoke.yml` after
+// every live-test job so we fail the CI run the moment a regression smuggles
+// AppleScript back into a headless code path.
+//
+// Resolution order for the log path:
+//   1. `$OPENSAFARI_AUDIT_LOG` env override (for tests / alternate homedirs)
+//   2. `$HOME/.opensafari/audit.log`
+//
+// Exit codes:
+//   0 — log absent (HEADLESS_ONLY=1 blocks construction) OR log has no
+//       `applescript` reference.
+//   1 — log contains a line referencing `applescript` (case-insensitive).
+//       The first 20 offending lines are printed to stderr with line numbers
+//       for quick triage.
+//   2 — unexpected IO error.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const logPath =
+  process.env.OPENSAFARI_AUDIT_LOG ||
+  path.join(os.homedir(), '.opensafari', 'audit.log');
+
+let raw;
+try {
+  raw = fs.readFileSync(logPath, 'utf8');
+} catch (err) {
+  if (err && err.code === 'ENOENT') {
+    console.error(
+      `[assert-no-applescript] ${logPath} not present — HEADLESS_ONLY=1 blocks ` +
+        'the AppleScript backend at construction time.'
+    );
+    process.exit(0);
+  }
+  console.error(
+    `[assert-no-applescript] failed to read ${logPath}: ${err.message}`
+  );
+  process.exit(2);
+}
+
+const needle = /applescript/i;
+const offenders = [];
+const lines = raw.split('\n');
+for (let i = 0; i < lines.length; i++) {
+  if (needle.test(lines[i])) {
+    offenders.push({ lineNumber: i + 1, text: lines[i] });
+    if (offenders.length >= 20) break;
+  }
+}
+
+if (offenders.length === 0) {
+  console.error(
+    `[assert-no-applescript] ${logPath} free of applescript references`
+  );
+  process.exit(0);
+}
+
+console.error(
+  `::error::audit.log references applescript — headless posture violated.`
+);
+for (const hit of offenders) {
+  console.error(`${logPath}:${hit.lineNumber}: ${hit.text}`);
+}
+process.exit(1);

--- a/tests/scripts/assert-no-applescript.test.ts
+++ b/tests/scripts/assert-no-applescript.test.ts
@@ -1,0 +1,80 @@
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/assert-no-applescript.js');
+
+function run(auditLog: string | null): { status: number; stdout: string; stderr: string } {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (auditLog === null) {
+    env.OPENSAFARI_AUDIT_LOG = '/nonexistent/path/audit.log';
+  } else {
+    env.OPENSAFARI_AUDIT_LOG = auditLog;
+  }
+  const result = spawnSync('node', [SCRIPT], { env, encoding: 'utf8' });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+describe('scripts/assert-no-applescript.js', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'assert-no-applescript-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('exits 0 when the audit log is absent', () => {
+    const result = run(null);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toMatch(/not present/);
+  });
+
+  it('exits 0 when the audit log has no applescript reference', () => {
+    const file = path.join(tmpDir, 'clean.log');
+    fs.writeFileSync(
+      file,
+      '{"tool":"app_tap","backendKind":"simhid"}\n{"tool":"navigate","backendKind":"webkit"}\n',
+    );
+    const result = run(file);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toMatch(/free of applescript references/);
+  });
+
+  it('exits 1 and prints offending lines when applescript is mentioned', () => {
+    const file = path.join(tmpDir, 'bad.log');
+    fs.writeFileSync(
+      file,
+      '{"tool":"app_tap","backendKind":"simhid"}\n{"tool":"app_tap","backendKind":"applescript"}\n',
+    );
+    const result = run(file);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/::error::audit\.log references applescript/);
+    expect(result.stderr).toMatch(/"backendKind":"applescript"/);
+  });
+
+  it('matches case-insensitively', () => {
+    const file = path.join(tmpDir, 'mixedcase.log');
+    fs.writeFileSync(file, 'loaded AppleScript backend as a fallback\n');
+    const result = run(file);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/mixedcase\.log:1/);
+  });
+
+  it('caps printed offenders at 20 lines', () => {
+    const file = path.join(tmpDir, 'flood.log');
+    const content = Array.from({ length: 50 }, () => 'applescript').join('\n');
+    fs.writeFileSync(file, content + '\n');
+    const result = run(file);
+    expect(result.status).toBe(1);
+    const offenderLines = result.stderr.split('\n').filter((l) => /flood\.log:\d+:/.test(l));
+    expect(offenderLines).toHaveLength(20);
+  });
+});


### PR DESCRIPTION
## Summary

- New `scripts/assert-no-applescript.js` — reads `\$HOME/.opensafari/audit.log` (or `\$OPENSAFARI_AUDIT_LOG`) and exits non-zero if any line matches `applescript` case-insensitively; absent log is treated as pass (HEADLESS_ONLY=1 blocks construction time).
- `.github/workflows/headless-smoke.yml` — collapses three identical inline bash blocks (Flutter, Native simhid, WebView) into a single `node scripts/assert-no-applescript.js` call per job.
- New `tests/scripts/assert-no-applescript.test.ts` — 5 cases covering all script branches.

Refs: #540

## Why

All three \"Verify no AppleScript fallback was loaded\" steps carried the same 11-line bash. Any future evolution of the assertion (parse JSONL, assert \`backendKind\`, tolerate alternate audit paths) would need to stay in lockstep across three copies. Centralising it is a small DX improvement and unblocks the upcoming \`backendKind\` assertion that lands in a separate PR (unit C).

## Test plan

- [x] \`npx jest tests/scripts/assert-no-applescript.test.ts\` → 5/5 pass.
- [x] Manual: empty log → exit 0. Absent log → exit 0. Log with \`applescript\` → exit 1 with \`::error::\` annotation and offending lines printed.
- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/headless-smoke.yml'))\"\` — YAML still valid after collapse.
- [ ] Scheduled cron run on \`develop\` after merge — three smoke jobs should still gate on AppleScript-free audit logs.

## Compatibility

Semantics match the bash implementation exactly:
- prints the same \`::error::\` annotation string
- prints at most 20 offending lines (previously \`grep -n ... | head -20\`)
- absent log is a pass (identical bash behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)