### PR TITLE
docs(flutter): release-mode fallback matrix + --profile QA recipe (#596)

### DIFF
--- a/docs/ci-recipes.md
+++ b/docs/ci-recipes.md
@@ -477,6 +477,37 @@ artifacts:
 export OPENSAFARI_HEADLESS_ONLY=1
 ```
 
+### QA-ready Flutter build
+
+**Recommendation:** build "QA" simulator artifacts with `flutter build ios --simulator --profile` instead of `--release`. Profile mode runs close to release performance **and** keeps the Dart VM Service online, so `FlutterVMInputBackend` (Tier 0) stays the active input path.
+
+Release builds compile Dart to AOT and reject runtime `evaluate` calls with `code 113`, which surfaces as `FlutterVMInputBackendError { code: 'VM_NO_EVALUATE' }`. The router then falls through to Tier 1.5 AX-press (element-targeted tools only) and ultimately AppleScript for coordinate gestures — the slowest and most fragile path, and — on Xcode 26+ where Tier-1 SimHID tap/swipe is disabled pending #491 — the only remaining coordinate fallback. See [Build-mode × Xcode tier matrix](./flutter-inspector.md#build-mode--xcode-tier-matrix-596) for the full routing table.
+
+```bash
+# Build a profile-mode simulator bundle (keeps VM Service; runs near release perf).
+flutter build ios --simulator --profile --target lib/main_qa.dart
+
+# Install and launch so flutter_connect lands on Tier 0.
+APP=build/ios/iphonesimulator/Runner.app
+xcrun simctl install booted "$APP"
+xcrun simctl launch --console booted "$(plutil -extract CFBundleIdentifier raw "$APP/Info.plist")"
+```
+
+```yaml
+# GitHub Actions — QA-ready Flutter simulator build
+- name: Build Flutter (profile mode)
+  run: flutter build ios --simulator --profile --target lib/main_qa.dart
+
+- name: Install + launch on booted simulator
+  run: |
+    APP=build/ios/iphonesimulator/Runner.app
+    BUNDLE=$(plutil -extract CFBundleIdentifier raw "$APP/Info.plist")
+    xcrun simctl install booted "$APP"
+    xcrun simctl launch booted "$BUNDLE"
+```
+
+> **Why not `--release`?** The Dart AOT runtime in release mode has no expression compiler, so Tier 0 probes fail and every subsequent tap/swipe degrades to AppleScript (or silently fails under `OPENSAFARI_HEADLESS_ONLY=1`). Profile mode keeps the tree-shaker and AOT-compatible optimisations while preserving the VM Service — the same trade-off that `flutter run --profile` makes for Flutter's own tooling.
+
 ### JUnit output generation
 
 OpenSafari's `qa_full_audit` tool emits JUnit-compatible XML directly. Pass `--format junit` to the CLI or `format: "junit"` via MCP:

--- a/docs/flutter-inspector.md
+++ b/docs/flutter-inspector.md
@@ -9,6 +9,30 @@ The Flutter Inspector tools provide real-time widget tree inspection for running
 
 Both tools require an active Flutter VM Service connection via `flutter_connect` (debug or profile builds only).
 
+## Build-mode × Xcode tier matrix (#596)
+
+Flutter build mode determines which input tier the router lands on. **Release builds on Xcode 26+ land on the slowest and most fragile path** — AX-press for element-targeted tools only, AppleScript for coordinate tools — because Tier 0 (`FlutterVMInputBackend`) requires `evaluate` support (Dart AOT cannot compile expressions at runtime) and Tier 1 SimHID tap/swipe is disabled on Xcode 26+ pending the `IndigoHIDMessageForMouseNSEvent` regression fix (#491, #537).
+
+Consumers often pick release mode for "QA" simulator builds to match production performance — and silently forfeit headless coverage. Use `flutter build ios --simulator --profile` instead: it keeps the VM Service online so Tier 0 stays available, while running close to release perf. See the [QA-ready Flutter build recipe](./ci-recipes.md#qa-ready-flutter-build).
+
+| Build mode | Xcode ≤ 25 | Xcode 26+ | VM Service | Tier 0 (`FlutterVMInputBackend`) |
+| --- | --- | --- | --- | --- |
+| `debug` | **Tier 0** (all gestures via VM Service) | **Tier 0** (all gestures via VM Service) | ✅ | ✅ `evaluate` available |
+| `profile` | **Tier 0** (recommended for perf-parity QA) | **Tier 0** (recommended for perf-parity QA) | ✅ | ✅ `evaluate` available |
+| `release` | Tier 1/2/3 (SimHID → simctl → WebKit) | ⚠️ **AX-press for element, AppleScript for coords** | ❌ (AOT) | ❌ falls through (`VM_NO_EVALUATE`) |
+
+Legend:
+
+- **Tier 0** `FlutterVMInputBackend` — synthetic `PointerDataPacket` via VM Service, zero OS input, fully headless.
+- **Tier 1** `SimulatorKitHIDInputBackend` — IOKit HID events; tap/swipe disabled on Xcode 26+.
+- **Tier 1.5** `AccessibilityPressInputBackend` — `AXUIElementPerformAction` for `app_tap_element` / `app_type_element` only.
+- **Tier 2/3** `SimctlIOInputBackend` / `NativeInputBackend` (WebKit) — coordinate-only on native UIKit.
+- **Tier 4** `AppleScriptInputBackend` — requires `Simulator.app` focus; blocked when `OPENSAFARI_HEADLESS_ONLY=1`.
+
+### Detecting release-mode fall-through
+
+When Tier 0 probes a release build it rejects with `FlutterVMInputBackendError { code: 'VM_NO_EVALUATE' }` whose `.message` surfaces the canonical recipe link. Tool consumers can key on the structured code to prompt users to rebuild with `--profile`, or parse `flutter_connect`'s response metadata (Dart VM flags expose the build mode).
+
 ## Flutter Compatibility Matrix
 
 | Flutter version | `flutter_root_widget` | `flutter_inspect_selection` | Inspector method chosen | Notes |

--- a/src/tools/flutter-vm-input-backend.ts
+++ b/src/tools/flutter-vm-input-backend.ts
@@ -72,7 +72,9 @@ export class FlutterVMInputBackendError extends Error {
           `(code 113). This app is likely a release build or was launched ` +
           `with \`simctl launch\` instead of \`flutter run\`. ` +
           `Use Tier 1.5 AX press (app_tap_element / app_type_element) or ` +
-          `relaunch under \`flutter run --debug\` for full gesture coverage.`
+          `relaunch under \`flutter run --debug\` for full gesture coverage. ` +
+          `See docs/ci-recipes.md#qa-ready-flutter-build for a CI-ready ` +
+          `--profile recipe that keeps Tier 0 available.`
         : `FlutterVMInputBackend.${op} failed: ${msg}`;
     super(userMessage);
     this.op = op;

--- a/tests/unit/flutter-vm-input-backend.test.ts
+++ b/tests/unit/flutter-vm-input-backend.test.ts
@@ -299,6 +299,8 @@ describe('FlutterVMInputBackend', () => {
         // User-facing message must surface the remediation — not just echo
         // the raw JSON-RPC error.
         expect(e.message).toMatch(/release build|flutter run/i);
+        // Must link the canonical QA recipe so users can self-serve (#596).
+        expect(e.message).toContain('docs/ci-recipes.md#qa-ready-flutter-build');
       }
     });
 


### PR DESCRIPTION
## Summary

- Add a **Build-mode × Xcode tier matrix** to `docs/flutter-inspector.md` that makes the release-mode + Xcode 26+ routing collapse explicit (AX-press for element tools, AppleScript for coordinates — the slowest path).
- Ship a **QA-ready Flutter build** recipe under `docs/ci-recipes.md#qa-ready-flutter-build` recommending `flutter build ios --simulator --profile` so Tier 0 stays available under perf-parity QA builds.
- Link that anchor from `FlutterVMInputBackendError`'s `VM_NO_EVALUATE` remediation message so users can self-serve from the error output.
- Unit test asserts the canonical recipe path lands in the error message.

## Why

Release-mode Dart AOT cannot compile `evaluate` at runtime, so `FlutterVMInputBackend.probeEvaluateCompile()` fails with `code: 113`. Combined with Tier-1 SimHID tap/swipe being disabled on Xcode 26+ (#491), the router falls through to Tier 1.5 AX-press (element-targeted tools only) and ultimately AppleScript for coordinates. Consumers routinely pick release mode for "QA" simulator builds to match production performance and silently forfeit headless coverage; the docs never connected the two stories.

## Matrix preview

| Build mode | Xcode ≤ 25 | Xcode 26+ | VM Service | Tier 0 |
| --- | --- | --- | --- | --- |
| `debug` | **Tier 0** | **Tier 0** | ✅ | ✅ |
| `profile` | **Tier 0** (recommended) | **Tier 0** (recommended) | ✅ | ✅ |
| `release` | Tier 1/2/3 | ⚠️ AX-press / AppleScript only | ❌ | ❌ `VM_NO_EVALUATE` |

## Test plan

- [x] `npx jest tests/unit/flutter-vm-input-backend.test.ts` — 23/23 passing (includes new link-in-message assertion).
- [x] `npx tsc --noEmit` clean.
- [x] Matrix renders in GitHub preview.
- [ ] The `qa_build_mode` enhancement from the issue body was skipped (would touch >3 files / `flutter_connect` response shape). Recommend a follow-up issue if consumers still want the runtime hint.

## Related

- Closes #596
- Cross-references #553 (Flutter VM routing polish), #491 (Xcode 26 SimHID tap regression), #484 (headless epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)