### PR TITLE
fix(540): admit ax-press to audit-log backendKind allow-list

### DIFF
--- a/src/ci/audit-log-posture.ts
+++ b/src/ci/audit-log-posture.ts
@@ -20,10 +20,18 @@ import * as fs from 'node:fs';
 
 /**
  * The only `InputBackendKind` values that satisfy the #540 acceptance
- * criterion. Keep this list narrow — any legacy backend (`applescript`,
- * `simctl`, `ax-press`) should be rejected by the posture check.
+ * criterion. Keep this list narrow — legacy foreground-coupled backends
+ * (`applescript`, `simctl`) must stay rejected.
+ *
+ * `ax-press` is allowed because PR #587's ADR on #573 established that the
+ * ax-bridge AX channel is already GUI-less: `AXUIElementCreateApplication(pid)`
+ * targets Simulator.app by PID and does not require it to be the macOS
+ * frontmost application. `app-tap-element` stamps `headless: true` on every
+ * ax-press result (src/tools/app-tap-element.ts), so the posture check
+ * treats it as a first-class headless backend.
  */
 export const ALLOWED_BACKEND_KINDS: readonly string[] = Object.freeze([
+  'ax-press',
   'flutter-vm',
   'simhid',
   'webkit',

--- a/tests/integration/audit-log-backend-kind.live.test.ts
+++ b/tests/integration/audit-log-backend-kind.live.test.ts
@@ -16,8 +16,10 @@ import {
  * an alternate collector). Otherwise fall back to the runtime location.
  *
  * Refs: #540 acceptance criterion
- *   "Telemetry: backendKind in {'flutter-vm','simhid','webkit'} only
- *    (applescript = 0)"
+ *   "Telemetry: backendKind in {'ax-press','flutter-vm','simhid','webkit'}
+ *    only (applescript = 0)".  `ax-press` is admitted because PR #587's ADR
+ *    on #573 established that the ax-bridge AX channel is already GUI-less
+ *    — the allow-list is maintained in `src/ci/audit-log-posture.ts`.
  */
 describe('audit.log posture — backendKind constraint', () => {
   const logPath =

--- a/tests/unit/audit-log-posture.test.ts
+++ b/tests/unit/audit-log-posture.test.ts
@@ -44,6 +44,7 @@ describe('src/ci/audit-log-posture', () => {
       '{"tool":"app_tap","backendKind":"simhid"}',
       '{"tool":"navigate","backendKind":"webkit"}',
       '{"tool":"flutter_tap","backendKind":"flutter-vm"}',
+      '{"tool":"app_tap_element","backendKind":"ax-press"}',
     ]);
     const report = scanAuditLog(file);
     expect(report.backendKinds).toEqual(
@@ -71,6 +72,16 @@ describe('src/ci/audit-log-posture', () => {
     expect(report.backendKinds.sort()).toEqual(['applescript', 'simctl', 'simhid']);
     expect(report.disallowedBackendKinds.sort()).toEqual(['applescript', 'simctl']);
     expect(report.applescriptHits).toBe(1);
+  });
+
+  it('treats ax-press as an allowed headless backend', () => {
+    const file = writeLog('ax-press.log', [
+      '{"tool":"app_tap_element","backendKind":"ax-press"}',
+    ]);
+    const report = scanAuditLog(file);
+    expect(report.backendKinds).toEqual(['ax-press']);
+    expect(report.disallowedBackendKinds).toEqual([]);
+    expect(report.applescriptHits).toBe(0);
   });
 
   it('is case-insensitive for applescript detection', () => {
@@ -110,9 +121,9 @@ describe('src/ci/audit-log-posture', () => {
   it('assertAuditLogPosture names every disallowed kind in its error message', () => {
     const file = writeLog('multi-bad.log', [
       '{"tool":"app_tap","backendKind":"simctl"}',
-      '{"tool":"app_tap","backendKind":"ax-press"}',
+      '{"tool":"app_tap","backendKind":"applescript"}',
     ]);
     expect(() => assertAuditLogPosture(file)).toThrow(/simctl/);
-    expect(() => assertAuditLogPosture(file)).toThrow(/ax-press/);
+    expect(() => assertAuditLogPosture(file)).toThrow(/applescript/);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `ax-press` to `ALLOWED_BACKEND_KINDS` in `src/ci/audit-log-posture.ts` alongside `flutter-vm`, `simhid`, and `webkit`.
- Leaves `applescript` and `simctl` rejected — the allow-list is still narrow, just now correct for the backends that actually exist.
- Updates the unit test that previously asserted `ax-press` was disallowed (it now has a positive test instead) and refreshes the doc-comment in the live posture test.

## Why

The 2026-04-17 verification pass on epic #540 noted:

> the newly-added `ax-press` backend is not in the AC whitelist `{flutter-vm, simhid, webkit}` and will need the AC updated or the backend excluded.

PR #587's ADR on issue #573 concluded the ax-bridge AX channel is already GUI-less — `AXUIElementCreateApplication(pid)` targets Simulator.app by PID and does not require it to be the macOS frontmost app. `src/tools/app-tap-element.ts` stamps `headless: true` on every `ax-press` result, so treating it as a first-class headless backend matches the observed posture. "AC updated" is the right side of that fork.

## Test plan

- [x] `npx jest --config jest.config.js tests/unit/audit-log-posture.test.ts` — 11 / 11 passing
- [x] Full jest unit suite — green locally
- [x] `npx eslint` clean on the three touched files

Refs: #540 · Follows: #587 (#573 ADR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)