### PR TITLE
feat(tools): StoreKit / IAP automation tools (#588)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -110,6 +110,31 @@ Run all 13 iOS QA detectors and generate a scored report.
 - **Output:** Report content as text (or file path for `html` format)
 - **CI usage:** See [CI/CD Integration](ci-integration.md) for example GitHub Actions workflows, exit code gating, and Jenkins/CircleCI examples.
 
+### StoreKit / In-App Purchase Tools (Tier 2)
+
+#### app_storekit_configure
+Load a `.storekit` configuration file into an iOS Simulator to enable sandbox IAP testing. Requires Xcode 14+. Disabled when `OPENSAFARI_DISABLE_STOREKIT=1`.
+- **Input:** `{ configPath: string, udid?: string }`
+- **Output:** `{ ok: true, productIds: string[], udid, configPath }`
+- **Errors:** `MISSING_FILE` (file not found or invalid JSON), `DEVICE_NOT_BOOTED`, `STOREKIT_DISABLED`, `XCODE_TOO_OLD`, `STOREKIT_ERROR`
+
+#### app_storekit_test_session
+Control the StoreKit sandbox test session: list, approve, decline, refund, or clear transactions, and toggle Ask to Buy. Requires Xcode 14+. Disabled when `OPENSAFARI_DISABLE_STOREKIT=1`.
+- **Input:** `{ action: 'list'|'approve'|'decline'|'refund'|'clear'|'askToBuy', udid?: string, transactionId?: string, enabled?: boolean }`
+  - `transactionId` required for `approve`, `decline`, `refund`
+  - `enabled` required for `askToBuy`
+- **Output (list):** `{ ok: true, transactions: [{ id, state, productId }] }`
+- **Output (others):** `{ ok: true, action, udid, ... }`
+- **Errors:** `MISSING_TRANSACTION_ID`, `MISSING_ENABLED`, `DEVICE_NOT_BOOTED`, `STOREKIT_DISABLED`, `XCODE_TOO_OLD`, `STOREKIT_ERROR`
+
+#### app_storekit_receipt
+Pull the StoreKit sandbox receipt (base64-encoded) from an installed app's data container. Checks `StoreKit/sandboxReceipt` then `Documents/receipt`. Disabled when `OPENSAFARI_DISABLE_STOREKIT=1`.
+- **Input:** `{ bundleId: string, udid?: string }`
+- **Output:** `{ receipt: string, path: string, bytes: number, bundleId, udid }`
+- **Errors:** `APP_NOT_INSTALLED`, `NO_RECEIPT`, `READ_ERROR`, `DEVICE_NOT_BOOTED`, `STOREKIT_DISABLED`
+
+See [StoreKit Automation Guide](storekit-automation.md) for a full walk-through with sample `.storekit` file.
+
 ## Claude Code Configuration
 
 ```json

--- a/docs/storekit-automation.md
+++ b/docs/storekit-automation.md
@@ -1,0 +1,268 @@
+# StoreKit / In-App Purchase Automation
+
+OpenSafari exposes three MCP tools for automating StoreKit and In-App Purchase (IAP)
+flows on the iOS Simulator. These tools wrap `xcrun simctl storekit` subcommands
+and are designed for Flutter apps using `in_app_purchase` and native IAP QA pipelines.
+
+## Requirements
+
+- macOS with Xcode 14 or later installed
+- A booted iOS Simulator (`device_boot`)
+- A `.storekit` configuration file created in Xcode (or manually, see example below)
+
+## Quick Start
+
+### 1. Load a StoreKit configuration
+
+```json
+// Tool call: app_storekit_configure
+{
+  "configPath": "/path/to/MyApp.storekit"
+}
+```
+
+Returns:
+```json
+{
+  "ok": true,
+  "productIds": ["com.example.monthly_sub", "com.example.lifetime"],
+  "udid": "AABBCCDD-...",
+  "configPath": "/path/to/MyApp.storekit"
+}
+```
+
+### 2. List pending transactions
+
+```json
+// Tool call: app_storekit_test_session
+{
+  "action": "list"
+}
+```
+
+Returns:
+```json
+{
+  "ok": true,
+  "action": "list",
+  "udid": "AABBCCDD-...",
+  "transactions": [
+    { "id": "txn-001", "state": "pending", "productId": "com.example.monthly_sub" }
+  ]
+}
+```
+
+### 3. Approve a pending transaction
+
+```json
+// Tool call: app_storekit_test_session
+{
+  "action": "approve",
+  "transactionId": "txn-001"
+}
+```
+
+### 4. Pull the sandbox receipt
+
+```json
+// Tool call: app_storekit_receipt
+{
+  "bundleId": "com.example.myapp"
+}
+```
+
+Returns:
+```json
+{
+  "receipt": "<base64-encoded-receipt>",
+  "path": "/Users/.../StoreKit/sandboxReceipt",
+  "bytes": 4096,
+  "bundleId": "com.example.myapp",
+  "udid": "AABBCCDD-..."
+}
+```
+
+---
+
+## Tool Reference
+
+### `app_storekit_configure`
+
+Loads a `.storekit` configuration file into the simulator, making its products
+available for purchase in the sandbox environment.
+
+| Parameter    | Type     | Required | Description                                         |
+|-------------|----------|----------|-----------------------------------------------------|
+| `configPath` | `string` | Yes      | Absolute path to the `.storekit` file               |
+| `udid`       | `string` | No       | Simulator UDID. Falls back to the sole booted device |
+
+**Success response:**
+```json
+{ "ok": true, "productIds": ["..."], "udid": "...", "configPath": "..." }
+```
+
+**Error codes:**
+- `MISSING_FILE` — `.storekit` file not found or invalid JSON
+- `DEVICE_NOT_BOOTED` — No simulator specified and none booted
+- `STOREKIT_DISABLED` — `OPENSAFARI_DISABLE_STOREKIT=1` is set
+- `XCODE_TOO_OLD` — Xcode version does not support `simctl storekit`
+- `STOREKIT_ERROR` — Underlying simctl error
+
+---
+
+### `app_storekit_test_session`
+
+Controls the StoreKit sandbox test session on the simulator. Supports listing,
+approving, declining, refunding, and clearing transactions, as well as toggling
+Ask to Buy parental controls.
+
+| Parameter       | Type      | Required                              | Description                                          |
+|----------------|-----------|---------------------------------------|------------------------------------------------------|
+| `action`        | `string`  | Yes                                   | `list`, `approve`, `decline`, `refund`, `clear`, `askToBuy` |
+| `udid`          | `string`  | No                                    | Simulator UDID. Falls back to the sole booted device  |
+| `transactionId` | `string`  | Required for `approve`/`decline`/`refund` | The transaction ID to act on                    |
+| `enabled`       | `boolean` | Required for `askToBuy`               | `true` to enable, `false` to disable Ask to Buy      |
+
+**Actions:**
+
+| Action      | Description                                         |
+|-------------|-----------------------------------------------------|
+| `list`      | Returns all pending sandbox transactions             |
+| `approve`   | Approves a specific pending transaction              |
+| `decline`   | Declines a specific pending transaction              |
+| `refund`    | Issues a refund for a completed transaction          |
+| `clear`     | Clears all pending transactions from the test session |
+| `askToBuy`  | Enables or disables Ask to Buy parental gate         |
+
+**Error codes:**
+- `MISSING_TRANSACTION_ID` — `transactionId` not provided for approve/decline/refund
+- `MISSING_ENABLED` — `enabled` not provided for askToBuy
+- `DEVICE_NOT_BOOTED` — No simulator specified and none booted
+- `STOREKIT_DISABLED` — `OPENSAFARI_DISABLE_STOREKIT=1` is set
+- `XCODE_TOO_OLD` — Xcode version does not support `simctl storekit`
+- `STOREKIT_ERROR` — Underlying simctl error
+
+---
+
+### `app_storekit_receipt`
+
+Retrieves the StoreKit sandbox receipt from the app's data container on the
+simulator, returned as a base64-encoded string. Checks both the modern path
+(`StoreKit/sandboxReceipt`) and the legacy path (`Documents/receipt`).
+
+| Parameter  | Type     | Required | Description                                         |
+|-----------|----------|----------|-----------------------------------------------------|
+| `bundleId` | `string` | Yes      | App bundle identifier (e.g. `com.example.myapp`)    |
+| `udid`     | `string` | No       | Simulator UDID. Falls back to the sole booted device |
+
+**Success response:**
+```json
+{
+  "receipt": "<base64>",
+  "path": "/Users/.../StoreKit/sandboxReceipt",
+  "bytes": 4096,
+  "bundleId": "com.example.myapp",
+  "udid": "AABBCCDD-..."
+}
+```
+
+**Error codes:**
+- `APP_NOT_INSTALLED` — App not found in simulator
+- `NO_RECEIPT` — Receipt file not present (purchase not yet made or app not launched)
+- `READ_ERROR` — Receipt file could not be read
+- `DEVICE_NOT_BOOTED` — No simulator specified and none booted
+- `STOREKIT_DISABLED` — `OPENSAFARI_DISABLE_STOREKIT=1` is set
+
+---
+
+## Sample `.storekit` File
+
+```json
+{
+  "identifier": "MyApp StoreKit Config",
+  "nonRenewingSubscriptions": [],
+  "products": [
+    {
+      "displayPrice": "0.99",
+      "familyShareable": false,
+      "localizations": [
+        {
+          "description": "Monthly subscription",
+          "displayName": "Monthly Pro",
+          "locale": "en_US"
+        }
+      ],
+      "productID": "com.example.monthly_sub",
+      "referenceName": "Monthly Pro",
+      "type": "RecurringSubscription"
+    },
+    {
+      "displayPrice": "9.99",
+      "familyShareable": false,
+      "localizations": [
+        {
+          "description": "Lifetime access",
+          "displayName": "Lifetime",
+          "locale": "en_US"
+        }
+      ],
+      "productID": "com.example.lifetime",
+      "referenceName": "Lifetime",
+      "type": "NonConsumable"
+    }
+  ],
+  "settings": {},
+  "subscriptionGroups": [],
+  "version": {
+    "major": 2,
+    "minor": 0
+  }
+}
+```
+
+---
+
+## Full IAP QA Walk-through
+
+### English (en-US)
+
+```
+1. Boot simulator:           device_boot
+2. Launch app:               app_launch { bundleId: "com.example.myapp" }
+3. Load StoreKit config:     app_storekit_configure { configPath: "/path/to/Config.storekit" }
+4. Trigger purchase in app:  (tap the buy button via app_tap)
+5. List transactions:        app_storekit_test_session { action: "list" }
+6. Approve transaction:      app_storekit_test_session { action: "approve", transactionId: "<id>" }
+7. Verify receipt:           app_storekit_receipt { bundleId: "com.example.myapp" }
+8. Test refund:              app_storekit_test_session { action: "refund", transactionId: "<id>" }
+9. Clear session:            app_storekit_test_session { action: "clear" }
+```
+
+### 한국어 (ko-KR)
+
+```
+1. 시뮬레이터 부팅:          device_boot
+2. 앱 실행:                  app_launch { bundleId: "com.example.myapp" }
+3. StoreKit 설정 로드:       app_storekit_configure { configPath: "/path/to/Config.storekit" }
+4. 앱에서 구매 트리거:       (app_tap으로 구매 버튼 탭)
+5. 트랜잭션 목록 조회:       app_storekit_test_session { action: "list" }
+6. 트랜잭션 승인:            app_storekit_test_session { action: "approve", transactionId: "<id>" }
+7. 영수증 확인:              app_storekit_receipt { bundleId: "com.example.myapp" }
+8. 환불 테스트:              app_storekit_test_session { action: "refund", transactionId: "<id>" }
+9. 세션 초기화:              app_storekit_test_session { action: "clear" }
+```
+
+---
+
+## Disabling StoreKit Automation
+
+Set `OPENSAFARI_DISABLE_STOREKIT=1` in the environment to disable all three StoreKit
+tools at call time. All tools will return `{ error: "STOREKIT_DISABLED" }` immediately.
+This is useful for CI environments that do not need IAP testing to avoid accidental
+simulator StoreKit state changes.
+
+## Telemetry
+
+All three tools emit `_meta._telemetry` with `backend: "storekit"` in their success
+responses. This field is always present and is not gated behind an env var (unlike the
+input-backend telemetry for tap/swipe operations).

--- a/src/native/simctl-storekit.ts
+++ b/src/native/simctl-storekit.ts
@@ -1,0 +1,125 @@
+/**
+ * simctl StoreKit helpers — thin wrappers around `xcrun simctl storekit` subcommands.
+ *
+ * Requires Xcode 14+ (simctl storekit was introduced in Xcode 14).
+ * Controlled by OPENSAFARI_DISABLE_STOREKIT=1 to allow opt-out in environments
+ * where StoreKit simulation is not available or not desired.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs/promises';
+
+const execFileAsync = promisify(execFile);
+
+export const STOREKIT_DISABLE_ENV = 'OPENSAFARI_DISABLE_STOREKIT';
+
+/**
+ * Thrown when OPENSAFARI_DISABLE_STOREKIT=1.
+ */
+export class StorekitDisabledError extends Error {
+  readonly code = 'STOREKIT_DISABLED';
+  constructor() {
+    super('StoreKit automation is disabled (OPENSAFARI_DISABLE_STOREKIT=1)');
+    this.name = 'StorekitDisabledError';
+  }
+}
+
+/**
+ * Thrown when Xcode < 14 (simctl storekit subcommand not found).
+ */
+export class StorekitUnsupportedError extends Error {
+  readonly code = 'XCODE_TOO_OLD';
+  constructor() {
+    super('simctl storekit requires Xcode 14 or later. Please update Xcode.');
+    this.name = 'StorekitUnsupportedError';
+  }
+}
+
+/** Verify that StoreKit automation is not disabled. Throws StorekitDisabledError if so. */
+export function assertStorekitEnabled(): void {
+  const val = process.env[STOREKIT_DISABLE_ENV];
+  if (val === '1' || val === 'true') {
+    throw new StorekitDisabledError();
+  }
+}
+
+/** Run xcrun simctl storekit <subArgs>. Wraps the Xcode < 14 detection. */
+export async function runStorekit(subArgs: string[], timeout = 30000): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('xcrun', ['simctl', 'storekit', ...subArgs], { timeout });
+    return stdout;
+  } catch (err: unknown) {
+    const error = err as Error & { stderr?: string; code?: number | string };
+    const msg = error.stderr ?? error.message ?? '';
+    // simctl exits with "unknown command" or similar when Xcode < 14
+    if (
+      msg.includes('Unknown subcommand') ||
+      msg.includes('unknown command') ||
+      msg.includes('is not a recognized') ||
+      (error.code === 1 && msg.includes('storekit'))
+    ) {
+      throw new StorekitUnsupportedError();
+    }
+    throw new Error(`simctl storekit ${subArgs.join(' ')} failed: ${msg}`);
+  }
+}
+
+/** Shape of a product entry inside a .storekit configuration file. */
+export interface StorekitProduct {
+  productID?: string;
+  // The actual field name varies by Xcode version
+  identifier?: string;
+  [key: string]: unknown;
+}
+
+/** Parse product IDs from a .storekit JSON file. */
+export async function parseStorekitProductIds(configPath: string): Promise<string[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(configPath, 'utf-8');
+  } catch {
+    throw new Error(`StoreKit config file not found: ${configPath}`);
+  }
+
+  let parsed: { products?: StorekitProduct[]; [key: string]: unknown };
+  try {
+    parsed = JSON.parse(raw) as { products?: StorekitProduct[] };
+  } catch {
+    throw new Error(`StoreKit config file is not valid JSON: ${configPath}`);
+  }
+
+  const products = parsed.products ?? [];
+  const ids: string[] = [];
+  for (const p of products) {
+    const id = (p.productID ?? p.identifier ?? '') as string;
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
+/** Shape of a StoreKit test-session transaction entry returned by `simctl storekit test-session list`. */
+export interface StorekitTransaction {
+  id: string;
+  state: string;
+  productId: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Parse transactions from the JSON output of `simctl storekit test-session list`.
+ * The command outputs a JSON array or an object with a `transactions` key.
+ */
+export function parseTransactionList(raw: string): StorekitTransaction[] {
+  if (!raw.trim()) return [];
+  try {
+    const parsed = JSON.parse(raw.trim()) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed as StorekitTransaction[];
+    }
+    const obj = parsed as { transactions?: StorekitTransaction[] };
+    return obj.transactions ?? [];
+  } catch {
+    return [];
+  }
+}

--- a/src/tools/app-storekit-configure.ts
+++ b/src/tools/app-storekit-configure.ts
@@ -1,0 +1,136 @@
+import { MCPServer } from '../mcp-server';
+import { getSessionManager } from '../session-manager';
+import {
+  assertStorekitEnabled,
+  runStorekit,
+  parseStorekitProductIds,
+  StorekitDisabledError,
+  StorekitUnsupportedError,
+} from '../native/simctl-storekit';
+
+export function registerAppStorekitConfigureTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_storekit_configure',
+      description:
+        'Configure StoreKit / In-App Purchase simulation on an iOS Simulator by loading a .storekit file. ' +
+        'Requires Xcode 14+. Disabled when OPENSAFARI_DISABLE_STOREKIT=1.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          configPath: {
+            type: 'string',
+            description: 'Absolute path to the .storekit configuration file',
+          },
+          udid: {
+            type: 'string',
+            description: 'Simulator UDID. Falls back to the sole booted device if omitted.',
+          },
+        },
+        required: ['configPath'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        assertStorekitEnabled();
+      } catch (err) {
+        if (err instanceof StorekitDisabledError) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ error: err.code, message: err.message }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+
+      const configPath = params.configPath as string;
+      if (!configPath) {
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify({ error: 'MISSING_CONFIG', message: 'configPath is required' }) },
+          ],
+          isError: true,
+        };
+      }
+
+      const sm = getSessionManager();
+      const udid = (params.udid as string | undefined) ?? sm.getSoleDeviceId();
+      if (!udid) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'DEVICE_NOT_BOOTED',
+                message: 'No device specified and no sole booted simulator found. Boot a simulator first.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      let productIds: string[];
+      try {
+        productIds = await parseStorekitProductIds(configPath);
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ error: 'MISSING_FILE', message: (err as Error).message }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      try {
+        await runStorekit(['configure', udid, configPath]);
+      } catch (err) {
+        if (err instanceof StorekitUnsupportedError) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ error: err.code, message: err.message }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ error: 'STOREKIT_ERROR', message: (err as Error).message }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              productIds,
+              udid,
+              configPath,
+              _meta: {
+                _telemetry: { backend: 'storekit', op: 'configure', udid, configPath },
+              },
+            }),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/app-storekit-receipt.ts
+++ b/src/tools/app-storekit-receipt.ts
@@ -1,0 +1,185 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { MCPServer } from '../mcp-server';
+import { getSessionManager } from '../session-manager';
+import {
+  assertStorekitEnabled,
+  StorekitDisabledError,
+} from '../native/simctl-storekit';
+
+const execFileAsync = promisify(execFile);
+
+export function registerAppStorekitReceiptTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_storekit_receipt',
+      description:
+        'Retrieve the StoreKit sandbox receipt for an installed app on an iOS Simulator, ' +
+        'base64-encoded. Locates the receipt via the app data container. ' +
+        'Disabled when OPENSAFARI_DISABLE_STOREKIT=1.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          bundleId: {
+            type: 'string',
+            description: 'App bundle identifier',
+          },
+          udid: {
+            type: 'string',
+            description: 'Simulator UDID. Falls back to the sole booted device if omitted.',
+          },
+        },
+        required: ['bundleId'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        assertStorekitEnabled();
+      } catch (err) {
+        if (err instanceof StorekitDisabledError) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ error: err.code, message: err.message }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+
+      const bundleId = params.bundleId as string;
+      if (!bundleId) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ error: 'MISSING_BUNDLE_ID', message: 'bundleId is required' }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const sm = getSessionManager();
+      const udid = (params.udid as string | undefined) ?? sm.getSoleDeviceId();
+      if (!udid) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'DEVICE_NOT_BOOTED',
+                message: 'No device specified and no sole booted simulator found. Boot a simulator first.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Locate the app data container via simctl get_app_container
+      let dataContainer: string;
+      try {
+        const { stdout } = await execFileAsync('xcrun', [
+          'simctl',
+          'get_app_container',
+          udid,
+          bundleId,
+          'data',
+        ]);
+        dataContainer = stdout.trim();
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'APP_NOT_INSTALLED',
+                message: `Cannot locate data container for ${bundleId} on ${udid}: ${(err as Error).message}`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Try known receipt paths in priority order
+      const candidatePaths = [
+        path.join(dataContainer, 'StoreKit', 'sandboxReceipt'),
+        path.join(dataContainer, 'Documents', 'receipt'),
+      ];
+
+      let receiptPath: string | null = null;
+      for (const candidate of candidatePaths) {
+        try {
+          await fs.access(candidate);
+          receiptPath = candidate;
+          break;
+        } catch {
+          // not found, try next
+        }
+      }
+
+      if (!receiptPath) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'NO_RECEIPT',
+                message: `No sandbox receipt found for ${bundleId} at expected paths: ${candidatePaths.join(', ')}`,
+                bundleId,
+                udid,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      let receiptBuffer: Buffer;
+      try {
+        receiptBuffer = await fs.readFile(receiptPath);
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'READ_ERROR',
+                message: `Failed to read receipt at ${receiptPath}: ${(err as Error).message}`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const receipt = receiptBuffer.toString('base64');
+      const bytes = receiptBuffer.length;
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              receipt,
+              path: receiptPath,
+              bytes,
+              bundleId,
+              udid,
+              _meta: {
+                _telemetry: { backend: 'storekit', op: 'receipt', udid, bundleId, bytes },
+              },
+            }),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/app-storekit-test-session.ts
+++ b/src/tools/app-storekit-test-session.ts
@@ -1,0 +1,235 @@
+import { MCPServer } from '../mcp-server';
+import { getSessionManager } from '../session-manager';
+import {
+  assertStorekitEnabled,
+  runStorekit,
+  parseTransactionList,
+  StorekitDisabledError,
+  StorekitUnsupportedError,
+} from '../native/simctl-storekit';
+
+type TestSessionAction = 'list' | 'approve' | 'decline' | 'refund' | 'clear' | 'askToBuy';
+
+const TRANSACTION_REQUIRED_ACTIONS: TestSessionAction[] = ['approve', 'decline', 'refund'];
+
+export function registerAppStorekitTestSessionTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_storekit_test_session',
+      description:
+        'Control StoreKit sandbox test sessions on an iOS Simulator. ' +
+        'Supports listing, approving, declining, refunding, and clearing transactions, ' +
+        'and toggling Ask to Buy. Requires Xcode 14+. Disabled when OPENSAFARI_DISABLE_STOREKIT=1.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          action: {
+            type: 'string',
+            enum: ['list', 'approve', 'decline', 'refund', 'clear', 'askToBuy'],
+            description: 'Action to perform on the test session',
+          },
+          udid: {
+            type: 'string',
+            description: 'Simulator UDID. Falls back to the sole booted device if omitted.',
+          },
+          transactionId: {
+            type: 'string',
+            description: 'Transaction ID (required for approve, decline, refund)',
+          },
+          enabled: {
+            type: 'boolean',
+            description: 'Enable or disable Ask to Buy (required for askToBuy action)',
+          },
+        },
+        required: ['action'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        assertStorekitEnabled();
+      } catch (err) {
+        if (err instanceof StorekitDisabledError) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ error: err.code, message: err.message }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+
+      const action = params.action as TestSessionAction;
+      if (!action) {
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify({ error: 'MISSING_ACTION', message: 'action is required' }) },
+          ],
+          isError: true,
+        };
+      }
+
+      const sm = getSessionManager();
+      const udid = (params.udid as string | undefined) ?? sm.getSoleDeviceId();
+      if (!udid) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'DEVICE_NOT_BOOTED',
+                message: 'No device specified and no sole booted simulator found. Boot a simulator first.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Validate transactionId requirement
+      if (TRANSACTION_REQUIRED_ACTIONS.includes(action)) {
+        const transactionId = params.transactionId as string | undefined;
+        if (!transactionId) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  error: 'MISSING_TRANSACTION_ID',
+                  message: `transactionId is required for action '${action}'`,
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
+      // Validate enabled requirement for askToBuy
+      if (action === 'askToBuy' && params.enabled === undefined) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'MISSING_ENABLED',
+                message: "enabled (boolean) is required for action 'askToBuy'",
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      try {
+        let raw: string;
+        let result: Record<string, unknown>;
+
+        switch (action) {
+          case 'list': {
+            raw = await runStorekit(['test-session', 'list', udid]);
+            const transactions = parseTransactionList(raw);
+            result = {
+              ok: true,
+              action,
+              udid,
+              transactions,
+              _meta: {
+                _telemetry: { backend: 'storekit', op: action, udid },
+              },
+            };
+            break;
+          }
+
+          case 'approve':
+          case 'decline':
+          case 'refund': {
+            const transactionId = params.transactionId as string;
+            await runStorekit(['test-session', action, udid, transactionId]);
+            result = {
+              ok: true,
+              action,
+              udid,
+              transactionId,
+              _meta: {
+                _telemetry: { backend: 'storekit', op: action, udid, transactionId },
+              },
+            };
+            break;
+          }
+
+          case 'clear': {
+            await runStorekit(['test-session', 'clear', udid]);
+            result = {
+              ok: true,
+              action,
+              udid,
+              _meta: {
+                _telemetry: { backend: 'storekit', op: action, udid },
+              },
+            };
+            break;
+          }
+
+          case 'askToBuy': {
+            const enabled = params.enabled as boolean;
+            await runStorekit(['test-session', 'ask-to-buy', udid, enabled ? 'enable' : 'disable']);
+            result = {
+              ok: true,
+              action,
+              udid,
+              enabled,
+              _meta: {
+                _telemetry: { backend: 'storekit', op: action, udid, enabled },
+              },
+            };
+            break;
+          }
+
+          default: {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify({
+                    error: 'INVALID_ACTION',
+                    message: `Unknown action '${action as string}'. Valid actions: list, approve, decline, refund, clear, askToBuy`,
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+        };
+      } catch (err) {
+        if (err instanceof StorekitUnsupportedError) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ error: err.code, message: err.message }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ error: 'STOREKIT_ERROR', message: (err as Error).message }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -124,6 +124,9 @@ import { registerAppTypeElementTool } from './app-type-element';
 import { registerAppWaitForNativeTool } from './app-wait-for';
 import { registerAppAssertElementTool } from './app-assert-element';
 import { registerDiagnoseTool } from './diagnose';
+import { registerAppStorekitConfigureTool } from './app-storekit-configure';
+import { registerAppStorekitTestSessionTool } from './app-storekit-test-session';
+import { registerAppStorekitReceiptTool } from './app-storekit-receipt';
 
 export { setWorkflowEngine } from './orchestration-tools';
 export { setBarrier } from './barrier-tools';
@@ -325,4 +328,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Tier 1: Diagnostics
   registerDiagnoseTool(server);
+
+  // Tier 2: StoreKit / In-App Purchase automation (#588)
+  registerAppStorekitConfigureTool(server);
+  registerAppStorekitTestSessionTool(server);
+  registerAppStorekitReceiptTool(server);
 }

--- a/tests/unit/app-storekit.test.ts
+++ b/tests/unit/app-storekit.test.ts
@@ -1,0 +1,556 @@
+/**
+ * Unit tests for StoreKit / IAP automation tools.
+ * No real simulator or Xcode required — all subprocess calls are mocked.
+ */
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerAppStorekitConfigureTool } from '../../src/tools/app-storekit-configure';
+import { registerAppStorekitTestSessionTool } from '../../src/tools/app-storekit-test-session';
+import { registerAppStorekitReceiptTool } from '../../src/tools/app-storekit-receipt';
+
+// ── child_process mock ────────────────────────────────────────────────────────
+const mockExecFile = jest.fn();
+
+jest.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => mockExecFile(...args),
+}));
+
+// ── fs/promises mock ──────────────────────────────────────────────────────────
+const mockFsAccess = jest.fn();
+const mockFsReadFile = jest.fn();
+
+jest.mock('fs/promises', () => ({
+  readFile: (...args: unknown[]) => mockFsReadFile(...args),
+  access: (...args: unknown[]) => mockFsAccess(...args),
+}));
+
+// ── session-manager mock ──────────────────────────────────────────────────────
+const mockGetSoleDeviceId = jest.fn<string | null, []>().mockReturnValue('TEST-UDID-5678');
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({ getSoleDeviceId: mockGetSoleDeviceId }),
+}));
+
+// ── simctl-storekit mock ──────────────────────────────────────────────────────
+// Error classes must be defined inside the factory to avoid hoisting issues.
+const mockRunStorekit = jest.fn<Promise<string>, [string[], number?]>();
+const mockParseStorekitProductIds = jest.fn<Promise<string[]>, [string]>();
+const mockParseTransactionList = jest.fn();
+const mockAssertStorekitEnabled = jest.fn();
+
+jest.mock('../../src/native/simctl-storekit', () => {
+  class StorekitDisabledError extends Error {
+    readonly code = 'STOREKIT_DISABLED';
+    constructor() {
+      super('StoreKit automation is disabled (OPENSAFARI_DISABLE_STOREKIT=1)');
+      this.name = 'StorekitDisabledError';
+    }
+  }
+  class StorekitUnsupportedError extends Error {
+    readonly code = 'XCODE_TOO_OLD';
+    constructor() {
+      super('simctl storekit requires Xcode 14 or later.');
+      this.name = 'StorekitUnsupportedError';
+    }
+  }
+  return {
+    assertStorekitEnabled: () => mockAssertStorekitEnabled(),
+    runStorekit: (...args: unknown[]) => mockRunStorekit(...(args as Parameters<typeof mockRunStorekit>)),
+    parseStorekitProductIds: (p: string) => mockParseStorekitProductIds(p),
+    parseTransactionList: (r: string) => mockParseTransactionList(r),
+    StorekitDisabledError,
+    StorekitUnsupportedError,
+    STOREKIT_DISABLE_ENV: 'OPENSAFARI_DISABLE_STOREKIT',
+  };
+});
+
+// Import error classes after mock is set up
+import {
+  StorekitDisabledError,
+  StorekitUnsupportedError,
+} from '../../src/native/simctl-storekit';
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+const UDID = 'TEST-UDID-5678';
+const CONFIG_PATH = '/tmp/test.storekit';
+const BUNDLE_ID = 'com.example.testapp';
+
+// Helper to parse the first content text
+function parseResult(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+// ── app_storekit_configure ────────────────────────────────────────────────────
+
+describe('app_storekit_configure', () => {
+  let server: MCPServer;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerAppStorekitConfigureTool(server);
+  });
+
+  beforeEach(() => {
+    mockAssertStorekitEnabled.mockReset().mockReturnValue(undefined);
+    mockRunStorekit.mockReset().mockResolvedValue('');
+    mockParseStorekitProductIds
+      .mockReset()
+      .mockResolvedValue(['com.example.product1', 'com.example.product2']);
+    mockGetSoleDeviceId.mockReturnValue(UDID);
+  });
+
+  test('is registered', () => {
+    expect(server.getRegisteredTools()).toContain('app_storekit_configure');
+  });
+
+  test('success: parses productIds and returns ok:true', async () => {
+    const handler = server.getToolHandler('app_storekit_configure')!;
+    const result = await handler('session', { configPath: CONFIG_PATH });
+
+    expect(result.isError).toBeUndefined();
+    const body = parseResult(result as { content: Array<{ type: string; text: string }> }) as {
+      ok: boolean;
+      productIds: string[];
+      udid: string;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.productIds).toEqual(['com.example.product1', 'com.example.product2']);
+    expect(body.udid).toBe(UDID);
+    expect(mockRunStorekit).toHaveBeenCalledWith(['configure', UDID, CONFIG_PATH]);
+  });
+
+  test('error: missing file returns MISSING_FILE', async () => {
+    mockParseStorekitProductIds.mockRejectedValue(
+      new Error('StoreKit config file not found: /tmp/missing.storekit'),
+    );
+
+    const handler = server.getToolHandler('app_storekit_configure')!;
+    const result = await handler('session', { configPath: '/tmp/missing.storekit' });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('MISSING_FILE');
+  });
+
+  test('error: STOREKIT_DISABLED when assertStorekitEnabled throws', async () => {
+    mockAssertStorekitEnabled.mockImplementation(() => {
+      throw new StorekitDisabledError();
+    });
+
+    const handler = server.getToolHandler('app_storekit_configure')!;
+    const result = await handler('session', { configPath: CONFIG_PATH });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('STOREKIT_DISABLED');
+  });
+
+  test('error: XCODE_TOO_OLD when runStorekit throws StorekitUnsupportedError', async () => {
+    mockRunStorekit.mockRejectedValue(new StorekitUnsupportedError());
+
+    const handler = server.getToolHandler('app_storekit_configure')!;
+    const result = await handler('session', { configPath: CONFIG_PATH });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('XCODE_TOO_OLD');
+  });
+
+  test('error: DEVICE_NOT_BOOTED when no device available', async () => {
+    mockGetSoleDeviceId.mockReturnValue(null);
+
+    const handler = server.getToolHandler('app_storekit_configure')!;
+    const result = await handler('session', { configPath: CONFIG_PATH });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('DEVICE_NOT_BOOTED');
+  });
+
+  test('uses explicit udid when provided', async () => {
+    const handler = server.getToolHandler('app_storekit_configure')!;
+    await handler('session', { configPath: CONFIG_PATH, udid: 'EXPLICIT-UDID' });
+
+    expect(mockRunStorekit).toHaveBeenCalledWith(['configure', 'EXPLICIT-UDID', CONFIG_PATH]);
+  });
+});
+
+// ── app_storekit_test_session ─────────────────────────────────────────────────
+
+describe('app_storekit_test_session', () => {
+  let server: MCPServer;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerAppStorekitTestSessionTool(server);
+  });
+
+  beforeEach(() => {
+    mockAssertStorekitEnabled.mockReset().mockReturnValue(undefined);
+    mockRunStorekit.mockReset().mockResolvedValue('[]');
+    mockParseTransactionList.mockReset().mockReturnValue([
+      { id: 'txn-1', state: 'pending', productId: 'com.example.product1' },
+    ]);
+    mockGetSoleDeviceId.mockReturnValue(UDID);
+  });
+
+  test('is registered', () => {
+    expect(server.getRegisteredTools()).toContain('app_storekit_test_session');
+  });
+
+  test('list: returns transactions', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'list' });
+
+    expect(result.isError).toBeUndefined();
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { ok: boolean; transactions: unknown[] };
+    expect(body.ok).toBe(true);
+    expect(Array.isArray(body.transactions)).toBe(true);
+    expect(mockRunStorekit).toHaveBeenCalledWith(['test-session', 'list', UDID]);
+  });
+
+  test('approve: requires transactionId', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'approve' });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('MISSING_TRANSACTION_ID');
+  });
+
+  test('decline: requires transactionId', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'decline' });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('MISSING_TRANSACTION_ID');
+  });
+
+  test('refund: requires transactionId', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'refund' });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('MISSING_TRANSACTION_ID');
+  });
+
+  test('approve: succeeds with transactionId', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'approve', transactionId: 'txn-123' });
+
+    expect(result.isError).toBeUndefined();
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { ok: boolean; transactionId: string };
+    expect(body.ok).toBe(true);
+    expect(body.transactionId).toBe('txn-123');
+    expect(mockRunStorekit).toHaveBeenCalledWith(['test-session', 'approve', UDID, 'txn-123']);
+  });
+
+  test('decline: succeeds with transactionId', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'decline', transactionId: 'txn-456' });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockRunStorekit).toHaveBeenCalledWith(['test-session', 'decline', UDID, 'txn-456']);
+  });
+
+  test('refund: succeeds with transactionId', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'refund', transactionId: 'txn-789' });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockRunStorekit).toHaveBeenCalledWith(['test-session', 'refund', UDID, 'txn-789']);
+  });
+
+  test('clear: clears pending transactions', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'clear' });
+
+    expect(result.isError).toBeUndefined();
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(mockRunStorekit).toHaveBeenCalledWith(['test-session', 'clear', UDID]);
+  });
+
+  test('askToBuy: requires enabled boolean', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'askToBuy' });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('MISSING_ENABLED');
+  });
+
+  test('askToBuy: enabled=true calls ask-to-buy enable', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'askToBuy', enabled: true });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockRunStorekit).toHaveBeenCalledWith([
+      'test-session',
+      'ask-to-buy',
+      UDID,
+      'enable',
+    ]);
+  });
+
+  test('askToBuy: enabled=false calls ask-to-buy disable', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'askToBuy', enabled: false });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockRunStorekit).toHaveBeenCalledWith([
+      'test-session',
+      'ask-to-buy',
+      UDID,
+      'disable',
+    ]);
+  });
+
+  test('STOREKIT_DISABLED error when disabled', async () => {
+    mockAssertStorekitEnabled.mockImplementation(() => {
+      throw new StorekitDisabledError();
+    });
+
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'list' });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('STOREKIT_DISABLED');
+  });
+
+  test('DEVICE_NOT_BOOTED when no device available', async () => {
+    mockGetSoleDeviceId.mockReturnValue(null);
+
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'list' });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('DEVICE_NOT_BOOTED');
+  });
+
+  test('_meta._telemetry has backend=storekit on list', async () => {
+    const handler = server.getToolHandler('app_storekit_test_session')!;
+    const result = await handler('session', { action: 'list' });
+
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { _meta: { _telemetry: { backend: string } } };
+    expect(body._meta._telemetry.backend).toBe('storekit');
+  });
+});
+
+// ── app_storekit_receipt ──────────────────────────────────────────────────────
+
+describe('app_storekit_receipt', () => {
+  let server: MCPServer;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerAppStorekitReceiptTool(server);
+  });
+
+  beforeEach(() => {
+    mockAssertStorekitEnabled.mockReset().mockReturnValue(undefined);
+    mockExecFile.mockReset();
+    mockFsAccess.mockReset();
+    mockFsReadFile.mockReset();
+    mockGetSoleDeviceId.mockReturnValue(UDID);
+  });
+
+  test('is registered', () => {
+    expect(server.getRegisteredTools()).toContain('app_storekit_receipt');
+  });
+
+  test('success: returns base64 receipt', async () => {
+    const receiptContent = Buffer.from('fake-receipt-data');
+
+    // Mock execFile for get_app_container (callback style)
+    mockExecFile.mockImplementation(
+      (
+        _cmd: string,
+        _args: string[],
+        callback: (err: null, result: { stdout: string }) => void,
+      ) => {
+        callback(null, { stdout: '/tmp/sim/data/container\n' });
+      },
+    );
+    // sandboxReceipt exists
+    mockFsAccess.mockResolvedValue(undefined);
+    mockFsReadFile.mockResolvedValue(receiptContent);
+
+    const handler = server.getToolHandler('app_storekit_receipt')!;
+    const result = await handler('session', { bundleId: BUNDLE_ID });
+
+    expect(result.isError).toBeUndefined();
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as {
+      receipt: string;
+      bytes: number;
+      path: string;
+      bundleId: string;
+      _meta: { _telemetry: { backend: string } };
+    };
+    expect(body.receipt).toBe(receiptContent.toString('base64'));
+    expect(body.bytes).toBe(receiptContent.length);
+    expect(body.bundleId).toBe(BUNDLE_ID);
+    expect(body._meta._telemetry.backend).toBe('storekit');
+  });
+
+  test('error: NO_RECEIPT when receipt files not found', async () => {
+    mockExecFile.mockImplementation(
+      (
+        _cmd: string,
+        _args: string[],
+        callback: (err: null, result: { stdout: string }) => void,
+      ) => {
+        callback(null, { stdout: '/tmp/sim/data/container\n' });
+      },
+    );
+    // Neither path exists
+    mockFsAccess.mockRejectedValue(new Error('ENOENT'));
+
+    const handler = server.getToolHandler('app_storekit_receipt')!;
+    const result = await handler('session', { bundleId: BUNDLE_ID });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('NO_RECEIPT');
+  });
+
+  test('error: APP_NOT_INSTALLED when get_app_container fails', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], callback: (err: Error) => void) => {
+        callback(new Error('No such bundle'));
+      },
+    );
+
+    const handler = server.getToolHandler('app_storekit_receipt')!;
+    const result = await handler('session', { bundleId: 'com.example.notinstalled' });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('APP_NOT_INSTALLED');
+  });
+
+  test('error: STOREKIT_DISABLED when assertStorekitEnabled throws', async () => {
+    mockAssertStorekitEnabled.mockImplementation(() => {
+      throw new StorekitDisabledError();
+    });
+
+    const handler = server.getToolHandler('app_storekit_receipt')!;
+    const result = await handler('session', { bundleId: BUNDLE_ID });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('STOREKIT_DISABLED');
+  });
+
+  test('error: DEVICE_NOT_BOOTED when no device available', async () => {
+    mockGetSoleDeviceId.mockReturnValue(null);
+
+    const handler = server.getToolHandler('app_storekit_receipt')!;
+    const result = await handler('session', { bundleId: BUNDLE_ID });
+
+    expect(result.isError).toBe(true);
+    const body = parseResult(
+      result as { content: Array<{ type: string; text: string }> },
+    ) as { error: string };
+    expect(body.error).toBe('DEVICE_NOT_BOOTED');
+  });
+});
+
+// ── simctl-storekit helpers (real implementation) ─────────────────────────────
+
+describe('simctl-storekit helpers (real module)', () => {
+  describe('parseTransactionList', () => {
+    const { parseTransactionList } = jest.requireActual<
+      typeof import('../../src/native/simctl-storekit')
+    >('../../src/native/simctl-storekit');
+
+    it('returns empty array for empty string', () => {
+      expect(parseTransactionList('')).toEqual([]);
+    });
+
+    it('parses array JSON', () => {
+      const data = [{ id: 'txn-1', state: 'pending', productId: 'com.example.p1' }];
+      expect(parseTransactionList(JSON.stringify(data))).toEqual(data);
+    });
+
+    it('parses object with transactions key', () => {
+      const data = {
+        transactions: [{ id: 'txn-2', state: 'approved', productId: 'com.example.p2' }],
+      };
+      expect(parseTransactionList(JSON.stringify(data))).toEqual(data.transactions);
+    });
+
+    it('returns empty array for invalid JSON', () => {
+      expect(parseTransactionList('not json')).toEqual([]);
+    });
+  });
+
+  describe('assertStorekitEnabled', () => {
+    const { assertStorekitEnabled, StorekitDisabledError: RealStorekitDisabledError } =
+      jest.requireActual<typeof import('../../src/native/simctl-storekit')>(
+        '../../src/native/simctl-storekit',
+      );
+
+    const realEnvKey = 'OPENSAFARI_DISABLE_STOREKIT';
+
+    afterEach(() => {
+      delete process.env[realEnvKey];
+    });
+
+    it('does not throw when env var is unset', () => {
+      delete process.env[realEnvKey];
+      expect(() => assertStorekitEnabled()).not.toThrow();
+    });
+
+    it('throws StorekitDisabledError when OPENSAFARI_DISABLE_STOREKIT=1', () => {
+      process.env[realEnvKey] = '1';
+      expect(() => assertStorekitEnabled()).toThrow(RealStorekitDisabledError);
+    });
+
+    it('throws StorekitDisabledError when OPENSAFARI_DISABLE_STOREKIT=true', () => {
+      process.env[realEnvKey] = 'true';
+      expect(() => assertStorekitEnabled()).toThrow(RealStorekitDisabledError);
+    });
+  });
+});


### PR DESCRIPTION
Closes #588

## Summary

- **`app_storekit_configure`** — loads a `.storekit` file into the simulator sandbox via `xcrun simctl storekit configure`, parses and returns product IDs
- **`app_storekit_test_session`** — controls the sandbox test session: `list`, `approve`, `decline`, `refund`, `clear`, `askToBuy` actions
- **`app_storekit_receipt`** — pulls the sandbox receipt from the app data container (checks `StoreKit/sandboxReceipt` then `Documents/receipt`), returns base64

## Cross-cutting

- `OPENSAFARI_DISABLE_STOREKIT=1` disables all three tools at call time → `STOREKIT_DISABLED`
- Xcode < 14 detected from simctl stderr → `XCODE_TOO_OLD`
- All tools emit `_meta._telemetry` with `backend: 'storekit'`
- Shared helper in `src/native/simctl-storekit.ts`
- All three tools registered in `src/tools/index.ts`

## Test plan

- [ ] `npx jest "app-storekit"` → 35 tests pass (no simulator required)
- [ ] `npm test` → 1681 tests, 114 suites all pass
- [ ] `npm run build` → compiles cleanly
- [ ] Manual: boot simulator, call `app_storekit_configure` with a valid `.storekit` file
- [ ] Manual: trigger IAP in app, call `app_storekit_test_session { action: "list" }`, approve transaction
- [ ] Manual: call `app_storekit_receipt { bundleId: "..." }` and verify base64 receipt
- [ ] Manual: set `OPENSAFARI_DISABLE_STOREKIT=1` → all three tools return `STOREKIT_DISABLED`

## Docs

- New `docs/storekit-automation.md` with en-US + ko-KR walk-throughs, sample `.storekit` file
- Updated `docs/api-reference.md` with all three tool entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)