### PR TITLE
feat(tools): localize app_alert_handle with AX label matching (#589)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -92,6 +92,37 @@ Detect WebView targets inside a running native app and list available ones.
   - `proxy_type` — proxy-supplied `type` field on the target determined classification (e.g. `type: 'WebView'` overrides URL-scheme heuristics).
   - `url_scheme` — fallback heuristic: non-http(s) schemes → `webview`; http(s) or empty/about:blank → `safari`.
 
+#### app_alert_handle
+Accept, dismiss, or press a named button on a system alert/dialog on a booted iOS Simulator.
+
+- **Input:**
+  - `action?: 'accept' | 'dismiss'` — Accept (Return key) or dismiss (Escape key) the alert. Used only when no `buttonLabel`/`buttonLabels` is provided.
+  - `buttonLabel?: string` — Exact button label to press (case-insensitive, trimmed). Walks the front-most alert's accessibility tree and invokes `AXPress` on the first match. Takes precedence over `action`.
+  - `buttonLabels?: string[]` — Ordered list of candidate labels tried in priority order; the first match is pressed. Takes precedence over `buttonLabel` and `action`. Useful for multi-locale support.
+  - `deviceId?: string` — Simulator UDID. Falls back to the active device if omitted.
+- **Output:** `{ handled: true, buttonLabel?, action?, deviceId, method, _meta }`
+- **Errors:**
+  - `DEVICE_NOT_BOOTED` — No booted simulator found.
+  - `MISSING_PARAMS` — Neither `action` nor `buttonLabel`/`buttonLabels` provided.
+  - `INVALID_ACTION` — `action` is not `"accept"` or `"dismiss"`.
+  - `NO_MATCHING_BUTTON` — None of the supplied labels matched a visible button; the error payload includes `visibleLabels` listing what was found.
+  - `ALERT_HANDLE_FAILED` — Key send or AX press failed.
+- **Examples:**
+  ```json
+  // Keyboard fallback — accept the default button
+  { "action": "accept" }
+
+  // Press a specific button by label (StoreKit, permission sheet, etc.)
+  { "buttonLabel": "Allow While Using App" }
+
+  // Multi-locale: try the localized label first, then English fallback
+  { "buttonLabels": ["앱을 사용하는 동안 허용", "Allow While Using App"] }
+  ```
+- **Notes:**
+  - The `buttonLabel`/`buttonLabels` path uses macOS `AXUIElement` accessibility API (`ax-bridge`) — it works on StoreKit password sheets, 3-button permission dialogs, and any alert where the default button is not the accept action.
+  - `_meta._telemetry[0].backend` is `"ax-press"` on the label path and the backend kind (e.g. `"simctl"`) on the keyboard path.
+  - For non-English simulators, build the candidate list with `resolveLocalizedButtonLabels` from `src/native/localized-button-matcher.ts` or seed it from `src/native/system-button-catalog.ts`.
+
 ### Advanced Tools (Tier 2)
 
 inspect, wait_for, long_press, swipe, press, dismiss_keyboard, select_option, device_list, device_rotate, appearance_toggle

--- a/src/native/localized-button-matcher.ts
+++ b/src/native/localized-button-matcher.ts
@@ -1,0 +1,155 @@
+/**
+ * Localized Button Matcher
+ *
+ * Shared helper for resolving the current simulator locale's button label
+ * for a given semantic key, optionally reading the app bundle's .lproj resources.
+ *
+ * Primary use-case: supply a list of locale-aware candidate labels to
+ * `app_alert_handle`'s `buttonLabels` parameter so the AX-press path works
+ * on non-English simulator locales without the caller knowing the target locale.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  SYSTEM_BUTTON_CATALOG,
+  SemanticButtonKey,
+  SupportedLocale,
+} from './system-button-catalog';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Retrieve the active locale identifier for a booted simulator via `simctl`.
+ *
+ * Returns the locale string (e.g. "ko_KR", "ja_JP", "en_US") or `null` when
+ * it cannot be determined (device not booted, simctl unavailable, etc.).
+ */
+export async function getSimulatorLocale(deviceId: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'xcrun',
+      ['simctl', 'spawn', deviceId, 'defaults', 'read', '-g', 'AppleLocale'],
+      { timeout: 8_000 },
+    );
+    const locale = stdout.trim();
+    return locale.length > 0 ? locale : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Map a full locale string (e.g. "ko_KR", "zh_Hans_CN") to a supported
+ * catalog locale key. Falls back to 'en' when no match is found.
+ */
+export function mapToSupportedLocale(locale: string): SupportedLocale {
+  // zh-Hans variants
+  if (locale.startsWith('zh_Hans') || locale.startsWith('zh-Hans')) return 'zh-Hans';
+  // Language prefix matching
+  const lang = locale.split('_')[0].split('-')[0];
+  const supported: SupportedLocale[] = ['en', 'ko', 'ja', 'zh-Hans'];
+  return (supported.find((s) => s === lang) as SupportedLocale | undefined) ?? 'en';
+}
+
+/**
+ * Read a localized string from an app bundle's .lproj Localizable.strings file.
+ *
+ * Searches `<bundlePath>/<locale>.lproj/Localizable.strings` for the given key.
+ * Returns `null` when the file is not found, the key is absent, or parsing fails.
+ *
+ * This is a best-effort read — callers should fall through to the catalog when null.
+ */
+export function readBundleLocalizedString(
+  bundlePath: string,
+  locale: string,
+  key: string,
+): string | null {
+  // Try the exact locale, then the language prefix, then English
+  const candidates = [
+    locale,
+    locale.split('_')[0],
+    'en',
+  ];
+
+  for (const candidate of candidates) {
+    const stringsPath = path.join(bundlePath, `${candidate}.lproj`, 'Localizable.strings');
+    if (!fs.existsSync(stringsPath)) continue;
+
+    try {
+      const content = fs.readFileSync(stringsPath, 'utf-8');
+      // Simple regex parse: "key" = "value";
+      const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const match = content.match(new RegExp(`"${escaped}"\\s*=\\s*"([^"\\\\]|\\\\.)*"`));
+      if (match) {
+        // Extract value between outer quotes
+        const full = match[0];
+        const valueMatch = full.match(/=\s*"((?:[^"\\]|\\.)*)"/);
+        if (valueMatch) {
+          return valueMatch[1].replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+        }
+      }
+    } catch {
+      // File read or parse failure — try next candidate
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the current locale's button label for a semantic key.
+ *
+ * Resolution order:
+ *   1. App bundle .lproj resources (if `bundlePath` provided)
+ *   2. System catalog (SYSTEM_BUTTON_CATALOG) for the detected locale
+ *   3. English catalog fallback
+ *
+ * @param params.semanticKey  Semantic button key (e.g. 'alert.ok')
+ * @param params.deviceId     Simulator UDID (used to detect active locale)
+ * @param params.bundlePath   Optional path to the app bundle for .lproj lookup
+ * @param params.stringKey    Optional Localizable.strings key (defaults to semanticKey)
+ * @returns                   Ordered list of label candidates (primary + English fallback)
+ */
+export async function resolveLocalizedButtonLabels(params: {
+  semanticKey: SemanticButtonKey;
+  deviceId: string;
+  bundlePath?: string;
+  stringKey?: string;
+}): Promise<string[]> {
+  const { semanticKey, deviceId, bundlePath, stringKey } = params;
+
+  const locale = await getSimulatorLocale(deviceId);
+  const supportedLocale = locale ? mapToSupportedLocale(locale) : 'en';
+
+  const candidates: string[] = [];
+
+  // 1. Bundle .lproj lookup (if bundle path provided)
+  if (bundlePath && locale) {
+    const bundleLabel = readBundleLocalizedString(
+      bundlePath,
+      locale,
+      stringKey ?? semanticKey,
+    );
+    if (bundleLabel && !candidates.includes(bundleLabel)) {
+      candidates.push(bundleLabel);
+    }
+  }
+
+  // 2. System catalog — locale-specific label
+  const catalogEntry = SYSTEM_BUTTON_CATALOG[semanticKey];
+  const localeLabel = catalogEntry[supportedLocale];
+  if (localeLabel && !candidates.includes(localeLabel)) {
+    candidates.push(localeLabel);
+  }
+
+  // 3. English fallback (always include as last resort)
+  const enLabel = catalogEntry['en'];
+  if (enLabel && !candidates.includes(enLabel)) {
+    candidates.push(enLabel);
+  }
+
+  return candidates;
+}

--- a/src/native/system-button-catalog.ts
+++ b/src/native/system-button-catalog.ts
@@ -1,0 +1,112 @@
+/**
+ * System Button Catalog
+ *
+ * Seed catalog mapping semantic button keys to their localized labels
+ * for common iOS system sheets and alerts.
+ *
+ * Locale coverage: en (English), ko (Korean), ja (Japanese), zh-Hans (Simplified Chinese).
+ *
+ * Usage: look up a semantic key to get the ordered list of label candidates
+ * for a given locale, then pass them as `buttonLabels` to `app_alert_handle`.
+ */
+
+/** Supported locale identifiers. */
+export type SupportedLocale = 'en' | 'ko' | 'ja' | 'zh-Hans';
+
+/** Per-locale string map for a single semantic button key. */
+export type LocalizedButtonEntry = Record<SupportedLocale, string>;
+
+/** All semantic button keys defined in this catalog. */
+export type SemanticButtonKey =
+  | 'storekit.signIn'
+  | 'storekit.cancel'
+  | 'alert.ok'
+  | 'alert.cancel'
+  | 'permission.allow'
+  | 'permission.deny'
+  | 'permission.whileUsing'
+  | 'settings.open'
+  | 'settings.cancel';
+
+/**
+ * Catalog mapping semantic keys → localized button labels.
+ *
+ * Sources:
+ *   - StoreKit: Apple Developer docs, iOS 17 StoreKit2 payment sheets
+ *   - Alert / Permission: iOS UIAlertController system strings
+ *   - Settings: iOS "Open Settings" sheet strings
+ */
+export const SYSTEM_BUTTON_CATALOG: Record<SemanticButtonKey, LocalizedButtonEntry> = {
+  'storekit.signIn': {
+    en: 'Sign In',
+    ko: '로그인',
+    ja: 'サインイン',
+    'zh-Hans': '登录',
+  },
+  'storekit.cancel': {
+    en: 'Cancel',
+    ko: '취소',
+    ja: 'キャンセル',
+    'zh-Hans': '取消',
+  },
+  'alert.ok': {
+    en: 'OK',
+    ko: '확인',
+    ja: 'OK',
+    'zh-Hans': '好',
+  },
+  'alert.cancel': {
+    en: 'Cancel',
+    ko: '취소',
+    ja: 'キャンセル',
+    'zh-Hans': '取消',
+  },
+  'permission.allow': {
+    en: 'Allow',
+    ko: '허용',
+    ja: '許可',
+    'zh-Hans': '允许',
+  },
+  'permission.deny': {
+    en: "Don't Allow",
+    ko: '허용 안 함',
+    ja: '許可しない',
+    'zh-Hans': '不允许',
+  },
+  'permission.whileUsing': {
+    en: 'Allow While Using App',
+    ko: '앱을 사용하는 동안 허용',
+    ja: 'Appの使用中は許可',
+    'zh-Hans': 'App使用期间允许',
+  },
+  'settings.open': {
+    en: 'Settings',
+    ko: '설정',
+    ja: '設定',
+    'zh-Hans': '设置',
+  },
+  'settings.cancel': {
+    en: 'Cancel',
+    ko: '취소',
+    ja: 'キャンセル',
+    'zh-Hans': '取消',
+  },
+};
+
+/**
+ * Resolve the localized label for a semantic key and locale.
+ *
+ * Falls back to English when the requested locale is not in the catalog.
+ *
+ * @param key    Semantic button key (e.g. 'alert.ok')
+ * @param locale Locale identifier (e.g. 'ko', 'ja', 'zh-Hans')
+ * @returns      Localized label string
+ */
+export function resolveSemanticLabel(
+  key: SemanticButtonKey,
+  locale: string,
+): string {
+  const entry = SYSTEM_BUTTON_CATALOG[key];
+  const supported = locale as SupportedLocale;
+  return entry[supported] ?? entry['en'];
+}

--- a/src/tools/app-alert-handle.ts
+++ b/src/tools/app-alert-handle.ts
@@ -3,6 +3,67 @@ import { SimulatorManager } from '../simulator';
 import { getSessionManager } from '../session-manager';
 import { getInputBackend } from './native-input-backend';
 import { runInputOp } from './native-input-utils';
+import { getAccessibilityBridge } from '../native/accessibility-bridge';
+import type { AXNode } from '../native/ax-types';
+
+/**
+ * Walk an AX tree looking for button nodes whose label matches one of the
+ * supplied candidate labels (case-insensitive, trimmed). Returns the first
+ * matching node in priority order (i.e. the order of `labels`).
+ */
+function findButtonByLabels(
+  node: AXNode,
+  labels: string[],
+): AXNode | null {
+  const normalizedLabels = labels.map((l) => l.trim().toLowerCase());
+
+  // BFS so we find top-level matches first
+  const queue: AXNode[] = [node];
+  // collect all button candidates first, then match by priority
+  const found: Array<{ priorityIndex: number; node: AXNode }> = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const nodeLabel = (current.label ?? '').trim().toLowerCase();
+    if (nodeLabel.length > 0) {
+      const idx = normalizedLabels.indexOf(nodeLabel);
+      if (idx !== -1) {
+        found.push({ priorityIndex: idx, node: current });
+      }
+    }
+    if (current.children) {
+      for (const child of current.children) {
+        queue.push(child);
+      }
+    }
+  }
+
+  if (found.length === 0) return null;
+
+  // Return the highest-priority (lowest index) match
+  found.sort((a, b) => a.priorityIndex - b.priorityIndex);
+  return found[0].node;
+}
+
+/**
+ * Collect all visible button labels from the AX tree.
+ */
+function collectButtonLabels(node: AXNode): string[] {
+  const labels: string[] = [];
+  const queue: AXNode[] = [node];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current.label && current.label.trim().length > 0) {
+      labels.push(current.label.trim());
+    }
+    if (current.children) {
+      for (const child of current.children) {
+        queue.push(child);
+      }
+    }
+  }
+  return labels;
+}
 
 export function registerAppAlertHandleTool(server: MCPServer): void {
   server.registerTool(
@@ -10,21 +71,41 @@ export function registerAppAlertHandleTool(server: MCPServer): void {
       name: 'app_alert_handle',
       description:
         'Accept or dismiss a system alert/dialog on a booted iOS Simulator. ' +
-        'Uses keyboard input (Return to accept, Escape to dismiss) with an AppleScript fallback.',
+        'When buttonLabel or buttonLabels is provided, walks the front-most alert\'s ' +
+        'accessibility tree and presses the first matching button (case-insensitive, ' +
+        'trimmed). Falls back to keyboard input (Return to accept, Escape to dismiss) ' +
+        'when no label is supplied. Supports StoreKit, permission sheets, and ' +
+        'non-English simulator locales.',
       inputSchema: {
         type: 'object' as const,
         properties: {
           action: {
             type: 'string',
             enum: ['accept', 'dismiss'],
-            description: 'Whether to accept or dismiss the alert',
+            description:
+              'Whether to accept or dismiss the alert. Used for the keyboard ' +
+              'fallback path when no buttonLabel(s) are provided.',
+          },
+          buttonLabel: {
+            type: 'string',
+            description:
+              'Exact (case-insensitive) label of the button to press. ' +
+              'Takes precedence over action when provided.',
+          },
+          buttonLabels: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Ordered list of candidate button labels to try in priority order. ' +
+              'The first matching button in the AX tree is pressed. ' +
+              'Takes precedence over buttonLabel and action when provided.',
           },
           deviceId: {
             type: 'string',
             description: 'Device UDID. Falls back to active device if omitted.',
           },
         },
-        required: ['action'],
+        required: [],
       },
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
@@ -49,7 +130,129 @@ export function registerAppAlertHandleTool(server: MCPServer): void {
         };
       }
 
-      const action = params.action as string;
+      // Resolve the candidate label list
+      const buttonLabels: string[] | undefined =
+        (params.buttonLabels as string[] | undefined) ??
+        (params.buttonLabel
+          ? [params.buttonLabel as string]
+          : undefined);
+
+      // ── AX-press path (label-based) ──────────────────────────────────────
+      if (buttonLabels && buttonLabels.length > 0) {
+        try {
+          const bridge = getAccessibilityBridge();
+          const tree = await bridge.dumpTree({ deviceId, maxDepth: 8 });
+
+          const matchedNode = findButtonByLabels(tree, buttonLabels);
+
+          if (!matchedNode) {
+            const visibleLabels = collectButtonLabels(tree);
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify({
+                    error: 'NO_MATCHING_BUTTON',
+                    message:
+                      `No button matching ${JSON.stringify(buttonLabels)} found. ` +
+                      `Visible button titles: ${JSON.stringify(visibleLabels)}.`,
+                    buttonLabels,
+                    visibleLabels,
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          const pressResponse = await bridge.press(matchedNode.path, deviceId);
+
+          if (!pressResponse.ok) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify({
+                    error: 'ALERT_HANDLE_FAILED',
+                    message:
+                      `AX press failed on "${matchedNode.label ?? matchedNode.path}": ` +
+                      `${pressResponse.message ?? pressResponse.code}`,
+                    code: pressResponse.code,
+                    path: matchedNode.path,
+                    _meta: {
+                      _telemetry: [
+                        {
+                          backend: 'ax-press',
+                          path: matchedNode.path,
+                          label: matchedNode.label,
+                          axCode: pressResponse.code,
+                        },
+                      ],
+                    },
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  handled: true,
+                  buttonLabel: matchedNode.label,
+                  deviceId,
+                  method: 'ax-press',
+                  _meta: {
+                    _telemetry: [
+                      {
+                        backend: 'ax-press',
+                        path: matchedNode.path,
+                        label: matchedNode.label,
+                      },
+                    ],
+                  },
+                }),
+              },
+            ],
+          };
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  error: 'ALERT_HANDLE_FAILED',
+                  message: `AX label-match failed: ${message}`,
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
+      // ── Keyboard fallback path (action-based) ─────────────────────────────
+      const action = params.action as string | undefined;
+
+      if (!action) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'MISSING_PARAMS',
+                message:
+                  'Either action ("accept"|"dismiss") or buttonLabel/buttonLabels must be provided.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
 
       if (action !== 'accept' && action !== 'dismiss') {
         return {

--- a/tests/unit/app-alert-handle.test.ts
+++ b/tests/unit/app-alert-handle.test.ts
@@ -32,6 +32,19 @@ jest.mock('../../src/session-manager', () => ({
   }),
 }));
 
+// Mock the accessibility bridge for label-matching path
+const mockDumpTree = jest.fn();
+const mockPress = jest.fn();
+
+jest.mock('../../src/native/accessibility-bridge', () => ({
+  getAccessibilityBridge: jest.fn(() => ({
+    dumpTree: mockDumpTree,
+    press: mockPress,
+    query: jest.fn(),
+    inspect: jest.fn(),
+  })),
+}));
+
 // Access mocked constructors via import (already mocked above)
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { SimulatorManager } = require('../../src/simulator');
@@ -41,6 +54,33 @@ const { getSessionManager } = require('../../src/session-manager');
 // Helper to parse response text
 function parseResult(result: { content: Array<{ type: string; text: string }> }) {
   return JSON.parse(result.content[0].text);
+}
+
+// ── Fake AX tree ──
+
+/** Build a minimal AX tree with named buttons */
+function makeTree(buttonLabels: string[]) {
+  return {
+    role: 'AXWindow',
+    label: undefined,
+    traits: [],
+    frame: { x: 0, y: 0, width: 375, height: 812 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    path: '',
+    children: buttonLabels.map((label, i) => ({
+      role: 'AXButton',
+      label,
+      traits: [],
+      frame: { x: 0, y: i * 44, width: 375, height: 44 },
+      visible: true,
+      enabled: true,
+      focused: false,
+      path: String(i),
+      children: undefined,
+    })),
+  };
 }
 
 // ── Tests ──
@@ -56,6 +96,7 @@ describe('app_alert_handle tool', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSendKey.mockResolvedValue(undefined);
+    mockPress.mockResolvedValue({ ok: true, code: 'OK', path: '0', actions: ['AXPress'], role: 'AXButton', identifier: null, label: 'OK', message: null, axErrorCode: null });
 
     // Re-setup default mock returns after clearAllMocks
     SimulatorManager.mockImplementation(() => ({
@@ -72,6 +113,8 @@ describe('app_alert_handle tool', () => {
   test('is registered with correct name', () => {
     expect(server.getRegisteredTools()).toContain('app_alert_handle');
   });
+
+  // ── Keyboard path (action-only, backward compat) ──────────────────────────
 
   test('accepts an alert via sendKey Return', async () => {
     const handler = server.getToolHandler('app_alert_handle')!;
@@ -98,14 +141,12 @@ describe('app_alert_handle tool', () => {
   test('sends correct key for accept (Return)', async () => {
     const handler = server.getToolHandler('app_alert_handle')!;
     await handler('test', { action: 'accept' });
-
     expect(mockSendKey).toHaveBeenCalledWith('TEST-UDID-1234', 'Return');
   });
 
   test('sends correct key for dismiss (Escape)', async () => {
     const handler = server.getToolHandler('app_alert_handle')!;
     await handler('test', { action: 'dismiss' });
-
     expect(mockSendKey).toHaveBeenCalledWith('TEST-UDID-1234', 'Escape');
   });
 
@@ -116,6 +157,14 @@ describe('app_alert_handle tool', () => {
     const text = parseResult(result as { content: Array<{ type: string; text: string }> });
     expect(text.error).toBe('INVALID_ACTION');
     expect(text.message).toContain('"close"');
+  });
+
+  test('returns MISSING_PARAMS when neither action nor buttonLabel provided', async () => {
+    const handler = server.getToolHandler('app_alert_handle')!;
+    const result = await handler('test', {});
+    expect(result.isError).toBe(true);
+    const text = parseResult(result as { content: Array<{ type: string; text: string }> });
+    expect(text.error).toBe('MISSING_PARAMS');
   });
 
   test('returns error when no device is booted', async () => {
@@ -137,7 +186,6 @@ describe('app_alert_handle tool', () => {
   test('uses explicit deviceId when provided', async () => {
     const handler = server.getToolHandler('app_alert_handle')!;
     await handler('test', { action: 'accept', deviceId: 'CUSTOM-UDID' });
-
     expect(mockSendKey).toHaveBeenCalledWith('CUSTOM-UDID', 'Return');
   });
 
@@ -151,5 +199,120 @@ describe('app_alert_handle tool', () => {
     const text = parseResult(result as { content: Array<{ type: string; text: string }> });
     expect(text.error).toBe('ALERT_HANDLE_FAILED');
     expect(text.message).toContain('Failed to accept alert');
+  });
+
+  // ── AX-press path (label-based) ───────────────────────────────────────────
+
+  test('presses button by buttonLabel (exact match)', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(['Cancel', 'OK']));
+    mockPress.mockResolvedValue({
+      ok: true, code: 'OK', path: '1', actions: ['AXPress'],
+      role: 'AXButton', identifier: null, label: 'OK', message: null, axErrorCode: null,
+    });
+
+    const handler = server.getToolHandler('app_alert_handle')!;
+    const result = await handler('test', { buttonLabel: 'OK' });
+
+    expect(result.isError).toBeUndefined();
+    const text = parseResult(result as { content: Array<{ type: string; text: string }> });
+    expect(text.handled).toBe(true);
+    expect(text.method).toBe('ax-press');
+    expect(text.buttonLabel).toBe('OK');
+    expect(text._meta._telemetry[0].backend).toBe('ax-press');
+    // should NOT have called sendKey
+    expect(mockSendKey).not.toHaveBeenCalled();
+  });
+
+  test('presses button case-insensitively', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(['Allow', "Don't Allow"]));
+    mockPress.mockResolvedValue({
+      ok: true, code: 'OK', path: '0', actions: ['AXPress'],
+      role: 'AXButton', identifier: null, label: 'Allow', message: null, axErrorCode: null,
+    });
+
+    const handler = server.getToolHandler('app_alert_handle')!;
+    const result = await handler('test', { buttonLabel: 'allow' }); // lowercase
+
+    expect(result.isError).toBeUndefined();
+    const text = parseResult(result as { content: Array<{ type: string; text: string }> });
+    expect(text.handled).toBe(true);
+    expect(text.buttonLabel).toBe('Allow');
+  });
+
+  test('respects multi-label priority order', async () => {
+    // tree has both "Cancel" (idx 0) and "Allow" (idx 1)
+    // buttonLabels: ['Allow', 'Cancel'] → priority 0 = Allow → should match Allow first
+    mockDumpTree.mockResolvedValue(makeTree(['Cancel', 'Allow']));
+    mockPress.mockResolvedValue({
+      ok: true, code: 'OK', path: '1', actions: ['AXPress'],
+      role: 'AXButton', identifier: null, label: 'Allow', message: null, axErrorCode: null,
+    });
+
+    const handler = server.getToolHandler('app_alert_handle')!;
+    const result = await handler('test', { buttonLabels: ['Allow', 'Cancel'] });
+
+    expect(result.isError).toBeUndefined();
+    const text = parseResult(result as { content: Array<{ type: string; text: string }> });
+    expect(text.handled).toBe(true);
+    expect(text.buttonLabel).toBe('Allow');
+    // The pressed path should correspond to 'Allow' (index 1 in tree)
+    expect(mockPress).toHaveBeenCalledWith('1', 'TEST-UDID-1234');
+  });
+
+  test('returns NO_MATCHING_BUTTON error with visible titles when no label matches', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(['Continue', 'Go Back']));
+
+    const handler = server.getToolHandler('app_alert_handle')!;
+    const result = await handler('test', { buttonLabel: 'OK' });
+
+    expect(result.isError).toBe(true);
+    const text = parseResult(result as { content: Array<{ type: string; text: string }> });
+    expect(text.error).toBe('NO_MATCHING_BUTTON');
+    expect(text.visibleLabels).toContain('Continue');
+    expect(text.visibleLabels).toContain('Go Back');
+  });
+
+  test('buttonLabels takes precedence over buttonLabel', async () => {
+    // When both are supplied, buttonLabels wins
+    mockDumpTree.mockResolvedValue(makeTree(['Allow', 'Deny']));
+    mockPress.mockResolvedValue({
+      ok: true, code: 'OK', path: '0', actions: ['AXPress'],
+      role: 'AXButton', identifier: null, label: 'Allow', message: null, axErrorCode: null,
+    });
+
+    const handler = server.getToolHandler('app_alert_handle')!;
+    // buttonLabels = ['Allow'], buttonLabel = 'Deny'
+    const result = await handler('test', { buttonLabels: ['Allow'], buttonLabel: 'Deny' });
+
+    expect(result.isError).toBeUndefined();
+    const text = parseResult(result as { content: Array<{ type: string; text: string }> });
+    expect(text.buttonLabel).toBe('Allow');
+  });
+
+  test('returns error when AX press fails with PRESS_FAILED', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(['OK']));
+    mockPress.mockResolvedValue({
+      ok: false, code: 'PRESS_FAILED', path: '0', actions: ['AXPress'],
+      role: 'AXButton', identifier: null, label: 'OK', message: 'AXPress returned error', axErrorCode: -25204,
+    });
+
+    const handler = server.getToolHandler('app_alert_handle')!;
+    const result = await handler('test', { buttonLabel: 'OK' });
+
+    expect(result.isError).toBe(true);
+    const text = parseResult(result as { content: Array<{ type: string; text: string }> });
+    expect(text.error).toBe('ALERT_HANDLE_FAILED');
+  });
+
+  test('backward-compat: action=accept with no labels uses keyboard path', async () => {
+    const handler = server.getToolHandler('app_alert_handle')!;
+    const result = await handler('test', { action: 'accept' });
+
+    // Must NOT call dumpTree
+    expect(mockDumpTree).not.toHaveBeenCalled();
+    expect(mockSendKey).toHaveBeenCalledWith('TEST-UDID-1234', 'Return');
+
+    const text = parseResult(result as { content: Array<{ type: string; text: string }> });
+    expect(text.method).toBe('input_backend');
   });
 });


### PR DESCRIPTION
Closes #589

## Summary

- **`app_alert_handle` extended** with `buttonLabel` and `buttonLabels` params: walks the front-most alert's AX tree and invokes `AXUIElementPerformAction(kAXPressAction)` on the first label match (case-insensitive, trimmed, priority-ordered)
- **`src/native/system-button-catalog.ts`**: seed catalog mapping semantic keys (`storekit.signIn`, `alert.ok`, `permission.allow`, `permission.whileUsing`, etc.) → `{en, ko, ja, zh-Hans}` labels
- **`src/native/localized-button-matcher.ts`**: shared helper that detects the active simulator locale via `simctl` and resolves the localized label list, with optional app bundle `.lproj` fallback
- Backward compatible: `action: 'accept'|'dismiss'` (keyboard path) still works when no label supplied; `action` is now optional when `buttonLabel`/`buttonLabels` present
- `NO_MATCHING_BUTTON` structured error includes `visibleLabels` list for diagnostics
- `_meta._telemetry[0].backend` is `'ax-press'` on label path, backend kind on keyboard path

## Test plan

- [x] 17 unit tests in `tests/unit/app-alert-handle.test.ts` — all pass
- [x] Full unit suite (1649 tests, 112 suites) — all pass
- [x] `npm run build` — TypeScript + webpack + Swift bridges compile cleanly
- [x] `npx tsc --noEmit` — zero type errors
- [ ] Live simulator test (requires booted device — skipped per issue instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)