### PR TITLE
feat(telemetry): emit _meta._telemetry by default (#595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — `_meta._telemetry` is on by default (#595)
+
+- **Input tool responses now carry `_meta._telemetry` without opt-in.** All 10 MCP input tools (`app_tap`, `app_swipe`, `app_scroll_native`, `app_key_input`, `app_double_tap`, `app_type_text`, `app_tap_element`, `app_type_element`, `app_dismiss_keyboard`, `app_alert_handle`) emit the compact per-call projection (`operation`, `elapsed_ms`, `ok`, `error?`) by default. CI and benchmarking harnesses no longer need to discover and flip `OPENSAFARI_INPUT_TELEMETRY_META=1` after hitting a mystery slowdown — observability is now Pareto-default.
+- **Opt-out preserved** for consumers who care about payload size: set `OPENSAFARI_INPUT_TELEMETRY_META=0` (or `false`) to suppress `_meta._telemetry`. Any other value — including unset — enables it.
+- **Response-size overhead** is ~100 bytes per call (one telemetry record). See `docs/ci-recipes.md` for a paste-able CI recipe.
+
 ### Added — Memory SLO infrastructure (#554)
 
 - **Process-wide memory instrumentation.** `timedInput` now records `{rss_mb, heap_used_mb}` on every input-backend call. The telemetry rollup exposes per-backend `p50_rss_mb` / `p95_rss_mb` / `max_rss_mb` percentiles alongside the existing latency percentiles. Memory fields in tool responses are opt-in via `OPENSAFARI_TELEMETRY_INCLUDE_MEMORY=1`.

--- a/docs/ci-recipes.md
+++ b/docs/ci-recipes.md
@@ -474,10 +474,13 @@ artifacts:
 | `OPENSAFARI_SAVE_FAILURE_SCREENSHOTS` | `1` | Local opt-in for the integration-suite screenshot-on-failure reporter. Auto-detects the booted simulator via `xcrun simctl list devices booted` when `OSF_DEVICE_ID` is unset, so devs can triage a red test locally without also exporting `CI=true`. |
 | `OSF_DEVICE_ID` | Simulator UDID | Explicit simulator target for the screenshot reporter and other integration helpers. Set by CI after booting; dev can use `OPENSAFARI_SAVE_FAILURE_SCREENSHOTS=1` instead to skip the export. |
 | `OSF_SCREENSHOT_DIR` | Directory path | Override base directory for failure screenshots (default `test-output/screenshots/`). |
+| `OPENSAFARI_INPUT_TELEMETRY_META` | `0` / `false` to disable | Controls whether input-tool responses carry `_meta._telemetry` (per-call `elapsed_ms`, `ok`, `operation`). **On by default since 0.5.0** (#595). Set to `0` only when payload size matters and you are not inspecting per-call timing. |
 
 ```bash
 # Recommended CI environment
 export OPENSAFARI_HEADLESS_ONLY=1
+# _meta._telemetry is on by default; uncomment to opt out:
+# export OPENSAFARI_INPUT_TELEMETRY_META=0
 ```
 
 ### QA-ready Flutter build
@@ -510,6 +513,37 @@ xcrun simctl launch --console booted "$(plutil -extract CFBundleIdentifier raw "
 ```
 
 > **Why not `--release`?** The Dart AOT runtime in release mode has no expression compiler, so Tier 0 probes fail and every subsequent tap/swipe degrades to AppleScript (or silently fails under `OPENSAFARI_HEADLESS_ONLY=1`). Profile mode keeps the tree-shaker and AOT-compatible optimisations while preserving the VM Service — the same trade-off that `flutter run --profile` makes for Flutter's own tooling.
+
+### Reading `_meta._telemetry` in CI
+
+Every input-tool response (`app_tap`, `app_swipe`, `app_type_text`, `app_tap_element`, etc.) embeds a compact telemetry projection under `result._meta._telemetry`. Use it to assert on per-call latency without scraping stderr.
+
+```js
+// Node — direct invocation
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+const res = await client.callTool({ name: 'app_tap', arguments: { x: 100, y: 200 } });
+const events = res._meta?._telemetry ?? [];
+for (const e of events) {
+  if (!e.ok) throw new Error(`app_tap failed: ${e.error}`);
+  if (e.elapsed_ms > 500) console.error(`slow tap: ${e.elapsed_ms}ms`);
+}
+```
+
+```yaml
+# GitHub Actions — failing the job when any op exceeds a budget
+- name: Smoke run with latency budget
+  run: |
+    node scripts/run-smoke.mjs > out.json
+    node -e '
+      const r = JSON.parse(require("fs").readFileSync("out.json", "utf8"));
+      const events = (r._meta && r._meta._telemetry) || [];
+      const slow = events.filter(e => e.elapsed_ms > 500);
+      if (slow.length) { console.error("latency budget exceeded", slow); process.exit(1); }
+    '
+```
+
+To suppress the field (e.g., matching legacy golden files), set `OPENSAFARI_INPUT_TELEMETRY_META=0` at the job or step level.
 
 ### JUnit output generation
 

--- a/src/metrics/input-telemetry.ts
+++ b/src/metrics/input-telemetry.ts
@@ -62,13 +62,13 @@ export type InputOperationResult = InputTelemetryEvent;
 export const OPENSAFARI_INPUT_TELEMETRY_ENV = 'OPENSAFARI_INPUT_TELEMETRY';
 
 /**
- * Env var that opts MCP tool responses into the Phase-2 `_telemetry` metadata
- * field. When set to `1` / `true`, each input tool (`app_tap`, `app_swipe`,
- * ...) attaches the captured `InputTelemetryEvent` list under `_meta._telemetry`
- * so clients and CI can assert on `elapsed_ms` without scraping stderr.
+ * Env var that controls the Phase-2 `_telemetry` metadata field on MCP tool
+ * responses. Each input tool (`app_tap`, `app_swipe`, ...) attaches the
+ * captured `InputTelemetryEvent` list under `_meta._telemetry` so clients and
+ * CI can assert on `elapsed_ms` without scraping stderr.
  *
- * Default-off so the field is strictly opt-in and does not inflate payloads
- * for consumers that only care about success/failure.
+ * Default-on since 0.5.0 (issue #595). Set to `0` / `false` to opt out and
+ * suppress the `_telemetry` projection when payload size matters.
  */
 export const OPENSAFARI_INPUT_TELEMETRY_META_ENV = 'OPENSAFARI_INPUT_TELEMETRY_META';
 
@@ -88,7 +88,7 @@ function isTelemetryEnabled(): boolean {
 /** Whether input tool responses should include `_meta._telemetry`. */
 export function isInputTelemetryMetaEnabled(): boolean {
   const value = process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
-  return value === '1' || value === 'true';
+  return value !== '0' && value !== 'false';
 }
 
 /**

--- a/src/tools/native-input-utils.ts
+++ b/src/tools/native-input-utils.ts
@@ -75,9 +75,10 @@ function compactTelemetry(events: InputTelemetryEvent[]): InputTelemetryMeta[] {
 
 /**
  * Build the `_meta` object that input tools include in their response
- * to expose which backend handled the operation. When a list of captured
- * telemetry events is supplied AND `OPENSAFARI_INPUT_TELEMETRY_META=1`, a
- * compact `_telemetry` projection is attached for per-call `elapsed_ms`.
+ * to expose which backend handled the operation. When captured telemetry
+ * events are supplied and the `OPENSAFARI_INPUT_TELEMETRY_META` gate is
+ * enabled (default on since 0.5.0; opt out with `=0`/`=false`), a compact
+ * `_telemetry` projection is attached for per-call `elapsed_ms`.
  */
 export function buildInputMeta(
   backend: InputBackend,
@@ -108,9 +109,10 @@ export function buildInputMeta(
 
 /**
  * Run a backend operation and return its result plus a ready-to-embed
- * `_meta` object. When `OPENSAFARI_INPUT_TELEMETRY_META=1` the operation is
- * wrapped in a telemetry capture scope and the resulting events land under
- * `_meta._telemetry`. Otherwise the operation runs directly (zero overhead).
+ * `_meta` object. When the `OPENSAFARI_INPUT_TELEMETRY_META` gate is enabled
+ * (default on since 0.5.0) the operation is wrapped in a telemetry capture
+ * scope and the resulting events land under `_meta._telemetry`. Setting the
+ * env var to `0` / `false` runs the operation directly (zero overhead).
  *
  * This is the one-line integration path for MCP input tools: they call the
  * helper instead of invoking the backend method by hand, and the `_meta`

--- a/tests/unit/app-scroll-native.test.ts
+++ b/tests/unit/app-scroll-native.test.ts
@@ -69,7 +69,9 @@ describe('app_scroll_native', () => {
     expect(body.status).toBe('scrolled');
     expect(body.direction).toBe('up');
     expect(body.backend).toBe('simctl');
-    expect(body._meta).toEqual({ backendKind: 'simctl', headless: true, deviceId: DEVICE_ID });
+    expect(body._meta).toEqual(
+      expect.objectContaining({ backendKind: 'simctl', headless: true, deviceId: DEVICE_ID }),
+    );
   });
 
   it('scrolls down with correct simctl args', async () => {

--- a/tests/unit/input-telemetry.test.ts
+++ b/tests/unit/input-telemetry.test.ts
@@ -231,7 +231,7 @@ describe('input-telemetry / meta opt-in flag', () => {
     delete process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
   });
 
-  test.each(['1', 'true'])(
+  test.each(['1', 'true', 'yes', ''])(
     'isInputTelemetryMetaEnabled returns true for OPENSAFARI_INPUT_TELEMETRY_META=%s',
     (value) => {
       process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = value;
@@ -239,13 +239,13 @@ describe('input-telemetry / meta opt-in flag', () => {
     },
   );
 
-  test('is false by default (opt-in)', () => {
+  test('is true by default (opt-out since 0.5.0, #595)', () => {
     delete process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
-    expect(isInputTelemetryMetaEnabled()).toBe(false);
+    expect(isInputTelemetryMetaEnabled()).toBe(true);
   });
 
-  test.each(['0', 'false', 'yes', ''])(
-    'is false for OPENSAFARI_INPUT_TELEMETRY_META=%s (strict)',
+  test.each(['0', 'false'])(
+    'is false for OPENSAFARI_INPUT_TELEMETRY_META=%s (explicit opt-out)',
     (value) => {
       process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = value;
       expect(isInputTelemetryMetaEnabled()).toBe(false);

--- a/tests/unit/native-input-utils.test.ts
+++ b/tests/unit/native-input-utils.test.ts
@@ -52,7 +52,7 @@ describe('runInputOp', () => {
     delete process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
   });
 
-  test('omits _telemetry from meta by default (opt-in not set)', async () => {
+  test('attaches _telemetry from meta by default (opt-out since 0.5.0, #595)', async () => {
     const backend = makeBackend('webkit');
     const { meta } = await runInputOp(backend, 'UDID', () =>
       backend.tap('UDID', 10, 20),
@@ -60,6 +60,17 @@ describe('runInputOp', () => {
     expect(meta.backendKind).toBe('webkit');
     expect(meta.headless).toBe(true);
     expect(meta.deviceId).toBe('UDID');
+    expect(Array.isArray(meta._telemetry)).toBe(true);
+    expect(meta._telemetry).toHaveLength(1);
+    expect(meta._telemetry![0].operation).toBe('tap');
+  });
+
+  test('omits _telemetry when OPENSAFARI_INPUT_TELEMETRY_META=0 (explicit opt-out)', async () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = '0';
+    const backend = makeBackend('webkit');
+    const { meta } = await runInputOp(backend, 'UDID', () =>
+      backend.tap('UDID', 10, 20),
+    );
     expect(meta._telemetry).toBeUndefined();
   });
 
@@ -116,8 +127,8 @@ describe('runInputOp', () => {
     expect(buildInputMeta(makeBackend('flutter-vm'), 'D').headless).toBe(true);
   });
 
-  test('buildInputMeta ignores telemetry events when opt-in is off', () => {
-    delete process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV];
+  test('buildInputMeta ignores telemetry events when explicitly opted out', () => {
+    process.env[OPENSAFARI_INPUT_TELEMETRY_META_ENV] = '0';
     const backend = makeBackend('webkit');
     const meta = buildInputMeta(backend, 'UDID', [
       {


### PR DESCRIPTION
## Summary

- Flip `OPENSAFARI_INPUT_TELEMETRY_META` from opt-in to opt-out — `_meta._telemetry` now ships in every input-tool response by default.
- Preserve an explicit opt-out (`OPENSAFARI_INPUT_TELEMETRY_META=0` / `false`) for payload-sensitive consumers.
- Ship a paste-able CI recipe (GitHub Actions + direct Node) under `docs/ci-recipes.md` plus an env-var table entry.
- Update `CHANGELOG.md` `[Unreleased]` with the default change.

## Why

Per the issue body, CI teams were writing ad-hoc timing wrappers because the default-off metric was discovered only after hitting a mystery slowdown. Response-size overhead is ~100 bytes/call — observability-by-default is the better Pareto.

## Behavior change

| Env value | Behavior |
|---|---|
| unset | **`_meta._telemetry` present** (new default) |
| `1` / `true` / any non-opt-out string | `_meta._telemetry` present |
| `0` / `false` | `_meta._telemetry` omitted (explicit opt-out) |

## Test plan

- [x] `npx jest tests/unit/input-telemetry.test.ts tests/unit/native-input-utils.test.ts` — 26/26 passing (inverted default-behavior tests, added explicit opt-out coverage).
- [x] `npx tsc --noEmit` clean.
- [ ] CI on this PR confirms no regressions in the broader suite.

## Related

- Closes #595
- Builds on #502 (structured telemetry epic), #528 (`_telemetry` metadata), #544 (latency rollup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)