### PR TITLE
feat(dx): local opt-in for screenshot-on-failure reporter (#598)

### DIFF
--- a/docs/ci-recipes.md
+++ b/docs/ci-recipes.md
@@ -471,6 +471,9 @@ artifacts:
 | `OPENSAFARI_HEADLESS_ONLY` | `1` | Block AppleScript/CGEvent fallback. Throws `HeadlessInputUnavailableError` instead of moving the physical mouse cursor. **Always set to `1` in CI.** |
 | `OPENSAFARI_PROXY_PORT` | Port number (default `9322`) | Override WebKit proxy port when the default is already in use. |
 | `OPENSAFARI_ALLOW_FOCUS_INPUT` | `1` | Re-enable focus-stealing input (for non-headless local runs only — never set in CI). |
+| `OPENSAFARI_SAVE_FAILURE_SCREENSHOTS` | `1` | Local opt-in for the integration-suite screenshot-on-failure reporter. Auto-detects the booted simulator via `xcrun simctl list devices booted` when `OSF_DEVICE_ID` is unset, so devs can triage a red test locally without also exporting `CI=true`. |
+| `OSF_DEVICE_ID` | Simulator UDID | Explicit simulator target for the screenshot reporter and other integration helpers. Set by CI after booting; dev can use `OPENSAFARI_SAVE_FAILURE_SCREENSHOTS=1` instead to skip the export. |
+| `OSF_SCREENSHOT_DIR` | Directory path | Override base directory for failure screenshots (default `test-output/screenshots/`). |
 
 ```bash
 # Recommended CI environment

--- a/tests/integration/screenshot-failure-reporter.cjs
+++ b/tests/integration/screenshot-failure-reporter.cjs
@@ -6,8 +6,11 @@
  * Activation:
  *   - Pass `--reporters=default --reporters=<path>/screenshot-failure-reporter.cjs`
  *     to jest. The `npm run test:integration` script wires this up by default.
- *   - The reporter no-ops when `OSF_DEVICE_ID` is unset (CI without a booted
- *     simulator) or when the booted device cannot be probed.
+ *   - The reporter no-ops when no iOS Simulator device id is resolvable — either
+ *     via `OSF_DEVICE_ID` (set explicitly by CI or the dev) or via the local
+ *     opt-in `OPENSAFARI_SAVE_FAILURE_SCREENSHOTS=1`, which auto-detects a
+ *     booted simulator through `xcrun simctl list devices booted` so the dev
+ *     does not have to mirror CI env just to triage a red test locally.
  *
  * Output:
  *   - Default: `<repo>/test-output/screenshots/<ISO-timestamp>_<sanitised-test-name>.png`
@@ -35,7 +38,34 @@ class ScreenshotOnFailureReporter {
       process.env.OSF_SCREENSHOT_DIR ||
       path.resolve(cwd, 'test-output', 'screenshots');
     this.deviceId = process.env.OSF_DEVICE_ID || null;
+    this.forced = process.env.OPENSAFARI_SAVE_FAILURE_SCREENSHOTS === '1';
+    // Local opt-in convenience: if the dev asked for failure screenshots but
+    // hasn't exported a device id, find the booted simulator ourselves. Keeps
+    // `CI=true` / `OSF_DEVICE_ID=…` as the CI path and this flag as the strictly
+    // additive local path — neither side effects the other.
+    if (!this.deviceId && this.forced) {
+      this.deviceId = ScreenshotOnFailureReporter.detectBootedDevice();
+    }
     this.captures = 0;
+  }
+
+  static detectBootedDevice() {
+    try {
+      const raw = execFileSync(
+        'xcrun',
+        ['simctl', 'list', 'devices', 'booted', '-j'],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 5_000 },
+      );
+      const parsed = JSON.parse(raw);
+      for (const devices of Object.values(parsed.devices || {})) {
+        for (const dev of devices || []) {
+          if (dev && dev.udid) return dev.udid;
+        }
+      }
+    } catch {
+      // Swallow: absence of xcrun / booted devices means "nothing to do".
+    }
+    return null;
   }
 
   /**

--- a/tests/unit/screenshot-failure-reporter.test.ts
+++ b/tests/unit/screenshot-failure-reporter.test.ts
@@ -13,12 +13,36 @@ interface ReporterStatic {
     deviceId: string | null;
     outputDir: string;
     captures: number;
+    forced: boolean;
     onTestCaseResult: (
       test: unknown,
       result: { status: string; title?: string; ancestorTitles?: string[] },
     ) => void;
   };
   slugify: (s: string) => string;
+  detectBootedDevice: () => string | null;
+}
+
+function withEnv<K extends string>(
+  key: K,
+  value: string | undefined,
+  fn: () => void,
+): void {
+  const original = process.env[key];
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+  try {
+    fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
 }
 
 const Reporter = ScreenshotOnFailureReporter as ReporterStatic;
@@ -61,9 +85,7 @@ describe('screenshot-failure-reporter', () => {
     });
 
     test('skips passed and skipped cases even when device id is set', () => {
-      const original = process.env.OSF_DEVICE_ID;
-      process.env.OSF_DEVICE_ID = 'fake-uuid';
-      try {
+      withEnv('OSF_DEVICE_ID', 'fake-uuid', () => {
         const r = new Reporter({ rootDir: process.cwd() });
         r.onTestCaseResult(null, {
           status: 'passed',
@@ -76,13 +98,69 @@ describe('screenshot-failure-reporter', () => {
           ancestorTitles: [],
         });
         expect(r.captures).toBe(0);
-      } finally {
-        if (original === undefined) {
-          delete process.env.OSF_DEVICE_ID;
-        } else {
-          process.env.OSF_DEVICE_ID = original;
-        }
-      }
+      });
+    });
+  });
+
+  describe('OPENSAFARI_SAVE_FAILURE_SCREENSHOTS opt-in', () => {
+    test('force flag triggers booted-device detection when OSF_DEVICE_ID is unset', () => {
+      const detect = jest
+        .spyOn(Reporter, 'detectBootedDevice')
+        .mockReturnValue('auto-detected-uuid');
+      withEnv('OSF_DEVICE_ID', undefined, () => {
+        withEnv('OPENSAFARI_SAVE_FAILURE_SCREENSHOTS', '1', () => {
+          const r = new Reporter({ rootDir: process.cwd() });
+          expect(r.forced).toBe(true);
+          expect(r.deviceId).toBe('auto-detected-uuid');
+          expect(detect).toHaveBeenCalledTimes(1);
+        });
+      });
+      detect.mockRestore();
+    });
+
+    test('force flag defers to an explicit OSF_DEVICE_ID when both are set', () => {
+      const detect = jest.spyOn(Reporter, 'detectBootedDevice');
+      withEnv('OSF_DEVICE_ID', 'explicit-uuid', () => {
+        withEnv('OPENSAFARI_SAVE_FAILURE_SCREENSHOTS', '1', () => {
+          const r = new Reporter({ rootDir: process.cwd() });
+          expect(r.forced).toBe(true);
+          expect(r.deviceId).toBe('explicit-uuid');
+          expect(detect).not.toHaveBeenCalled();
+        });
+      });
+      detect.mockRestore();
+    });
+
+    test('absence of the flag leaves detection dormant', () => {
+      const detect = jest.spyOn(Reporter, 'detectBootedDevice');
+      withEnv('OSF_DEVICE_ID', undefined, () => {
+        withEnv('OPENSAFARI_SAVE_FAILURE_SCREENSHOTS', undefined, () => {
+          const r = new Reporter({ rootDir: process.cwd() });
+          expect(r.forced).toBe(false);
+          expect(r.deviceId).toBeNull();
+          expect(detect).not.toHaveBeenCalled();
+        });
+      });
+      detect.mockRestore();
+    });
+
+    test('flag without a booted simulator still no-ops on failure', () => {
+      const detect = jest
+        .spyOn(Reporter, 'detectBootedDevice')
+        .mockReturnValue(null);
+      withEnv('OSF_DEVICE_ID', undefined, () => {
+        withEnv('OPENSAFARI_SAVE_FAILURE_SCREENSHOTS', '1', () => {
+          const r = new Reporter({ rootDir: process.cwd() });
+          expect(r.deviceId).toBeNull();
+          r.onTestCaseResult(null, {
+            status: 'failed',
+            title: 'red',
+            ancestorTitles: [],
+          });
+          expect(r.captures).toBe(0);
+        });
+      });
+      detect.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `OPENSAFARI_SAVE_FAILURE_SCREENSHOTS=1` as a dedicated local opt-in for the integration-suite screenshot-on-failure reporter, so devs can reproduce failure artifacts without exporting `CI=true` (which carries unrelated side effects such as disabling chalk colours).
- When the flag is set and `OSF_DEVICE_ID` is unset, the reporter auto-detects the booted simulator via `xcrun simctl list devices booted -j`. Explicit `OSF_DEVICE_ID` always wins; the flag never overrides the CI path.
- Documents the flag (plus neighbouring `OSF_DEVICE_ID` / `OSF_SCREENSHOT_DIR` knobs) in `docs/ci-recipes.md`.

## Test plan
- [x] `npm test` → 1650/1650 pass locally
- [x] New unit tests cover: flag-triggered auto-detect, flag yielding to an explicit device id, dormant detection when the flag is unset, and no-op capture when the flag is on but no simulator is booted.
- [x] `artifacts/` path already covered by existing `test-output/` gitignore rule.

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)