### PR TITLE
feat(540): npm run test:live — DX-facing integration target with cursor-monitor guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:unit": "jest --config jest.config.js",
     "test:integration": "jest --preset ts-jest --testEnvironment node --roots tests/integration --testPathIgnorePatterns '/node_modules/' --testPathIgnorePatterns 'webkit-connection' --testTimeout=120000 --runInBand --reporters=default --reporters=<rootDir>/tests/integration/screenshot-failure-reporter.cjs",
     "test:integration:monitored": "node scripts/run-with-cursor-monitor.js -- npm run test:integration",
+    "test:live": "OSF_LIVE=1 node scripts/run-with-cursor-monitor.js -- npm run test:integration",
     "test:ci": "jest --config jest.ci.config.js",
     "test:sentinel": "jest --config jest.sentinel.config.js",
     "test:coverage": "jest --coverage",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -18,6 +18,23 @@ OPENSAFARI_ALLOW_FOCUS_INPUT=1 npx jest tests/integration/<name>.live.test.ts \
 `testPathIgnorePatterns` from `jest.config.js`; without it Jest re-applies the
 exclusion and reports zero tests.
 
+## DX-facing live run (epic #540)
+
+For the headless posture guarantee in epic #540 ("no job moves the mouse") the
+canonical developer command is:
+
+```bash
+npm run test:live
+```
+
+This sets `OSF_LIVE=1` and wraps the full integration suite with
+`scripts/run-with-cursor-monitor.js`, which pipes the child through the
+`cursor-monitor` Swift helper. The helper polls `CGEventGetLocation` and fails
+the run the moment the macOS cursor moves — so any regression that silently
+reintroduces a focus-stealing backend is caught locally before it lands in CI.
+`npm run test:integration:monitored` remains as the non-gated alias for ad-hoc
+use without the `OSF_LIVE` signal.
+
 ## Prerequisites
 
 | Requirement | Why |


### PR DESCRIPTION
## Summary

- Adds `npm run test:live` to `package.json` — sets `OSF_LIVE=1` and wraps the full integration suite with `scripts/run-with-cursor-monitor.js`.
- Documents the new DX target in `tests/integration/README.md`, explaining that the wrapper pipes the child through the `cursor-monitor` Swift helper which polls `CGEventGetLocation` and fails the run the moment the macOS cursor moves.
- Keeps `test:integration:monitored` as the non-gated alias for ad-hoc use without the `OSF_LIVE` signal.

## Why

Epic #540 acceptance criteria call for:

- `OSF_LIVE=1 npm run test:integration` green on local dev
- Integration tests never move the mouse (CI `CGEventGetLocation` monitor)

The wrapper and the Swift cursor-monitor already exist, but no top-level npm script surfaced them as the canonical developer command. This patch is the small naming gap between the existing infra and the AC text — no behavioural change to the underlying suite, just a reliable DX entry point.

## Test plan

- [x] `npm run test:live` prints the expected `OSF_LIVE=1` env line and invokes the cursor-monitor wrapper before delegating to `jest`.
- [x] `test:integration:monitored` still resolves and runs unchanged.

Refs: #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)