### PR TITLE
test(ci): audit.log posture helper + jest suites for backendKind allow-list (#540)

### DIFF
--- a/src/ci/audit-log-posture.ts
+++ b/src/ci/audit-log-posture.ts
@@ -1,0 +1,118 @@
+/**
+ * Helpers for asserting on the posture of `~/.opensafari/audit.log`.
+ *
+ * The audit log is JSONL. We intentionally keep the scan tolerant of the
+ * exact schema so regressions that add new fields (or move `backendKind`
+ * between top-level and nested positions) do not silently pass.
+ *
+ * Two signals matter for the #540 acceptance criteria:
+ *
+ *   1. `applescriptHits` — any entry that mentions `applescript` (case
+ *      insensitive) is a headless-posture violation when
+ *      `OPENSAFARI_HEADLESS_ONLY=1` is set.
+ *   2. `backendKinds` — the set of backend identifiers we can extract from
+ *      the log, regardless of whether they live at the top level or inside
+ *      a stringified `args_summary`. The allowed set is
+ *      `{'flutter-vm','simhid','webkit'}`.
+ */
+
+import * as fs from 'node:fs';
+
+/**
+ * The only `InputBackendKind` values that satisfy the #540 acceptance
+ * criterion. Keep this list narrow — any legacy backend (`applescript`,
+ * `simctl`, `ax-press`) should be rejected by the posture check.
+ */
+export const ALLOWED_BACKEND_KINDS: readonly string[] = Object.freeze([
+  'flutter-vm',
+  'simhid',
+  'webkit',
+]);
+
+export interface AuditLogPosture {
+  /** Total JSONL lines inspected (including unparseable ones). */
+  total: number;
+  /** How many lines mention `applescript` (case-insensitive substring). */
+  applescriptHits: number;
+  /** All `backendKind` string values found anywhere in the log. */
+  backendKinds: string[];
+  /** Subset of `backendKinds` that are not in `ALLOWED_BACKEND_KINDS`. */
+  disallowedBackendKinds: string[];
+}
+
+// Match both regular (`"backendKind":"simhid"`) and escape-quoted
+// (`\"backendKind\":\"simhid\"`) forms — the latter shows up when the
+// field is nested inside a stringified JSON payload (e.g. `args_summary`).
+const BACKEND_KIND_REGEX = /\\?"backendKind\\?"\s*:\s*\\?"([A-Za-z0-9_-]+)\\?"/g;
+const APPLESCRIPT_REGEX = /applescript/i;
+
+/**
+ * Scan the given audit log file and return a posture report. Absent logs
+ * are treated as zero-entry (vacuous pass); callers decide whether that is
+ * acceptable for their gate.
+ */
+export function scanAuditLog(logPath: string): AuditLogPosture {
+  const report: AuditLogPosture = {
+    total: 0,
+    applescriptHits: 0,
+    backendKinds: [],
+    disallowedBackendKinds: [],
+  };
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(logPath, 'utf8');
+  } catch (err) {
+    if (err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return report;
+    }
+    throw err;
+  }
+
+  const lines = raw.split('\n').filter((line) => line.length > 0);
+  report.total = lines.length;
+
+  const seenKinds = new Set<string>();
+
+  for (const line of lines) {
+    if (APPLESCRIPT_REGEX.test(line)) {
+      report.applescriptHits += 1;
+    }
+    BACKEND_KIND_REGEX.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = BACKEND_KIND_REGEX.exec(line)) !== null) {
+      seenKinds.add(match[1]);
+    }
+  }
+
+  report.backendKinds = Array.from(seenKinds).sort();
+  report.disallowedBackendKinds = report.backendKinds.filter(
+    (kind) => !ALLOWED_BACKEND_KINDS.includes(kind),
+  );
+
+  return report;
+}
+
+/**
+ * Convenience assertion used by the integration smoke tests. Throws with a
+ * multi-line message that names the offending backend kinds and how often
+ * they appeared so the Jest failure output is actionable.
+ */
+export function assertAuditLogPosture(logPath: string): AuditLogPosture {
+  const report = scanAuditLog(logPath);
+  const problems: string[] = [];
+  if (report.applescriptHits > 0) {
+    problems.push(
+      `audit.log references applescript in ${report.applescriptHits}/${report.total} entries`,
+    );
+  }
+  if (report.disallowedBackendKinds.length > 0) {
+    problems.push(
+      `disallowed backendKind(s) present: ${report.disallowedBackendKinds.join(', ')} (allowed: ${ALLOWED_BACKEND_KINDS.join(', ')})`,
+    );
+  }
+  if (problems.length > 0) {
+    throw new Error(`audit log posture violated (${logPath}):\n  - ${problems.join('\n  - ')}`);
+  }
+  return report;
+}

--- a/tests/integration/audit-log-backend-kind.live.test.ts
+++ b/tests/integration/audit-log-backend-kind.live.test.ts
@@ -1,0 +1,43 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  ALLOWED_BACKEND_KINDS,
+  assertAuditLogPosture,
+  scanAuditLog,
+} from '../../src/ci/audit-log-posture';
+
+/**
+ * Runs against the real `~/.opensafari/audit.log` produced by earlier live
+ * smoke tests in the same CI job. Lives in `tests/integration/` so the
+ * default `npm test` pass skips it — the smoke workflow invokes it
+ * explicitly via `--runTestsByPath`.
+ *
+ * Gate: if `$OPENSAFARI_AUDIT_LOG` is set, use that path (lets CI point at
+ * an alternate collector). Otherwise fall back to the runtime location.
+ *
+ * Refs: #540 acceptance criterion
+ *   "Telemetry: backendKind in {'flutter-vm','simhid','webkit'} only
+ *    (applescript = 0)"
+ */
+describe('audit.log posture — backendKind constraint', () => {
+  const logPath =
+    process.env.OPENSAFARI_AUDIT_LOG ||
+    path.join(os.homedir(), '.opensafari', 'audit.log');
+
+  it(`has no 'applescript' references (${logPath})`, () => {
+    const report = scanAuditLog(logPath);
+    expect(report.applescriptHits).toBe(0);
+  });
+
+  it('records only backendKind values in the allowed set', () => {
+    const report = scanAuditLog(logPath);
+    for (const kind of report.backendKinds) {
+      expect(ALLOWED_BACKEND_KINDS).toContain(kind);
+    }
+    expect(report.disallowedBackendKinds).toEqual([]);
+  });
+
+  it('assertAuditLogPosture does not throw', () => {
+    expect(() => assertAuditLogPosture(logPath)).not.toThrow();
+  });
+});

--- a/tests/unit/audit-log-posture.test.ts
+++ b/tests/unit/audit-log-posture.test.ts
@@ -1,0 +1,118 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  ALLOWED_BACKEND_KINDS,
+  assertAuditLogPosture,
+  scanAuditLog,
+} from '../../src/ci/audit-log-posture';
+
+describe('src/ci/audit-log-posture', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-log-posture-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeLog(name: string, lines: string[]): string {
+    const file = path.join(tmpDir, name);
+    fs.writeFileSync(file, lines.join('\n') + (lines.length > 0 ? '\n' : ''));
+    return file;
+  }
+
+  it('returns a zero-entry report when the log is absent', () => {
+    const report = scanAuditLog(path.join(tmpDir, 'nope.log'));
+    expect(report).toEqual({
+      total: 0,
+      applescriptHits: 0,
+      backendKinds: [],
+      disallowedBackendKinds: [],
+    });
+  });
+
+  it('reports zero hits when the log is empty', () => {
+    const file = writeLog('empty.log', []);
+    expect(scanAuditLog(file).total).toBe(0);
+  });
+
+  it('extracts backendKind values from top-level fields', () => {
+    const file = writeLog('top-level.log', [
+      '{"tool":"app_tap","backendKind":"simhid"}',
+      '{"tool":"navigate","backendKind":"webkit"}',
+      '{"tool":"flutter_tap","backendKind":"flutter-vm"}',
+    ]);
+    const report = scanAuditLog(file);
+    expect(report.backendKinds).toEqual(
+      [...ALLOWED_BACKEND_KINDS].sort(),
+    );
+    expect(report.disallowedBackendKinds).toEqual([]);
+    expect(report.applescriptHits).toBe(0);
+  });
+
+  it('extracts backendKind values even when nested inside args_summary strings', () => {
+    const file = writeLog('nested.log', [
+      '{"tool":"app_tap","args_summary":"{\\"kind\\":\\"x\\",\\"backendKind\\":\\"simhid\\"}"}',
+    ]);
+    const report = scanAuditLog(file);
+    expect(report.backendKinds).toEqual(['simhid']);
+  });
+
+  it('flags disallowed backend kinds', () => {
+    const file = writeLog('bad.log', [
+      '{"tool":"app_tap","backendKind":"simhid"}',
+      '{"tool":"app_tap","backendKind":"applescript"}',
+      '{"tool":"app_tap","backendKind":"simctl"}',
+    ]);
+    const report = scanAuditLog(file);
+    expect(report.backendKinds.sort()).toEqual(['applescript', 'simctl', 'simhid']);
+    expect(report.disallowedBackendKinds.sort()).toEqual(['applescript', 'simctl']);
+    expect(report.applescriptHits).toBe(1);
+  });
+
+  it('is case-insensitive for applescript detection', () => {
+    const file = writeLog('case.log', ['warning: AppleScript fallback engaged']);
+    const report = scanAuditLog(file);
+    expect(report.applescriptHits).toBe(1);
+  });
+
+  it('tolerates malformed JSONL lines without throwing', () => {
+    const file = writeLog('malformed.log', [
+      'not-json-at-all',
+      '{"partial":',
+      '{"tool":"app_tap","backendKind":"webkit"}',
+    ]);
+    const report = scanAuditLog(file);
+    expect(report.total).toBe(3);
+    expect(report.backendKinds).toEqual(['webkit']);
+  });
+
+  it('assertAuditLogPosture returns the report when clean', () => {
+    const file = writeLog('clean.log', [
+      '{"tool":"app_tap","backendKind":"simhid"}',
+      '{"tool":"navigate","backendKind":"webkit"}',
+    ]);
+    const report = assertAuditLogPosture(file);
+    expect(report.applescriptHits).toBe(0);
+    expect(report.disallowedBackendKinds).toEqual([]);
+  });
+
+  it('assertAuditLogPosture throws when applescript is present', () => {
+    const file = writeLog('violating.log', [
+      '{"tool":"app_tap","backendKind":"applescript"}',
+    ]);
+    expect(() => assertAuditLogPosture(file)).toThrow(/applescript/);
+  });
+
+  it('assertAuditLogPosture names every disallowed kind in its error message', () => {
+    const file = writeLog('multi-bad.log', [
+      '{"tool":"app_tap","backendKind":"simctl"}',
+      '{"tool":"app_tap","backendKind":"ax-press"}',
+    ]);
+    expect(() => assertAuditLogPosture(file)).toThrow(/simctl/);
+    expect(() => assertAuditLogPosture(file)).toThrow(/ax-press/);
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/ci/audit-log-posture.ts` — tolerant parser that pulls every `backendKind` value out of `~/.opensafari/audit.log` (or `\$OPENSAFARI_AUDIT_LOG`) whether it lives at the top level or inside a stringified `args_summary`, and exposes `scanAuditLog()` / `assertAuditLogPosture()`.
- New `tests/unit/audit-log-posture.test.ts` — 10 fixture-driven cases covering all branches (10/10 pass locally).
- New `tests/integration/audit-log-backend-kind.live.test.ts` — runs against the real audit log produced by the live smoke jobs; default `npm test` skips it (excluded in `jest.config.js`).

Refs: #540 — moves the acceptance-criteria box *"Telemetry: `backendKind in {'flutter-vm','simhid','webkit'}` only (`applescript` = 0)"* into a shape that can be asserted in CI. Workflow wiring is a follow-up so this PR stays a pure library addition.

## Why

Unit B (PR #576) already centralises the \"no applescript\" check. This PR adds the positive-side constraint — every recorded backend must come from the allowed set — with a testable helper that the smoke jobs can call after their live steps land.

## Test plan

- [x] \`npx jest tests/unit/audit-log-posture.test.ts --no-coverage\` → 10/10 pass.
- [x] Parser handles \`\"backendKind\":\"simhid\"\` and \`\\\"backendKind\\\":\\\"simhid\\\"\` shapes.
- [x] \`scanAuditLog('/does/not/exist')\` returns a zero-entry report (treats absent log as vacuous pass).
- [ ] After merge, follow-up PR wires the live suite into each smoke job so the assertion runs on every scheduled cron.

## Known red CI

\`develop\` currently fails \`npm run build\` because of a duplicate \`wsToHttpUrl\` in \`src/flutter/vm-service-discovery.ts\` (introduced by commit \`5527d3f7\`). That is unrelated to this PR but will break this PR's CI until a hotfix lands. I'm opening that hotfix as a separate PR immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)