### PR TITLE
fix(webview): bundle-aware target classification (#592)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -83,6 +83,15 @@ Reset app state: terminate, reset privacy permissions, uninstall. The app must b
 - **Output:** `{ reset: boolean, bundleId, deviceId, steps: string[] }`
 - **Steps:** `terminated` → `privacy_reset` → `uninstalled` (each step proceeds independently)
 
+#### app_webview_connect
+Detect WebView targets inside a running native app and list available ones.
+- **Input:** `{ bundleId?: string, deviceId?: string }`
+- **Output:** `{ deviceId, targets: [{ id, title, url, type, classificationReason }], count }`
+- **`classificationReason`** values: `bundle_match` | `proxy_type` | `url_scheme`
+  - `bundle_match` — target matched via `bundleId` parameter (metadata fields or title/url substring). When `bundleId` is provided, HTTPS WebViews such as payment-return pages or OAuth callbacks are promoted from `safari` to `webview` classification via this reason.
+  - `proxy_type` — proxy-supplied `type` field on the target determined classification (e.g. `type: 'WebView'` overrides URL-scheme heuristics).
+  - `url_scheme` — fallback heuristic: non-http(s) schemes → `webview`; http(s) or empty/about:blank → `safari`.
+
 ### Advanced Tools (Tier 2)
 
 inspect, wait_for, long_press, swipe, press, dismiss_keyboard, select_option, device_list, device_rotate, appearance_toggle

--- a/src/tools/app-webview-connect.ts
+++ b/src/tools/app-webview-connect.ts
@@ -6,23 +6,73 @@ import { getSharedProxy } from '../simulator/proxy';
 
 const DEFAULT_PROXY_HOST = 'localhost';
 
+type ClassificationReason = 'bundle_match' | 'proxy_type' | 'url_scheme';
+type TargetType = 'safari' | 'webview';
+
+interface ClassificationResult {
+  type: TargetType;
+  reason: ClassificationReason;
+}
+
+interface ListTarget {
+  id: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+  type?: string;
+  appId?: string;
+  bundleId?: string;
+  app_id?: string;
+}
+
 /**
  * Determine whether a target looks like a Safari browser tab vs a native app WebView.
- * Safari targets typically load http/https URLs and have titles like "Safari" or blank/about.
- * WebView targets often have app-specific schemes or titles tied to app bundle identifiers.
+ *
+ * Priority order (first match wins):
+ * 1. bundle_match — ownerBundleId matches target metadata (appId/bundleId/app_id fields,
+ *    or title/url substring). Classifies as webview.
+ * 2. proxy_type — target has a `type` field from the proxy. Maps safari/mobilesafari →
+ *    safari; any string containing "webview" → webview.
+ * 3. url_scheme — fallback heuristic: empty/about:blank → safari; non-http(s) → webview;
+ *    http(s) → safari.
  */
-function classifyTarget(target: { url: string; title: string; type?: string }): 'safari' | 'webview' {
-  const url = target.url ?? '';
-  // Explicit type hint from proxy
-  if (target.type) {
-    if (target.type.toLowerCase().includes('safari')) return 'safari';
-    if (target.type.toLowerCase().includes('webview')) return 'webview';
+function classifyTarget(
+  target: ListTarget,
+  ownerBundleId?: string,
+): ClassificationResult {
+  // 1. bundle_match
+  if (ownerBundleId) {
+    const lower = ownerBundleId.toLowerCase();
+    const metadataFields = [target.appId, target.bundleId, target.app_id];
+    const metadataMatch = metadataFields.some(
+      (field) => field !== undefined && field.toLowerCase() === lower,
+    );
+    const substringMatch =
+      target.title.toLowerCase().includes(lower) ||
+      target.url.toLowerCase().includes(lower);
+    if (metadataMatch || substringMatch) {
+      return { type: 'webview', reason: 'bundle_match' };
+    }
   }
-  // about:blank or empty URL — likely Safari new tab
-  if (!url || url === 'about:blank') return 'safari';
-  // file:// or custom scheme — WebView
-  if (!url.startsWith('http://') && !url.startsWith('https://')) return 'webview';
-  return 'safari';
+
+  // 2. proxy_type
+  if (target.type) {
+    const t = target.type.toLowerCase();
+    if (t === 'safari' || t === 'mobilesafari') {
+      return { type: 'safari', reason: 'proxy_type' };
+    }
+    if (t.includes('webview')) {
+      return { type: 'webview', reason: 'proxy_type' };
+    }
+  }
+
+  // 3. url_scheme fallback
+  const url = target.url ?? '';
+  if (!url || url === 'about:blank') return { type: 'safari', reason: 'url_scheme' };
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    return { type: 'webview', reason: 'url_scheme' };
+  }
+  return { type: 'safari', reason: 'url_scheme' };
 }
 
 export function registerAppWebviewConnectTool(server: MCPServer): void {
@@ -66,7 +116,7 @@ export function registerAppWebviewConnectTool(server: MCPServer): void {
       }
 
       // List all targets from ios-webkit-debug-proxy
-      let targets: Array<{ id: string; title: string; url: string; webSocketDebuggerUrl: string; type?: string }>;
+      let targets: ListTarget[];
       try {
         targets = await (client as any).listTargets?.() ?? [];
       } catch (err) {
@@ -77,24 +127,31 @@ export function registerAppWebviewConnectTool(server: MCPServer): void {
         };
       }
 
-      // Classify and filter targets
-      const classified = targets.map((t) => ({
-        id: t.id,
-        title: t.title,
-        url: t.url,
-        webSocketDebuggerUrl: t.webSocketDebuggerUrl,
-        type: classifyTarget(t),
-      }));
+      // Classify all targets
+      const classified = targets.map((t) => {
+        const { type, reason } = classifyTarget(t, bundleId);
+        return {
+          id: t.id,
+          title: t.title,
+          url: t.url,
+          webSocketDebuggerUrl: t.webSocketDebuggerUrl,
+          type,
+          classificationReason: reason,
+        };
+      });
 
-      // Filter to WebView targets only; optionally filter by bundleId in title/url
-      let webviewTargets = classified.filter((t) => t.type === 'webview');
-      if (bundleId) {
-        webviewTargets = webviewTargets.filter(
-          (t) =>
-            t.title.toLowerCase().includes(bundleId.toLowerCase()) ||
-            t.url.toLowerCase().includes(bundleId.toLowerCase()),
+      // Keep WebView targets only. When bundleId is provided, further restrict to targets
+      // that either matched via bundle_match (already promoted) OR contain the bundleId
+      // substring in title/url (backward-compatible filter for non-HTTPS webviews).
+      const webviewTargets = classified.filter((t) => {
+        if (t.type !== 'webview') return false;
+        if (!bundleId) return true;
+        return (
+          t.classificationReason === 'bundle_match' ||
+          t.title.toLowerCase().includes(bundleId.toLowerCase()) ||
+          t.url.toLowerCase().includes(bundleId.toLowerCase())
         );
-      }
+      });
 
       const result = {
         deviceId: resolvedDeviceId,

--- a/tests/unit/app-webview-connect.test.ts
+++ b/tests/unit/app-webview-connect.test.ts
@@ -1,7 +1,7 @@
 import { MCPServer, setWebKitClient } from '../../src/mcp-server';
 import { registerAppWebviewConnectTool } from '../../src/tools/app-webview-connect';
 
-function createMockClient(targets: Array<{ id: string; title: string; url: string; webSocketDebuggerUrl: string; type?: string }>) {
+function createMockClient(targets: Array<{ id: string; title: string; url: string; webSocketDebuggerUrl: string; type?: string; appId?: string; bundleId?: string; app_id?: string }>) {
   return {
     async listTargets() { return targets; },
     async connect() {},
@@ -132,5 +132,78 @@ describe('app_webview_connect tool', () => {
     const data = JSON.parse((result.content as any)[0].text);
     expect(data.count).toBe(0);
     expect(data.targets).toHaveLength(0);
+  });
+
+  // New tests for bundle-aware classification
+
+  test('HTTPS payment-return target classified as webview when bundleId matches', async () => {
+    const targets = [
+      { id: 'page-pg', title: 'Payment', url: 'https://pay.example.com/return', webSocketDebuggerUrl: 'ws://localhost:9222/devtools/page/page-pg', appId: 'com.example.shopping' },
+    ];
+    const mock = createMockClient(targets);
+    setWebKitClient(mock as any);
+    const handler = server.getToolHandler('app_webview_connect')!;
+    const result = await handler('test', { bundleId: 'com.example.shopping' });
+    const data = JSON.parse((result.content as any)[0].text);
+    const target = data.targets.find((t: any) => t.id === 'page-pg');
+    expect(target).toBeDefined();
+    expect(target.type).toBe('webview');
+    expect(target.classificationReason).toBe('bundle_match');
+  });
+
+  test('HTTPS target with non-matching bundleId stays safari and is filtered out', async () => {
+    const targets = [
+      { id: 'page-pure', title: 'Google', url: 'https://google.com', webSocketDebuggerUrl: 'ws://localhost:9222/devtools/page/page-pure' },
+    ];
+    const mock = createMockClient(targets);
+    setWebKitClient(mock as any);
+    const handler = server.getToolHandler('app_webview_connect')!;
+    const result = await handler('test', { bundleId: 'com.example.shopping' });
+    const data = JSON.parse((result.content as any)[0].text);
+    expect(data.targets.map((t: any) => t.id)).not.toContain('page-pure');
+  });
+
+  test('file:// target classified webview with reason url_scheme', async () => {
+    const targets = [
+      { id: 'page-file', title: 'x', url: 'file:///app/index.html', webSocketDebuggerUrl: 'ws://localhost:9222/devtools/page/page-file' },
+    ];
+    const mock = createMockClient(targets);
+    setWebKitClient(mock as any);
+    const handler = server.getToolHandler('app_webview_connect')!;
+    const result = await handler('test', {});
+    const data = JSON.parse((result.content as any)[0].text);
+    const target = data.targets.find((t: any) => t.id === 'page-file');
+    expect(target).toBeDefined();
+    expect(target.classificationReason).toBe('url_scheme');
+  });
+
+  test('proxy-supplied type=WebView overrides url_scheme', async () => {
+    const targets = [
+      { id: 'page-pt', title: 'x', url: 'https://cdn.example.com/frame.html', webSocketDebuggerUrl: 'ws://localhost:9222/devtools/page/page-pt', type: 'WebView' },
+    ];
+    const mock = createMockClient(targets);
+    setWebKitClient(mock as any);
+    const handler = server.getToolHandler('app_webview_connect')!;
+    const result = await handler('test', {});
+    const data = JSON.parse((result.content as any)[0].text);
+    const target = data.targets.find((t: any) => t.id === 'page-pt');
+    expect(target).toBeDefined();
+    expect(target.type).toBe('webview');
+    expect(target.classificationReason).toBe('proxy_type');
+  });
+
+  test('bundle_match by title substring still works for backward compatibility', async () => {
+    const targets = [
+      { id: 'page-legacy', title: 'com.example.app \u2013 Home', url: 'about:blank', webSocketDebuggerUrl: 'ws://localhost:9222/devtools/page/page-legacy' },
+    ];
+    const mock = createMockClient(targets);
+    setWebKitClient(mock as any);
+    const handler = server.getToolHandler('app_webview_connect')!;
+    const result = await handler('test', { bundleId: 'com.example.app' });
+    const data = JSON.parse((result.content as any)[0].text);
+    const target = data.targets.find((t: any) => t.id === 'page-legacy');
+    expect(target).toBeDefined();
+    expect(target.classificationReason).toBe('bundle_match');
+    expect(target.type).toBe('webview');
   });
 });


### PR DESCRIPTION
## Summary

- `app_webview_connect` now uses a three-priority classification system: `bundle_match` → `proxy_type` → `url_scheme`
- Each target in the response includes a `classificationReason` field for debuggability
- HTTPS WebViews (payment-return, OAuth, embedded T&C) are correctly promoted to `webview` when `bundleId` matches target metadata

## Problem

`classifyTarget()` used a URL-scheme heuristic that misclassified any HTTPS WebView (e.g. payment-return pages, OAuth callbacks) as `'safari'`, making them invisible to `app_webview_connect` even when a `bundleId` was provided.

## Fix

New priority order in `classifyTarget(target, ownerBundleId?)`:

1. **`bundle_match`**: if `ownerBundleId` matches target `appId`/`bundleId`/`app_id` fields (exact, case-insensitive) or is a substring of title/url — classify as `webview`
2. **`proxy_type`**: if target has a proxy-supplied `type` field — `safari`/`mobilesafari` → `safari`; contains `webview` → `webview`
3. **`url_scheme`**: existing fallback — non-http(s) → `webview`; http(s) or empty/about:blank → `safari`

When `bundleId` is provided, the post-filter keeps webview targets that either matched via `bundle_match` or contain the bundleId substring in title/url (backward-compatible).

## Pre-deploy Checklist

- [x] `classifyTarget` signature updated with `ownerBundleId` parameter
- [x] `classificationReason` field added to each target in response
- [x] Response shape backward compatible (`{ deviceId, targets, count }`)
- [x] Docs updated in `docs/api-reference.md`
- [x] All 13 unit tests pass (5 new, 8 existing preserved)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean

## Test Plan

```bash
npx jest tests/unit/app-webview-connect.test.ts --runInBand
```

Expected: 13 passed, 0 failed

New test cases:
- HTTPS payment-return target classified as webview when bundleId matches
- HTTPS target with non-matching bundleId stays safari and is filtered out
- file:// target classified webview with reason url_scheme
- proxy-supplied type=WebView overrides url_scheme
- bundle_match by title substring still works for backward compatibility

Closes #592