### PR TITLE
fix(build): remove duplicate wsToHttpUrl function (#540)

### DIFF
--- a/src/flutter/vm-service-discovery.ts
+++ b/src/flutter/vm-service-discovery.ts
@@ -86,11 +86,6 @@ export function httpToWsUrl(httpUrl: string): string {
   return `${base}/ws`;
 }
 
-export function wsToHttpUrl(wsUrl: string): string {
-  const base = wsUrl.replace(/^ws/, 'http').replace(/\/ws\/?$/, '/');
-  return base.endsWith('/') ? base : `${base}/`;
-}
-
 /**
  * Convert a VM Service WebSocket URL to its HTTP equivalent.
  *


### PR DESCRIPTION
## Summary

\`develop\` is currently failing CI on every subsequent push/PR because commit \`5527d3f7\` accidentally re-declared \`wsToHttpUrl\` in \`src/flutter/vm-service-discovery.ts\`. ts-loader surfaces this as TS2323 + TS2393 during \`npm run build\`, which fails the \`lint\` and \`test\` jobs (both run \`npm run build\` through the \`prepare\` hook — see \`.github/workflows/ci.yml\`).

This PR removes the undocumented duplicate (lines 89-92) and keeps the documented one (lines 99-102).

## Evidence

Before:
\`\`\`
src/flutter/vm-service-discovery.ts(89,17): error TS2323: Cannot redeclare exported variable 'wsToHttpUrl'.
src/flutter/vm-service-discovery.ts(89,17): error TS2393: Duplicate function implementation.
server (webpack 5.105.4) compiled with 5 errors in 3458 ms
\`\`\`

After:
\`\`\`
server (webpack 5.105.4) compiled successfully in 3391 ms
\`\`\`

## Test plan

- [x] \`npm run build:src\` — 0 errors.
- [x] \`npx jest tests/unit/flutter-vm-service.test.ts --no-coverage\` — 21/21 pass.
- [x] \`git grep wsToHttpUrl\` confirms no caller relied on the duplicate's definition (both were byte-identical).

## Why this blocks #540 work

Three in-flight PRs (#575 / #576 / #577) inherit this broken state — their CI will stay red until this lands. Those PRs will rebase after merge.

Refs: #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)