### PR TITLE
test(webview): WebView↔Native cross-context E2E (#593)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -83,14 +83,21 @@ Reset app state: terminate, reset privacy permissions, uninstall. The app must b
 - **Output:** `{ reset: boolean, bundleId, deviceId, steps: string[] }`
 - **Steps:** `terminated` → `privacy_reset` → `uninstalled` (each step proceeds independently)
 
-#### app_webview_connect
-Detect WebView targets inside a running native app and list available ones.
-- **Input:** `{ bundleId?: string, deviceId?: string }`
-- **Output:** `{ deviceId, targets: [{ id, title, url, type, classificationReason }], count }`
+Detect WebView targets inside a running native app and list available ones via
+ios-webkit-debug-proxy. Use the returned `webSocketDebuggerUrl` with
+`WebKitClient.connectToUrl()` to run `Runtime.evaluate` calls inside the
+WebView, then call `WebKitClient.disconnect()` to bounce back to the native
+AX context.
+- **Input:** `{ bundleId?: string, deviceId?: string, proxyPort?: number }`
+- **Output:** `{ deviceId, targets: [{ id, title, url, webSocketDebuggerUrl, type, classificationReason }], count }`
 - **`classificationReason`** values: `bundle_match` | `proxy_type` | `url_scheme`
   - `bundle_match` — target matched via `bundleId` parameter (metadata fields or title/url substring). When `bundleId` is provided, HTTPS WebViews such as payment-return pages or OAuth callbacks are promoted from `safari` to `webview` classification via this reason.
   - `proxy_type` — proxy-supplied `type` field on the target determined classification (e.g. `type: 'WebView'` overrides URL-scheme heuristics).
   - `url_scheme` — fallback heuristic: non-http(s) schemes → `webview`; http(s) or empty/about:blank → `safari`.
+
+The canonical end-to-end example for WebView ↔ Native switching is
+`tests/integration/webview-native-context.live.test.ts` (opt-in via
+`OPENSAFARI_LIVE_WEBVIEW=1`).
 
 #### app_alert_handle
 Accept, dismiss, or press a named button on a system alert/dialog on a booted iOS Simulator.

--- a/tests/fixtures/webview_flutter_bridge/.gitignore
+++ b/tests/fixtures/webview_flutter_bridge/.gitignore
@@ -1,0 +1,10 @@
+/build/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+ios/Pods/
+ios/Runner.xcworkspace/xcuserdata/
+ios/Flutter/Flutter.framework
+ios/Flutter/Flutter.podspec
+ios/Flutter/Generated.xcconfig
+ios/Flutter/flutter_export_environment.sh

--- a/tests/fixtures/webview_flutter_bridge/README.md
+++ b/tests/fixtures/webview_flutter_bridge/README.md
@@ -1,0 +1,55 @@
+# webview_flutter_bridge — Flutter fixture for WebView↔Native E2E
+
+## Purpose
+
+A minimal single-screen Flutter app that embeds a `WebViewWidget` (via
+`webview_flutter`) pointing at a bundled local HTML asset. The asset is
+deterministic and makes **no network requests**, ensuring stable test
+conditions.
+
+The fixture is exercised by
+`tests/integration/webview-native-context.live.test.ts` (opt-in via
+`OPENSAFARI_LIVE_WEBVIEW=1`).
+
+Bundle ID: `com.opensafari.fixtures.webviewbridge`
+
+## Generating the Flutter scaffold
+
+```sh
+cd tests/fixtures/webview_flutter_bridge
+flutter create --org com.opensafari.fixtures --project-name webview_flutter_bridge --platforms=ios .
+```
+
+After running `flutter create`, overwrite the generated files with the
+versions in this directory:
+
+```sh
+# Overwrite entrypoint and manifest
+cp lib/main.dart   <generated>/lib/main.dart
+cp pubspec.yaml    <generated>/pubspec.yaml
+
+# Add the local HTML asset
+mkdir -p assets
+cp assets/index.html <generated>/assets/index.html
+```
+
+## Building and installing
+
+```sh
+./build.sh --install --device-id <UDID>
+```
+
+`build.sh` will:
+1. Run `flutter pub get`.
+2. Build for the iOS Simulator (`flutter build ios --simulator --debug --no-codesign`).
+3. Install the `.app` bundle onto the simulator identified by `<UDID>` using
+   `xcrun simctl install`.
+
+## Screen layout
+
+| Element                    | Key / identifier         | Role                          |
+|---------------------------|--------------------------|-------------------------------|
+| `ElevatedButton` (top)    | `load_webview_btn`       | Tapping renders the WebView   |
+| `WebViewWidget`           | —                        | Shows `assets/index.html`     |
+| `ElevatedButton` (bottom) | `native_confirm_btn`     | Sets status text to "confirmed" |
+| `Text`                    | `native_status_text`     | Displays confirmation status  |

--- a/tests/fixtures/webview_flutter_bridge/assets/index.html
+++ b/tests/fixtures/webview_flutter_bridge/assets/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OpenSafari Bridge Fixture</title>
+  <style>
+    body { font-family: sans-serif; padding: 24px; }
+    button { padding: 12px 24px; font-size: 16px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <h1 id="heading">WebView Bridge</h1>
+  <button id="web-action" onclick="document.getElementById('web-info').textContent = 'clicked'">
+    Click me
+  </button>
+  <div id="web-info">idle</div>
+</body>
+</html>

--- a/tests/fixtures/webview_flutter_bridge/build.sh
+++ b/tests/fixtures/webview_flutter_bridge/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# build.sh — build and optionally install the webview_flutter_bridge fixture.
+#
+# Usage:
+#   ./build.sh                          # build only
+#   ./build.sh --install                # build + install to booted simulator
+#   ./build.sh --install --device-id <UDID>  # build + install to specific device
+#
+# Requirements:
+#   - Flutter SDK on PATH (run `flutter --version` to verify)
+#   - macOS with Xcode 15+ installed
+#   - A booted iOS Simulator (for --install)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUNDLE_ID="com.opensafari.fixtures.webviewbridge"
+APP_PATH="$SCRIPT_DIR/build/ios/iphonesimulator/Runner.app"
+
+INSTALL=false
+DEVICE_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install) INSTALL=true; shift ;;
+    --device-id) DEVICE_ID="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Verify flutter is available
+if ! command -v flutter &>/dev/null; then
+  echo "ERROR: 'flutter' not found on PATH." >&2
+  echo "Install the Flutter SDK: https://docs.flutter.dev/get-started/install" >&2
+  exit 1
+fi
+
+echo "==> flutter pub get"
+(cd "$SCRIPT_DIR" && flutter pub get)
+
+echo "==> flutter build ios --simulator --debug --no-codesign"
+(cd "$SCRIPT_DIR" && flutter build ios --simulator --debug --no-codesign)
+
+echo "Built: $APP_PATH"
+echo "Bundle ID: $BUNDLE_ID"
+
+if [ "$INSTALL" = true ]; then
+  if [ -z "$DEVICE_ID" ]; then
+    DEVICE_ID="booted"
+  fi
+  echo "==> Installing to device: $DEVICE_ID"
+  xcrun simctl install "$DEVICE_ID" "$APP_PATH"
+  echo "Installed $BUNDLE_ID on $DEVICE_ID"
+fi

--- a/tests/fixtures/webview_flutter_bridge/lib/main.dart
+++ b/tests/fixtures/webview_flutter_bridge/lib/main.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'OpenSafari Bridge Fixture',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueGrey),
+      ),
+      home: const BridgePage(),
+    );
+  }
+}
+
+class BridgePage extends StatefulWidget {
+  const BridgePage({super.key});
+
+  @override
+  State<BridgePage> createState() => _BridgePageState();
+}
+
+class _BridgePageState extends State<BridgePage> {
+  bool _webViewVisible = false;
+  String _nativeStatus = 'idle';
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted);
+  }
+
+  Future<void> _loadWebView() async {
+    await _controller.loadFlutterAsset('assets/index.html');
+    setState(() {
+      _webViewVisible = true;
+    });
+  }
+
+  void _confirmNative() {
+    setState(() {
+      _nativeStatus = 'confirmed';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Bridge Fixture'),
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Semantics(
+              identifier: 'load_webview_btn',
+              child: ElevatedButton(
+                key: const Key('load_webview_btn'),
+                onPressed: _loadWebView,
+                child: const Text('Load WebView'),
+              ),
+            ),
+          ),
+          if (_webViewVisible)
+            Expanded(
+              child: WebViewWidget(controller: _controller),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Semantics(
+              identifier: 'native_confirm_btn',
+              child: ElevatedButton(
+                key: const Key('native_confirm_btn'),
+                onPressed: _confirmNative,
+                child: const Text('Confirm Native'),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: Semantics(
+              identifier: 'native_status_text',
+              child: Text(
+                _nativeStatus,
+                key: const Key('native_status_text'),
+                style: const TextStyle(fontSize: 18),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/tests/fixtures/webview_flutter_bridge/pubspec.yaml
+++ b/tests/fixtures/webview_flutter_bridge/pubspec.yaml
@@ -1,0 +1,24 @@
+name: webview_flutter_bridge
+description: "Minimal Flutter fixture that embeds a local HTML asset via webview_flutter for OpenSafari E2E tests."
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  webview_flutter: ^4.7.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true
+
+  assets:
+    - assets/index.html

--- a/tests/integration/webview-native-context.live.test.ts
+++ b/tests/integration/webview-native-context.live.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Live integration suite for issue #593 — WebView↔Native cross-context E2E.
+ *
+ * Exercises the full native→webview→native bounce:
+ *
+ *   1. Builds and installs the webview_flutter_bridge fixture app.
+ *   2. Launches the fixture via `simctl launch`.
+ *   3. AX-presses `load_webview_btn` to render the embedded WebView.
+ *   4. Discovers the WebView target via ios-webkit-debug-proxy.
+ *   5. Connects to the WebView, asserts heading text, and clicks a DOM button.
+ *   6. Disconnects and bounces back to native — AX-presses `native_confirm_btn`
+ *      and polls until `native_status_text` reads "confirmed".
+ *   7. Surfaces an RSS memory delta (non-fatal) so CI logs show the number.
+ *
+ * **Opt-in only.** Ignored by `npm test` (jest.config.js excludes
+ * `tests/integration/`). To run locally:
+ *
+ *   1. Boot an iPhone simulator.
+ *   2. Start ios-webkit-debug-proxy:
+ *        ios_webkit_debug_proxy -c <UDID>:9322
+ *   3. Run:
+ *        OPENSAFARI_LIVE_WEBVIEW=1 OSF_DEVICE_ID=<UDID> \
+ *          npx jest tests/integration/webview-native-context.live.test.ts \
+ *          --runInBand --testPathIgnorePatterns=/node_modules/
+ *
+ * Environment variables:
+ *   OPENSAFARI_LIVE_WEBVIEW  — must be '1' to opt in
+ *   OSF_DEVICE_ID            — UDID of the target simulator (required)
+ *   OPENSAFARI_PROXY_PORT    — ios-webkit-debug-proxy port (default: 9322)
+ */
+
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+import { WebKitClient } from '../../src/webkit/client';
+import {
+  ensureSemanticsActive,
+  getAccessibilityBridge,
+} from '../../src/native';
+import { resetInputBackend } from '../../src/tools/native-input-backend';
+
+/* ─── Environment ──────────────────────────────────────────────────── */
+
+const LIVE = process.env.OPENSAFARI_LIVE_WEBVIEW === '1';
+const DEVICE_ID =
+  process.env.OSF_DEVICE_ID ?? '3BEF4E9A-069A-4419-AC62-AB889348EF12';
+const BUNDLE_ID = 'com.opensafari.fixtures.webviewbridge';
+const PROXY_HOST = 'localhost';
+const PROXY_PORT = parseInt(
+  process.env.OPENSAFARI_PROXY_PORT ?? '9322',
+  10,
+);
+
+const FIXTURE_DIR = path.resolve(
+  __dirname,
+  '../../tests/fixtures/webview_flutter_bridge',
+);
+const BUILD_SCRIPT = path.join(FIXTURE_DIR, 'build.sh');
+
+jest.setTimeout(240_000);
+
+/* ─── Helpers ──────────────────────────────────────────────────────── */
+
+/**
+ * Classify a target URL: file:// or custom scheme → webview; http(s) → safari.
+ * TODO(#592): once bundle-aware classification lands, prefer
+ * app_webview_connect + classificationReason === 'bundle_match' over this
+ * URL heuristic.
+ */
+function isWebViewUrl(url: string): boolean {
+  if (!url || url === 'about:blank') return false;
+  return !url.startsWith('http://') && !url.startsWith('https://');
+}
+
+function launchFixture(): void {
+  try {
+    execFileSync('xcrun', ['simctl', 'terminate', DEVICE_ID, BUNDLE_ID], {
+      stdio: 'pipe',
+    });
+  } catch {
+    /* not running — fine */
+  }
+  execFileSync('xcrun', ['simctl', 'launch', DEVICE_ID, BUNDLE_ID], {
+    stdio: 'pipe',
+  });
+}
+
+function terminateFixture(): void {
+  try {
+    execFileSync('xcrun', ['simctl', 'terminate', DEVICE_ID, BUNDLE_ID], {
+      stdio: 'pipe',
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/* ─── Suite ────────────────────────────────────────────────────────── */
+
+describe('issue #593 — WebView↔Native cross-context E2E', () => {
+  if (!LIVE) {
+    test.skip(
+      'set OPENSAFARI_LIVE_WEBVIEW=1 and OSF_DEVICE_ID=<UDID> to run WebView↔Native E2E tests',
+      () => {},
+    );
+    return;
+  }
+
+  let webkitClient: WebKitClient;
+  const rssAtStart = process.memoryUsage().rss;
+
+  beforeAll(async () => {
+    // Build + install the Flutter fixture
+    execFileSync(
+      '/bin/sh',
+      [BUILD_SCRIPT, '--install', '--device-id', DEVICE_ID],
+      { timeout: 180_000, stdio: 'pipe' },
+    );
+
+    launchFixture();
+    // Wait for the app process to start, then re-launch to bring it to the
+    // foreground (same pattern as webview-smoke.live.test.ts).
+    await new Promise((r) => setTimeout(r, 3000));
+    execFileSync('xcrun', ['simctl', 'launch', DEVICE_ID, BUNDLE_ID], {
+      stdio: 'pipe',
+    });
+    await new Promise((r) => setTimeout(r, 3000));
+
+    resetInputBackend();
+    await ensureSemanticsActive(DEVICE_ID);
+  });
+
+  afterAll(async () => {
+    if (webkitClient) {
+      await webkitClient.disconnect().catch(() => {});
+    }
+    terminateFixture();
+    resetInputBackend();
+
+    // ── Memory soak regression surface (test 5) ──────────────────────
+    // Not a hard assertion — surfaces the delta so CI logs capture it.
+    // The 100 MB hard check is handled by the nightly sentinel.
+    const rssDelta = process.memoryUsage().rss - rssAtStart;
+    // eslint-disable-next-line no-console
+    console.error(
+      `[webview-native-context] RSS delta across suite: ${(rssDelta / 1024 / 1024).toFixed(1)} MB`,
+    );
+  });
+
+  // ─── Test 1: AX press on load_webview_btn shows the WebView ────────
+
+  test('AX press on load_webview_btn launches the embedded WebView', async () => {
+    webkitClient = new WebKitClient({ host: PROXY_HOST, port: PROXY_PORT });
+
+    const bridge = getAccessibilityBridge();
+    const result = await bridge.query(
+      { identifier: 'load_webview_btn' },
+      { deviceId: DEVICE_ID },
+    );
+    expect(result.matches.length).toBeGreaterThan(0);
+
+    const match = result.matches[0];
+    const pressResult = await bridge.press(match.path, DEVICE_ID);
+    expect(pressResult.ok).toBe(true);
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `[webview-native-context] AX press load_webview_btn: ok=${pressResult.ok}, code=${pressResult.code}`,
+    );
+
+    // Poll for a WebView target (file:// URL from Flutter asset) up to 30 s.
+    // TODO(#592): once bundle-aware classification lands, prefer
+    // app_webview_connect + classificationReason === 'bundle_match' over this
+    // URL heuristic.
+    let webviewTarget:
+      | { id: string; title: string; url: string; webSocketDebuggerUrl: string }
+      | undefined;
+    for (let i = 0; i < 30; i++) {
+      const targets = await webkitClient.listTargets();
+      webviewTarget = targets.find(
+        (t) =>
+          isWebViewUrl(t.url) ||
+          t.title.includes('Bridge Fixture') ||
+          t.title.includes('OpenSafari Bridge Fixture'),
+      );
+      if (webviewTarget) break;
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+
+    expect(webviewTarget).toBeDefined();
+    // eslint-disable-next-line no-console
+    console.error(
+      `[webview-native-context] WebView target: url="${webviewTarget!.url}", title="${webviewTarget!.title}"`,
+    );
+  });
+
+  // ─── Test 2: Context-switch + DOM eval round-trip ──────────────────
+
+  test('context-switch + DOM eval round-trip — heading text is "WebView Bridge"', async () => {
+    const targets = await webkitClient.listTargets();
+    const wvTarget = targets.find(
+      (t) =>
+        isWebViewUrl(t.url) ||
+        t.title.includes('Bridge Fixture') ||
+        t.title.includes('OpenSafari Bridge Fixture'),
+    );
+    expect(wvTarget).toBeDefined();
+
+    await webkitClient.connectToUrl(wvTarget!.webSocketDebuggerUrl);
+
+    const result = await webkitClient.send<{
+      result: { type: string; value: string };
+    }>('Runtime.evaluate', {
+      expression: 'document.getElementById("heading").textContent',
+    });
+
+    expect(result.result.type).toBe('string');
+    expect(result.result.value).toBe('WebView Bridge');
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `[webview-native-context] DOM heading: "${result.result.value}"`,
+    );
+  });
+
+  // ─── Test 3: In-WebView click mutates DOM ──────────────────────────
+
+  test('in-WebView click mutates DOM — web-info becomes "clicked"', async () => {
+    const clickResult = await webkitClient.send<{
+      result: { type: string; value: string };
+    }>('Runtime.evaluate', {
+      expression: `
+        document.getElementById('web-action').click();
+        document.getElementById('web-info').textContent;
+      `,
+    });
+
+    expect(clickResult.result.value).toBe('clicked');
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `[webview-native-context] In-WebView click: web-info="${clickResult.result.value}"`,
+    );
+  });
+
+  // ─── Test 4: Bounce back to native ─────────────────────────────────
+
+  test('bounce back to native — native_confirm_btn sets native_status_text to "confirmed"', async () => {
+    await webkitClient.disconnect().catch(() => {});
+
+    const bridge = getAccessibilityBridge();
+    const btnResult = await bridge.query(
+      { identifier: 'native_confirm_btn' },
+      { deviceId: DEVICE_ID },
+    );
+    expect(btnResult.matches.length).toBeGreaterThan(0);
+
+    const pressResult = await bridge.press(
+      btnResult.matches[0].path,
+      DEVICE_ID,
+    );
+    expect(pressResult.ok).toBe(true);
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `[webview-native-context] AX press native_confirm_btn: ok=${pressResult.ok}`,
+    );
+
+    // Poll native_status_text until value === 'confirmed' (10 s max)
+    let confirmed = false;
+    for (let i = 0; i < 10; i++) {
+      const statusResult = await bridge.query(
+        { identifier: 'native_status_text' },
+        { deviceId: DEVICE_ID },
+      );
+      if (statusResult.matches.length > 0) {
+        const m = statusResult.matches[0] as { value?: string; label?: string };
+        // eslint-disable-next-line no-console
+        console.error(
+          `[webview-native-context] native_status_text poll ${i + 1}: value="${m.value}" label="${m.label}"`,
+        );
+        if (m.value === 'confirmed' || m.label === 'confirmed') {
+          confirmed = true;
+          break;
+        }
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+
+    expect(confirmed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tests/fixtures/webview_flutter_bridge/` — a minimal Flutter fixture app embedding `webview_flutter` with a deterministic local HTML asset (`assets/index.html`). No network requests; fully self-contained.
- Adds `tests/integration/webview-native-context.live.test.ts` — opt-in integration suite (gated behind `OPENSAFARI_LIVE_WEBVIEW=1`) covering the full native→webview→native context-switch bridge:
  1. AX-press `load_webview_btn` → WebView target appears in ios-webkit-debug-proxy
  2. `connectToUrl` + `Runtime.evaluate` → DOM heading text assertion (`"WebView Bridge"`)
  3. In-WebView JS click → `web-info` DOM mutation (`"clicked"`)
  4. Disconnect + AX-press `native_confirm_btn` → poll `native_status_text` until `"confirmed"`
  5. RSS memory delta surfaced in `afterAll` (non-fatal; nightly sentinel owns the 100 MB hard check)
- Updates `docs/api-reference.md` to add an `app_webview_connect` section pointing to the canonical E2E example.

## Pre-deploy checklist

- [x] Flutter fixture authored (`lib/main.dart`, `pubspec.yaml`, `assets/index.html`, `build.sh`)
- [x] Integration test compiles cleanly (`npx tsc --noEmit` — zero errors)
- [x] `npm run build` passes
- [x] Suite excluded from default `npm test` (`jest.config.js` already ignores `/tests/integration/`)
- [x] `console.error` used for all logging (no `console.log`)
- [x] `OPENSAFARI_LIVE_WEBVIEW=1` gate in place; skip message shown when unset
- [ ] Live smoke run against booted simulator — requires `OPENSAFARI_LIVE_WEBVIEW=1 OSF_DEVICE_ID=<UDID>` (nightly CI job)
- [ ] Flutter fixture built and installed end-to-end (requires Flutter SDK + Xcode on CI runner)

## How to run locally

```sh
# 1. Boot a simulator and start ios-webkit-debug-proxy
ios_webkit_debug_proxy -c <UDID>:9322

# 2. Build + install the fixture (requires Flutter SDK)
cd tests/fixtures/webview_flutter_bridge
./build.sh --install --device-id <UDID>

# 3. Run the suite
OPENSAFARI_LIVE_WEBVIEW=1 OSF_DEVICE_ID=<UDID> \
  npx jest tests/integration/webview-native-context.live.test.ts \
  --runInBand --testPathIgnorePatterns=/node_modules/
```

## Notes

- **Bundle-aware classification (#592):** This suite uses a URL-scheme heuristic (`file://` → webview) to discover the WebView target, independent of PR #592. A `TODO(#592)` comment is in the target-discovery block; once #592 lands and `classificationReason === 'bundle_match'` is available, the heuristic can be replaced with `app_webview_connect`.
- `docs/api-reference.md` did not previously have an `app_webview_connect` entry; one was added in this PR rather than skipping the doc update.

Closes #593