### PR TITLE
docs(private-apis): add deployment-scope guidance + warning link (#601)

### DIFF
--- a/docs/private-apis.md
+++ b/docs/private-apis.md
@@ -18,6 +18,71 @@ auditable. Every private symbol we touch is listed here together with:
 If you add a new private-framework call, you **must** update this file in
 the same PR. Reviewers will block merges that skip this step.
 
+## Deployment scope
+
+> **TL;DR — host-side simulator automation only. Do not bundle into a shipping iOS app.**
+
+OpenSafari loads `SimulatorKit.framework` and `CoreSimulator.framework` via
+`dlopen` and uses Apple-private IOKit / Accessibility entry points. These
+frameworks are part of the **macOS developer toolchain** (they ship inside
+`/Library/Developer/PrivateFrameworks/` and `Xcode.app`), not the iOS SDK,
+and they are intended for tooling that drives the iOS Simulator from a
+developer Mac.
+
+### ✅ Allowed
+
+- Running OpenSafari on a developer Mac as an MCP server / CLI.
+- Running OpenSafari on macOS CI runners (GitHub Actions `macos-*`,
+  Buildkite Mac agents, internal Mac mini farms) for headless QA against
+  the iOS Simulator.
+- Bundling OpenSafari with internal developer tooling distributed to
+  engineers (it never leaves macOS).
+
+### ❌ Not allowed
+
+- **Bundling `sim-hid-bridge`, `ax-bridge`, the SimulatorKit `dlopen`
+  helper, or any other private-API helper inside an iOS `.ipa` submitted
+  to the App Store, TestFlight, Ad Hoc, or Enterprise (in-house)
+  distribution.** Private frameworks and undocumented APIs trigger App
+  Store Review Guideline 2.5.1 / 2.5.2 rejections, and Enterprise
+  Distribution programs prohibit shipping software that uses
+  non-public APIs.
+- Shipping derivative works that load `SimulatorKit.framework`,
+  `CoreSimulator.framework`, or any `Indigo*` / `IOHIDEvent*` symbol
+  inside an iOS device build (the symbols don't exist on-device anyway,
+  but stripping them out of a fork before redistribution is the
+  consumer's responsibility).
+- Re-targeting the helpers to drive a physical iOS device. The
+  SimulatorKit HID path operates on `SimDevice` instances managed by
+  CoreSimulator; it has no on-device counterpart and any attempt to
+  port it would require additional, separately-prohibited private APIs.
+
+### Rationale
+
+- **Apple App Review** — Guideline 2.5.1 requires apps to use only
+  public APIs; 2.5.2 requires self-contained executable code. Bundling
+  `dlopen("…/SimulatorKit.framework/SimulatorKit")` inside an iOS app
+  fails both even before the framework's absence on iOS becomes the
+  immediate runtime crash.
+- **Framework provenance** — `SimulatorKit.framework` and
+  `CoreSimulator.framework` live under
+  `/Library/Developer/PrivateFrameworks/` (Mac developer tools), not in
+  any iOS SDK. They have no code-signing entitlement that would let
+  them ship inside an `.ipa`.
+- **Same posture as `idb`** — Facebook's `idb` (which uses the same
+  SimulatorKit HID surface) is a host-side daemon for the same reason;
+  it is not shipped inside iOS apps either.
+
+### License interaction
+
+The MIT license on this repository covers OpenSafari's own source. It
+does **not** sublicense Apple's frameworks. Any use of
+`SimulatorKit.framework`, `CoreSimulator.framework`, or other Apple
+private APIs remains subject to the Xcode and macOS license agreements
+you accepted when installing them. See [`../LICENSE`](../LICENSE) for
+the OpenSafari grant; consult Apple's developer agreements for the
+permissible scope of the loaded frameworks themselves.
+
 ## Loaded frameworks
 
 | Framework | Path | Why |

--- a/src/tools/sim-hid-input-backend.ts
+++ b/src/tools/sim-hid-input-backend.ts
@@ -223,7 +223,10 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
         '[opensafari] SimulatorKitHIDInputBackend uses private Apple frameworks ' +
           '(SimulatorKit.framework, CoreSimulator.framework) via dlopen. ' +
           'These APIs are undocumented and Xcode updates may break them. ' +
-          PRIVATE_API_DOC_REF,
+          'Where can I use this? macOS host / CI only — never bundle inside an ' +
+          'iOS .ipa shipped to the App Store or TestFlight. ' +
+          PRIVATE_API_DOC_REF +
+          ' (see "Deployment scope").',
       );
     }
     const { cmd, cmdArgs } = this.resolveSpawn(args);

--- a/tests/unit/sim-hid-input-backend.test.ts
+++ b/tests/unit/sim-hid-input-backend.test.ts
@@ -425,6 +425,11 @@ describe('SimulatorKitHIDInputBackend private-API warning', () => {
     );
     expect(warningCalls).toHaveLength(1);
     expect(warningCalls[0][0]).toMatch(/docs\/private-apis\.md/);
+    // Issue #601: warning must signal deployment scope (host/CI only, not iOS .ipa)
+    expect(warningCalls[0][0]).toMatch(/Where can I use this\?/);
+    expect(warningCalls[0][0]).toMatch(/macOS host \/ CI only/);
+    expect(warningCalls[0][0]).toMatch(/never bundle inside an iOS \.ipa/);
+    expect(warningCalls[0][0]).toMatch(/Deployment scope/);
   });
 
   test('does not re-emit the notice on subsequent spawns', async () => {


### PR DESCRIPTION
Closes #601.

## Summary
- Add a **"Deployment scope"** section to `docs/private-apis.md` that explicitly draws the host-only line: OpenSafari's SimulatorKit / CoreSimulator / AX private-API calls are appropriate for developer Macs + macOS CI runners, and **must not** be bundled inside an iOS `.ipa` submitted to the App Store, TestFlight, Ad Hoc, or Enterprise distribution.
- Update the one-time `stderr` notice emitted by `SimulatorKitHIDInputBackend` to include a short "Where can I use this? macOS host / CI only — never bundle inside an iOS .ipa shipped to the App Store or TestFlight." pointer, with a `(see "Deployment scope")` anchor hint to the doc.
- Extend the existing warning-latch unit test to assert the new deployment-scope language + anchor string.

## Why
v0.4.8 #527 added a one-time runtime warning pointing at `docs/private-apis.md`, but the doc only covered the technical / BC-monitoring angle. Consumers expanding from "MCP dev tool" to "include in my shipping iOS app for internal QA" risked App Review rejection (Guidelines 2.5.1 / 2.5.2) or Enterprise Distribution violations because the doc did not draw the host-vs-device line explicitly.

Key points captured in the new section:
- ✅ Allowed: developer Macs, macOS CI (GitHub Actions `macos-*`, Buildkite Mac agents, internal Mac farms), internal dev tooling shipped to engineers.
- ❌ Not allowed: any iOS `.ipa` distribution (App Store / TestFlight / Ad Hoc / Enterprise), forks that keep the SimulatorKit call surface on-device, physical-device re-targeting.
- Framework provenance: `SimulatorKit.framework` and `CoreSimulator.framework` ship under `/Library/Developer/PrivateFrameworks/` and inside `Xcode.app` — they are **macOS developer-tool frameworks**, not iOS SDK surfaces, and have no entitlement to ship in an `.ipa`.
- License interaction: the MIT grant on this repo covers OpenSafari source only; Apple-framework use remains subject to the Xcode / macOS license agreements. (Does not change the MIT grant.)

## Pre-Deploy Checklist
- [x] Section added with bullet summary + expanded rationale (`docs/private-apis.md` §"Deployment scope")
- [x] One-time warning string updated in `src/tools/sim-hid-input-backend.ts`
- [x] Warning-latch unit tests updated (`tests/unit/sim-hid-input-backend.test.ts` — 32/32 pass). The test file the issue referenced (`tests/unit/mcp-telemetry-metadata.test.ts`) doesn't exist in the repo; the actual assertions live in `sim-hid-input-backend.test.ts` under the "private-API warning" describe block, which is the correct location.
- [ ] Legal review / maintainer sign-off — requesting review from @shaun0927.

## Post-Deploy Validation Checklist
- [ ] Doc renders on GitHub and via the warning link
- [ ] No behavior change — only informational (console.error message is one line longer; no new side effects)
- [ ] Release notes mention the clarification (target milestone 0.5.1)
- [ ] Community Q&A / issues referencing deployment scope reduced over following month

## Verification
- `npx jest tests/unit/sim-hid-input-backend.test.ts` → ✅ 32/32 pass
- `npm run build` → ✅ ok

## Related
- #493, #527, #529 (idb comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)