### PR TITLE
fix(flutter): remove duplicate wsToHttpUrl declaration

### DIFF
--- a/src/flutter/vm-service-discovery.ts
+++ b/src/flutter/vm-service-discovery.ts
@@ -86,11 +86,6 @@ export function httpToWsUrl(httpUrl: string): string {
   return `${base}/ws`;
 }
 
-export function wsToHttpUrl(wsUrl: string): string {
-  const base = wsUrl.replace(/^ws/, 'http').replace(/\/ws\/?$/, '/');
-  return base.endsWith('/') ? base : `${base}/`;
-}
-
 /**
  * Convert a VM Service WebSocket URL to its HTTP equivalent.
  *


### PR DESCRIPTION
## Summary

`src/flutter/vm-service-discovery.ts` declared \`wsToHttpUrl\` twice. The uncommented copy at line 89 was a byte-identical clone of the JSDoc-documented one at line 94.

Webpack silently de-duplicates, so \`npm run build\` on a clean cache kept passing, but ts-jest refuses to compile the file:

\`\`\`
src/flutter/vm-service-discovery.ts:89:17 - error TS2323: Cannot redeclare exported variable 'wsToHttpUrl'.
src/flutter/vm-service-discovery.ts:89:17 - error TS2393: Duplicate function implementation.
\`\`\`

Any jest suite whose import graph transitively reaches this module (e.g. the upcoming per-cache survey in #554, which imports \`../flutter/vm-service-client\` → \`./vm-service-discovery\`) fails at the ts-jest transform step.

Remove the bare copy; keep the documented one.

## Test plan

- [x] \`npx jest tests/unit/cache-budget.test.ts tests/unit/diagnose.test.ts tests/unit/memory-tracker.test.ts tests/unit/memory-budget.test.ts tests/unit/input-telemetry.test.ts tests/unit/input-telemetry-rollup.test.ts\` — 83/83 green after this fix (previously 2 suites fail to compile)
- [ ] \`npm run build\` green on CI
- [x] Upstream of this change: unblocks #554 follow-up PRs that add jest coverage for the per-cache budget survey

🤖 Generated with [Claude Code](https://claude.com/claude-code)