### PR TITLE
feat(ci): parameterize sentinel alert destination (#599)

### DIFF
--- a/.github/workflows/_sentinel-notify.yml
+++ b/.github/workflows/_sentinel-notify.yml
@@ -1,0 +1,93 @@
+name: Sentinel Notify (reusable)
+
+# Forks-friendly notifier for the Private API Sentinel (#541, #599).
+#
+# Called from `private-api-sentinel.yml` on scheduled failures so forks and
+# downstream orgs can redirect alerts to their own Slack / Discord endpoint
+# without editing the sentinel workflow itself.
+#
+# Contract:
+#   - `webhook-url` (secret) selects the destination. If missing or empty the
+#     job short-circuits — the sentinel run still succeeds and the GitHub
+#     tracking issue still gets opened, so a missing secret never masks a
+#     regression.
+#   - `channel` (var, default `#opensafari-sentinels`) is forwarded to
+#     Slack-compatible endpoints. Ignored by Discord, which drives channel
+#     routing from the webhook URL itself.
+#   - The webhook host switches the payload shape: `hooks.slack.com` uses the
+#     Slack Incoming Webhooks schema (`text`); everything else falls back to
+#     Discord's `{ "content": "…" }` schema, which also works for Mattermost
+#     and Rocket.Chat.
+#
+# This keeps the sentinel workflow declarative (no per-provider curl blocks)
+# and gives future notifiers (PagerDuty, Telegram) a single surface to grow.
+
+on:
+  workflow_call:
+    inputs:
+      title:
+        required: true
+        type: string
+        description: Short headline for the alert (e.g. "Private API regression").
+      body:
+        required: true
+        type: string
+        description: Multi-line body. Kept small; use the workflow run URL for the full log.
+      runner:
+        required: true
+        type: string
+        description: Matrix runner label so recipients can spot which row failed.
+      run-url:
+        required: true
+        type: string
+        description: Direct URL to the failing workflow run.
+      channel:
+        required: false
+        type: string
+        default: '#opensafari-sentinels'
+        description: Slack channel override. Ignored by Discord-shaped webhooks.
+    secrets:
+      webhook-url:
+        required: false
+        description: Slack / Discord / Mattermost Incoming Webhook URL. Missing ⇒ no-op.
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.webhook-url }}
+          CHANNEL: ${{ inputs.channel }}
+          TITLE: ${{ inputs.title }}
+          BODY: ${{ inputs.body }}
+          RUNNER: ${{ inputs.runner }}
+          RUN_URL: ${{ inputs.run-url }}
+        run: |
+          if [ -z "${WEBHOOK_URL}" ]; then
+            echo "SENTINEL_WEBHOOK_URL is not configured — skipping webhook notification."
+            echo "(The GitHub tracking issue will still be opened by the caller.)"
+            exit 0
+          fi
+
+          # Slack vs. generic: switch purely on host so a single secret rotation
+          # can move the org between providers without touching the workflow.
+          host="$(printf '%s' "${WEBHOOK_URL}" | awk -F/ '{print $3}')"
+          text="*${TITLE}*"$'\n'"Runner: \`${RUNNER}\`"$'\n'"Run: ${RUN_URL}"$'\n\n'"${BODY}"
+
+          if [ "${host}" = "hooks.slack.com" ]; then
+            payload=$(jq -n \
+              --arg channel "${CHANNEL}" \
+              --arg text "${text}" \
+              '{channel: $channel, text: $text}')
+          else
+            # Discord / Mattermost / Rocket.Chat all accept { "content": "…" }.
+            payload=$(jq -n --arg content "${text}" '{content: $content}')
+          fi
+
+          # `--fail-with-body` surfaces 4xx payloads (e.g. a revoked webhook)
+          # so the workflow logs tell the on-call why the ping was dropped.
+          curl --silent --show-error --fail-with-body \
+            -H 'Content-Type: application/json' \
+            -X POST -d "${payload}" \
+            "${WEBHOOK_URL}"

--- a/.github/workflows/private-api-sentinel.yml
+++ b/.github/workflows/private-api-sentinel.yml
@@ -36,6 +36,15 @@ permissions:
   contents: read
   issues: write
 
+# Fork-friendly alerting (#599):
+#   - `SENTINEL_WEBHOOK_URL` (secret, optional): Slack / Discord / Mattermost
+#     Incoming Webhook. Missing ⇒ notify step is a no-op, the GitHub tracking
+#     issue still gets opened so a missing secret never masks a regression.
+#   - `SENTINEL_CHANNEL` (variable, optional): Slack channel override. Defaults
+#     to `#opensafari-sentinels`. Ignored by Discord-shaped webhooks, whose
+#     channel routing is baked into the URL.
+# See `docs/ci-integration.md` → "Private API Sentinel alerting" for setup.
+
 jobs:
   sentinel:
     # Matrix across hosted macOS runners so a regression tied to a specific
@@ -200,3 +209,22 @@ jobs:
             }
         env:
           RUNNER_LABEL: ${{ matrix.runner }}
+
+  notify:
+    # Fan-in notifier: posts a single alert per sentinel run to whatever webhook
+    # the fork has configured. Kept as a separate job so the sentinel matrix
+    # itself does not gain network dependencies on Slack / Discord.
+    needs: sentinel
+    if: failure() && github.event_name == 'schedule'
+    uses: ./.github/workflows/_sentinel-notify.yml
+    with:
+      title: 'Private API Sentinel — regression detected'
+      runner: 'fan-in (see workflow run for matrix rows)'
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      body: |
+        One or more probes failed on the daily scheduled sentinel run.
+        Check the `sentinel-*` artifacts on the workflow run for the full jest
+        report and the `sentinel` tracking issue for the triage checklist.
+      channel: ${{ vars.SENTINEL_CHANNEL || '#opensafari-sentinels' }}
+    secrets:
+      webhook-url: ${{ secrets.SENTINEL_WEBHOOK_URL }}

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -414,6 +414,50 @@ For apps that embed WebViews, discover and switch between native and web context
             error-logs.json
 ```
 
+## Private API Sentinel alerting
+
+The [`private-api-sentinel`](../.github/workflows/private-api-sentinel.yml)
+workflow runs the six private-API probes daily and is the canary for Apple-side
+breakage across Xcode / macOS releases. It always opens a `sentinel`-labeled
+GitHub tracking issue on failure; it can additionally post to a Slack, Discord,
+or Mattermost webhook when the repo is configured for it.
+
+### Configuration
+
+| Name | Kind | Default | Purpose |
+|---|---|---|---|
+| `SENTINEL_WEBHOOK_URL` | Secret | _unset_ | Incoming Webhook URL. When unset the notifier short-circuits and only the GitHub tracking issue is opened. Rotate via repo → Settings → Secrets and variables → Actions. |
+| `SENTINEL_CHANNEL` | Variable | `#opensafari-sentinels` | Slack channel override. Ignored by Discord / Mattermost webhooks, whose channel routing is encoded in the URL. |
+
+The workflow switches payload shape on the webhook host: `hooks.slack.com`
+receives a Slack-format `{ channel, text }` body; any other host receives a
+Discord-compatible `{ content }` body that Mattermost and Rocket.Chat also
+accept. No custom action is required.
+
+### Fork checklist
+
+1. **Add the secret**: `SENTINEL_WEBHOOK_URL` at repo scope. Minimum permissions
+   on the receiving provider:
+   - Slack: `chat:write` via Incoming Webhooks app, scoped to the destination
+     channel only.
+   - Discord: channel-specific webhook from _Channel Settings → Integrations_.
+   - Mattermost / Rocket.Chat: channel Incoming Webhook.
+2. **Optional**: set `vars.SENTINEL_CHANNEL` if your Slack destination is not
+   `#opensafari-sentinels`.
+3. **Rotate**: updating the secret takes effect on the next scheduled run; no
+   workflow edit needed.
+
+### Behaviour
+
+- Missing secret → `notify` job logs the reason and exits 0. The `sentinel`
+  matrix status is unaffected, and the GitHub tracking issue still gets
+  opened, so a missing secret never silently masks a regression.
+- Invalid / revoked webhook → `curl --fail-with-body` fails the notify job and
+  echoes the provider response so the on-call can see why the ping dropped.
+- Custom notifiers (PagerDuty, Telegram, …) can be added by extending the
+  reusable workflow at `.github/workflows/_sentinel-notify.yml`; callers do not
+  need to change.
+
 ## See also
 
 - [Getting Started](getting-started.md)


### PR DESCRIPTION
## Summary
- Lets forks redirect Private API Sentinel alerts to Slack / Discord / Mattermost without editing the workflow, via `secrets.SENTINEL_WEBHOOK_URL` + optional `vars.SENTINEL_CHANNEL` (default `#opensafari-sentinels`).
- Extracts the notify step into a reusable workflow `.github/workflows/_sentinel-notify.yml`. Payload shape switches on webhook host — `hooks.slack.com` gets Slack's schema, everything else gets Discord's `{content}` (Mattermost / Rocket.Chat compatible).
- Missing secret ⇒ notify job logs the reason and exits 0. Matrix status is unaffected and the GitHub tracking issue still opens, so a missing webhook never masks a regression.

## Test plan
- [x] `python3 -c 'yaml.safe_load(...)'` on both workflow files
- [x] `actionlint` clean on both workflow files
- [ ] CI dry run (will happen on merge to `develop`; scheduled run validates notify path)
- [ ] Downstream fork check — point a Discord webhook at a fork, trigger `workflow_dispatch`, confirm the message lands

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)