### PR TITLE
perf(metrics): single-syscall memory sampling on timedInput hot path (#554)

### DIFF
--- a/src/metrics/input-telemetry.ts
+++ b/src/metrics/input-telemetry.ts
@@ -14,7 +14,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { InputBackendKind } from '../tools/native-input-backend';
 import { accumulateInputTelemetry } from './input-telemetry-rollup';
-import { recordMemorySample, bytesToMB, isMemoryTrackingEnabled } from './memory-tracker';
+import {
+  recordMemorySample,
+  recordMemorySampleFromRss,
+  bytesToMB,
+  isMemoryTrackingEnabled,
+} from './memory-tracker';
 
 /**
  * Stable set of operations we time. Matches the `InputBackend` interface
@@ -124,11 +129,16 @@ export function emitInputTelemetry(event: InputTelemetryEvent): void {
   } catch {
     // Ditto — rollup failures stay invisible to the caller.
   }
-  // Piggyback a cheap RSS sample on every telemetry tick so peak memory
-  // is observable from `diagnose` without any separate scheduling. The
-  // tracker guards itself with its own env var and try/catch, so this
-  // call cannot destabilise the telemetry path.
-  recordMemorySample();
+  // Piggyback peak-RSS tracking on every telemetry tick so `diagnose`
+  // observes memory without any separate scheduling. When the caller
+  // already sampled a full `process.memoryUsage()` (e.g. `timedInput`
+  // via `sampleMemoryFields`) we reuse its RSS reading to avoid a
+  // redundant syscall on the per-op hot path (#554 microbench budget).
+  if (event.rss_mb !== undefined) {
+    recordMemorySampleFromRss(event.rss_mb * 1_048_576);
+  } else {
+    recordMemorySample();
+  }
   const buf = captureStore.getStore();
   if (buf) buf.push(event);
 }

--- a/src/metrics/memory-tracker.ts
+++ b/src/metrics/memory-tracker.ts
@@ -129,6 +129,32 @@ function maybeRecordTimeSeries(rssBytes: number, nowMs: number): void {
 // ── public API ────────────────────────────────────────────────────────────────
 
 /**
+ * Internal: apply tracker bookkeeping (peak, counter, time-series, soft-cap
+ * watchdog) for a pre-observed RSS reading. Split out of `recordMemorySample`
+ * so hot-path callers that have already produced an RSS number (e.g. from a
+ * shared `process.memoryUsage()` call in `sampleMemoryFields`) can avoid a
+ * second syscall per tool call.
+ */
+function applySample(rss: number, nowMs: number): void {
+  if (rss > peakRssBytes) peakRssBytes = rss;
+  sampleCount += 1;
+
+  maybeRecordTimeSeries(rss, nowMs);
+
+  // Soft-cap watchdog — rate-limited to one warning per 60 s.
+  const capMB = getMemorySoftCapMB();
+  if (capMB !== null) {
+    const rssMB = bytesToMB(rss);
+    if (rssMB > capMB && nowMs - lastCapWarningMs >= CAP_WARNING_COOLDOWN_MS) {
+      lastCapWarningMs = nowMs;
+      console.error(
+        `[memory-watchdog] RSS crossed soft cap: ${rssMB} MB > ${capMB} MB`,
+      );
+    }
+  }
+}
+
+/**
  * Record one RSS sample against the peak tracker. Safe to call from any
  * hot path — constant-time work, never throws. The caller does not need
  * to check the env var first; that gate is applied here.
@@ -142,24 +168,23 @@ function maybeRecordTimeSeries(rssBytes: number, nowMs: number): void {
 export function recordMemorySample(): void {
   if (!isMemoryTrackingEnabled()) return;
   try {
-    const rss = readRssBytes();
-    const nowMs = Date.now();
-    if (rss > peakRssBytes) peakRssBytes = rss;
-    sampleCount += 1;
+    applySample(readRssBytes(), Date.now());
+  } catch {
+    // Memory sampling must never mask an input-backend failure.
+  }
+}
 
-    maybeRecordTimeSeries(rss, nowMs);
-
-    // Soft-cap watchdog — rate-limited to one warning per 60 s.
-    const capMB = getMemorySoftCapMB();
-    if (capMB !== null) {
-      const rssMB = bytesToMB(rss);
-      if (rssMB > capMB && nowMs - lastCapWarningMs >= CAP_WARNING_COOLDOWN_MS) {
-        lastCapWarningMs = nowMs;
-        console.error(
-          `[memory-watchdog] RSS crossed soft cap: ${rssMB} MB > ${capMB} MB`,
-        );
-      }
-    }
+/**
+ * Record a sample using an already-observed RSS reading. Used by callers
+ * (e.g. `timedInput`) that need the full `process.memoryUsage()` breakdown
+ * for telemetry and can feed its `rss` back to the tracker for free,
+ * eliminating a redundant syscall on the per-op hot path.
+ */
+export function recordMemorySampleFromRss(rssBytes: number): void {
+  if (!isMemoryTrackingEnabled()) return;
+  if (!Number.isFinite(rssBytes) || rssBytes < 0) return;
+  try {
+    applySample(rssBytes, Date.now());
   } catch {
     // Memory sampling must never mask an input-backend failure.
   }

--- a/tests/unit/memory-tracker.test.ts
+++ b/tests/unit/memory-tracker.test.ts
@@ -4,6 +4,7 @@
 
 import {
   recordMemorySample,
+  recordMemorySampleFromRss,
   getMemorySnapshot,
   resetMemoryTracker,
   bytesToMB,
@@ -83,19 +84,51 @@ describe('memory-tracker', () => {
     expect(bytesToMB(1_153_434)).toBe(1.1); // 1.1000... → 1.1
   });
 
-  test('recordMemorySample + memory field extraction < 50 µs per call (microbench)', () => {
+  test('recordMemorySampleFromRss ticks peak + sampleCount without a syscall', () => {
+    // No prior samples — tracker starts clean (resetMemoryTracker ran in beforeEach).
+    expect(getMemorySnapshot().sampleCount).toBe(0);
+
+    recordMemorySampleFromRss(10 * 1_048_576);
+    recordMemorySampleFromRss(42 * 1_048_576);
+
+    const snap = getMemorySnapshot();
+    // sampleCount is bumped even though we never called process.memoryUsage.rss().
+    expect(snap.sampleCount).toBe(2);
+    // Peak tracks the larger of the two feeds (42 MB > 10 MB).
+    expect(snap.peakRssBytes).toBeGreaterThanOrEqual(42 * 1_048_576);
+  });
+
+  test('recordMemorySampleFromRss is a no-op for non-finite / negative inputs', () => {
+    recordMemorySampleFromRss(Number.NaN);
+    recordMemorySampleFromRss(-1);
+    recordMemorySampleFromRss(Number.POSITIVE_INFINITY);
+    expect(getMemorySnapshot().sampleCount).toBe(0);
+  });
+
+  test('recordMemorySampleFromRss respects the tracking-disabled kill switch', () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_MEMORY_ENV] = '0';
+    recordMemorySampleFromRss(999 * 1_048_576);
+    // Snapshot bumps peak from the live usage, so we only assert the counter.
+    expect(getMemorySnapshot().sampleCount).toBe(0);
+  });
+
+  test('single-syscall memory sampling + field extraction < 50 µs per call (microbench)', () => {
+    // Mirrors the optimized per-op hot path that `timedInput` exercises when
+    // memory tracking is enabled: ONE `process.memoryUsage()` call feeding
+    // both the telemetry event (rss_mb/heap_used_mb) and the peak tracker
+    // (via `recordMemorySampleFromRss`). This is what the issue #554 budget
+    // (< 50 µs / call) measures — not two independent syscalls.
     const iterations = 10_000;
     const start = process.hrtime.bigint();
     for (let i = 0; i < iterations; i++) {
-      recordMemorySample();
       const usage = process.memoryUsage();
-      // Mirror the same bytesToMB conversions done in timedInput.
+      recordMemorySampleFromRss(usage.rss);
       void bytesToMB(usage.rss);
       void bytesToMB(usage.heapUsed);
     }
     const elapsedNs = Number(process.hrtime.bigint() - start);
     const perCallUs = elapsedNs / iterations / 1_000;
-    // Allow generous headroom for CI machines; the budget is 50 µs / call.
+    // Budget is 50 µs / call per the issue; assert against it directly.
     expect(perCallUs).toBeLessThan(50);
   });
 


### PR DESCRIPTION
## Summary

- Deduplicate `process.memoryUsage()` syscalls on the per-op hot path so the `timedInput` memory sampler stays under the 50 µs budget called out in #554.
- Add `recordMemorySampleFromRss(rssBytes)` in `memory-tracker` for callers that already have a fresh RSS reading (peak / time-series / soft-cap watchdog all reuse a single sample).
- Update `emitInputTelemetry` to take the new path whenever the event already carries `rss_mb`; events without memory fields still call `recordMemorySample()` so non-timedInput paths keep ticking.
- Rewrite the microbench to measure the optimized single-syscall sequence and assert directly against the `< 50 µs` budget.

## Why

The pre-existing microbench exercised two `process.memoryUsage()` / `rss()` syscalls per iteration (one in `sampleMemoryFields`, another in the follow-up `recordMemorySample`). On a loaded macOS host the per-call overhead ran 68–157 µs across 3 independent runs — consistently above the issue #554 budget. Reusing a single sample removes the second syscall and lands us well under budget.

## Checklist item closed

- \`[x]\` **Instrumentation → No measurable latency regression (< 50 µs overhead per call, measured by a microbench)** (#554)

## Test plan

- [x] \`npx jest tests/unit/memory-tracker.test.ts tests/unit/input-telemetry.test.ts tests/unit/input-telemetry-rollup.test.ts tests/unit/diagnose.test.ts\` — 67/67 green (microbench included, previously 1 failing)
- [ ] \`npm run build\` green on CI
- [ ] Peak-tracker behaviour unchanged when \`OPENSAFARI_INPUT_TELEMETRY_MEMORY=0\` is set (new \`recordMemorySampleFromRss\` early-returns via the same kill-switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)