### PR TITLE
docs(readme): split Xcode 26+ row into element-targeted vs coordinate (#600)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ OpenSafari runs fully headless on CI — no display server, no mouse focus, no `
 | Safari (Web) | ✅ | ✅ | ✅ | WebKit Remote Debug |
 | Flutter App | ✅ | ✅ | ✅ | FlutterVMInputBackend |
 | Native iOS App (Xcode ≤ 16) | ✅ | ✅ | ✅ | SimulatorKitHID (Tier 1) / `simctl` |
-| Native iOS App (Xcode 26+) | ✅ | ⚠️ Partial | ⚠️ | Keys/buttons headless via SimHID; tap/swipe pending — see [#491](https://github.com/shaun0927/opensafari/issues/491) |
+| Native iOS App (Xcode 26+, element-targeted) | ✅ | ✅ | ✅ | AX-press (Tier 1.5) for `app_tap_element` / `app_type_element` when the element advertises `AXPress` — see [docs/headless-architecture.md](docs/headless-architecture.md) |
+| Native iOS App (Xcode 26+, coordinate `app_tap({x,y})`) | ✅ | ⚠️ Partial | ⚠️ | Keys/buttons headless via SimHID; raw coordinate tap/swipe falls through to AppleScript fallback — see [#491](https://github.com/shaun0927/opensafari/issues/491) |
 | WebView in Native | ✅ | ⚠️ Partial | ⚠️ | WebKit + Native |
 
 > ✅ Supported and stable. ⚠️ Partially supported — see linked docs for current status and limitations.
@@ -52,8 +53,8 @@ OpenSafari runs fully headless on CI — no display server, no mouse focus, no `
 
 |  | OpenSafari | Appium | idb | XCUITest |
 |---|:---:|:---:|:---:|:---:|
-| **Headless native input** (no mouse focus, no `Simulator.app` activation) | **⚠️ SimulatorKit HID** (keys/buttons on Xcode 26+; tap/swipe pending [#491](https://github.com/shaun0927/opensafari/issues/491)) | ❌ ([XCUI focus](https://appium.io/docs/en/2.0/ecosystem/drivers/)) | ✅ `FBSimulatorHID` | ❌ |
-| **Works on Xcode 26+** (after `simctl io input` removal) | ⚠️ Safari & Flutter fully; native tap/swipe pending | ⚠️ driver-dependent | ✅ | ✅ |
+| **Headless native input** (no mouse focus, no `Simulator.app` activation) | **✅ AX-press + SimulatorKit HID** (element-targeted tap & keys/buttons headless on Xcode 26+; coordinate-only tap/swipe pending [#491](https://github.com/shaun0927/opensafari/issues/491)) | ❌ ([XCUI focus](https://appium.io/docs/en/2.0/ecosystem/drivers/)) | ✅ `FBSimulatorHID` | ❌ |
+| **Works on Xcode 26+** (after `simctl io input` removal) | ✅ Safari, Flutter, and element-targeted native taps; ⚠️ coordinate-only native tap/swipe pending | ⚠️ driver-dependent | ✅ | ✅ |
 | **Flutter native taps** (no OS-level input) | ✅ Dart VM `PointerDataPacket` | ⚠️ 3rd-party plugin | ❌ | ❌ |
 | **MCP / LLM integration** | ✅ native | ❌ | ❌ | ❌ |
 | **Private API dependency** | SimulatorKit (documented, sentinel-guarded) | UIAutomation / XCUI | SimulatorKit | none |


### PR DESCRIPTION
Closes #600.

## Summary
- Replace the single `Native iOS App (Xcode 26+) — ⚠ Partial` row in the README "Headless Capabilities" table with two explicit rows:
  - **Element-targeted** (`app_tap_element` / `app_type_element`) — ✅ headless via Tier 1.5 AX-press
  - **Coordinate** (`app_tap({x,y})`, `app_swipe(...)`) — ⚠ partial, falls through to AppleScript fallback ([#491](https://github.com/shaun0927/opensafari/issues/491))
- Update the "Headless input vs other iOS automation tools" comparison rows so the AX-press capability is no longer hidden behind a single ⚠ glyph.

## Why
The previous single ⚠ row predates the Tier-1.5 AX-press shipment in v0.4.9 (#552). New readers were scanning the table, seeing one ⚠, and concluding the entire Xcode 26+ story was broken — when in fact element-targeted automation (the common case with proper `Semantics`) is fully headless today.

`docs/headless-architecture.md` already mirrors the split in its scenario matrix (rows for "Xcode 26+, element-targeted" → ax-press and "Xcode 26+, coordinate-only tap/swipe" → AppleScript). No further change needed there.

## Pre-Deploy Checklist
- [x] README table renders correctly (markdown table syntax preserved)
- [x] `docs/headless-architecture.md` already mirrors the split (rows 144–148 differentiate element-targeted vs coordinate-only)
- [x] Links back to #491 + AX-press / headless-architecture doc retained
- [ ] `npm run docs:check` — script does not exist in package.json (no-op)

## Post-Deploy Validation Checklist
- [ ] Spot-check that new contributors can disambiguate support levels from a cold read
- [ ] No broken anchors from other docs that linked the old single row (no anchor existed — row was unanchored)
- [ ] README front-matter unchanged

## Related
- #492 (prior doc adjustment), #537, #491, #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)