### PR TITLE
ci: add matrix skeleton to headless-smoke jobs (#540)

### DIFF
--- a/.github/workflows/headless-smoke.yml
+++ b/.github/workflows/headless-smoke.yml
@@ -27,7 +27,16 @@ env:
 jobs:
   safari-smoke:
     name: Safari — headless QA audit
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Baseline cell. Additional cells (macos-14, macos-15, macos-16,
+        # Xcode / device / Flutter-version dimensions) land in follow-up PRs
+        # — adding them before the runner images are proven stable would
+        # keep the cron red and reset the 30-day green countdown from #540.
+        # See epic #540 + child issue #574 for the staged rollout plan.
+        os: [macos-latest]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -210,7 +219,11 @@ jobs:
 
   flutter-smoke:
     name: Flutter — headless VM-Service input
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
     timeout-minutes: 35
     env:
       FLUTTER_CHANNEL: 'stable'
@@ -444,7 +457,11 @@ jobs:
 
   native-smoke:
     name: Native — SimulatorKit HID (Tier 1)
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
@@ -600,7 +617,11 @@ jobs:
 
   webview-smoke:
     name: WebView — hybrid native + WebView headless
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
     timeout-minutes: 30
     env:
       FIXTURE_DIR: 'tests/integration/fixtures/webview_sample'


### PR DESCRIPTION
## Summary

Adds a single-cell \`strategy.matrix\` stanza to all four smoke jobs (safari / flutter / native / webview) in \`.github/workflows/headless-smoke.yml\`.

- \`matrix.os: [macos-latest]\` — baseline cell, behaviour unchanged.
- \`fail-fast: false\` — future sibling cells won't kill each other once the matrix grows.
- \`runs-on: \${{ matrix.os }}\` on all four jobs.

Refs: #540 (acceptance-criteria Matrix section) + #574 (cross-Xcode matrix child issue).

## Why

Epic #540's Matrix section requires green runs across macOS 14/15/16, Xcode 15/16/17/26, iPhone 15/16/17/Pro/iPad, and Flutter 3.x/4.x. Each dimension will be rolled out as runner images become available. Landing the skeleton now means the rollout is a one-line append to \`matrix.os\` (or a new matrix dimension) rather than a full job duplication.

## Why one cell now, more later

Adding additional cells (macos-14, macos-15, macos-16) before the runner images are proven stable would keep the cron red and reset the 30-day green countdown in the epic's closing rule. Child issue #574 tracks the staged rollout.

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/headless-smoke.yml'))\"\` — YAML valid.
- [x] \`git diff\` touches only the four job headers; no step logic moved.
- [x] Job \`name:\` fields kept unchanged so any existing branch-protection status-check names still match once the single-cell matrix kicks in (GitHub auto-appends \`(macos-latest)\` only when multiple cells exist).
- [ ] Cron run on \`develop\` after merge — same green signal as today's single-runner job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)