### PR TITLE
test(573): sentinel probe 7 enforces the ax-bridge GUI-less invariant

### DIFF
--- a/.github/workflows/private-api-sentinel.yml
+++ b/.github/workflows/private-api-sentinel.yml
@@ -12,6 +12,9 @@ name: Private API Sentinel
 #   4. ax-bridge AXUIElement dump returns non-empty JSON
 #   5. webinspectord_sim socket — findSocketPath() resolves
 #   6. ios_webkit_debug_proxy binary on PATH
+#   7. ax-bridge GUI-less invariant — source resolves the AX root via
+#      AXUIElementCreateApplication(pid) and runtime dumps still succeed
+#      when Simulator.app is not the macOS frontmost app (#573 ADR).
 #
 # On scheduled failures the job opens / updates a tracking issue labeled
 # `sentinel` with the failing probe name and jest error message so the

--- a/tests/sentinel/private-api-probe.test.ts
+++ b/tests/sentinel/private-api-probe.test.ts
@@ -1,13 +1,16 @@
 /**
  * Private API Regression Sentinel (issue #503).
  *
- * Probes the six private-API surfaces that opensafari depends on:
+ * Probes the seven private-API surfaces that opensafari depends on:
  *   1. SimulatorKit.framework          — dlopen path exists
  *   2. CoreSimulator.framework         — dlopen path exists
  *   3. sim-hid-bridge                   — loads frameworks + resolves HID symbols
  *   4. ax-bridge (AXUIElement)          — dumps non-empty JSON from a booted simulator
  *   5. webinspectord_sim socket         — findSocketPath() returns a live path
  *   6. ios_webkit_debug_proxy binary    — is on PATH
+ *   7. ax-bridge GUI-less invariant     — resolves AX root via
+ *                                          AXUIElementCreateApplication(pid) and
+ *                                          does not require Simulator.app foreground (#573)
  *
  * Excluded from `npm test`. Designed to run daily in CI (see
  * .github/workflows/private-api-sentinel.yml) so Apple-side breakage in
@@ -29,7 +32,7 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import * as path from 'path';
 
 import { findSocketPath } from '../../src/simulator/socket-finder';
@@ -277,6 +280,105 @@ describe('Private API Sentinel', () => {
         throw new Error(
           'ios_webkit_debug_proxy not found on PATH. ' +
             'Install with: brew install ios-webkit-debug-proxy',
+        );
+      }
+    });
+  });
+
+  // Probe 7 enforces the ADR recorded in PR #587 on issue #573:
+  // ax-bridge resolves the AX root through `AXUIElementCreateApplication(pid)`,
+  // which targets Simulator.app by PID. Epic #540 requires the property that
+  // AX reads do not depend on Simulator.app being the macOS frontmost app.
+  // A static assertion on the Swift source guarantees the design invariant;
+  // the opportunistic runtime check exercises it when the environment permits.
+  describe('7. ax-bridge GUI-less invariant (#573)', () => {
+    const swiftSource = path.join(REPO_ROOT, 'src', 'native', 'ax-bridge.swift');
+
+    test('swift source resolves AX root via AXUIElementCreateApplication(pid)', async () => {
+      if (!existsSync(swiftSource)) {
+        throw new Error(
+          `ax-bridge.swift not found at ${swiftSource} — cannot verify GUI-less invariant`,
+        );
+      }
+      const contents = readFileSync(swiftSource, 'utf8');
+
+      // Must construct the AX element from a PID — this is what makes the
+      // bridge independent of the frontmost-application state.
+      expect(contents).toMatch(/AXUIElementCreateApplication\s*\(/);
+
+      // Must not reach for the system-wide root, which would couple reads
+      // to whatever app happens to be focused.
+      expect(contents).not.toMatch(/AXUIElementCreateSystemWide\s*\(/);
+    });
+
+    test('ax-bridge dump succeeds while Simulator.app is not the frontmost app', async () => {
+      const bridge = findBinaryOrSource(['ax-bridge', 'ax-bridge.swift']);
+      if (!bridge) throw new Error('ax-bridge not found — run npm run build first');
+
+      const udid = await getBootedUdid();
+      if (!udid) {
+        console.warn(
+          '[sentinel] No booted simulator — skipping ax-bridge GUI-less runtime probe.',
+        );
+        return;
+      }
+
+      // Query the current frontmost GUI application via osascript. If
+      // Simulator.app happens to be frontmost (e.g. a developer ran the
+      // probe locally with the Simulator window focused), skip rather
+      // than silently passing a false positive: the runtime invariant
+      // cannot be checked without a non-Simulator app on top.
+      let frontmost = '';
+      try {
+        const { stdout } = await execFileAsync('osascript', [
+          '-e',
+          'tell application "System Events" to name of first application process whose frontmost is true',
+        ]);
+        frontmost = stdout.trim();
+      } catch (err) {
+        console.warn(
+          `[sentinel] osascript frontmost probe failed (${(err as Error).message}); skipping runtime GUI-less probe.`,
+        );
+        return;
+      }
+
+      if (/^Simulator$/i.test(frontmost)) {
+        console.warn(
+          '[sentinel] Simulator.app is currently frontmost; cannot verify GUI-less invariant without touching UI state. Skipping runtime probe.',
+        );
+        return;
+      }
+
+      const result = await spawnBridge(bridge, ['dump', '--device', udid, '--max-depth', '2']);
+
+      expect(result.signal).not.toBe('SIGABRT');
+      expect(result.signal).not.toBe('SIGSEGV');
+
+      const body = result.stdout.trim();
+      expect(body.length).toBeGreaterThan(0);
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(body);
+      } catch (err) {
+        throw new Error(
+          `ax-bridge dump produced non-JSON output while Simulator.app was not frontmost (was '${frontmost}'). ` +
+            `parseError=${(err as Error).message} stdout=${body} stderr=${result.stderr.trim()}`,
+        );
+      }
+
+      const maybeError = parsed as { error?: unknown; code?: string };
+      if (maybeError && typeof maybeError === 'object' && 'error' in maybeError) {
+        if (maybeError.code === 'SIMULATOR_NOT_RUNNING') {
+          console.warn(
+            '[sentinel] ax-bridge reports SIMULATOR_NOT_RUNNING — Simulator.app is not launched in this environment. Skipping runtime GUI-less probe.',
+          );
+          return;
+        }
+        throw new Error(
+          `ax-bridge returned error shape while Simulator.app was not frontmost (was '${frontmost}'): ` +
+            `code=${maybeError.code ?? 'unknown'} error=${String(maybeError.error)}. ` +
+            'The GUI-less invariant recorded in the #573 ADR has regressed.',
         );
       }
     });


### PR DESCRIPTION
## Summary

Adds the seventh private-API sentinel probe to prevent the ax-bridge GUI-less invariant from silently regressing. The invariant — that AX reads go through `AXUIElementCreateApplication(pid)` and therefore do not require Simulator.app to be the macOS frontmost app — was recorded in PR #587's ADR on issue #573.

- Static check: the Swift source at `src/native/ax-bridge.swift` must call `AXUIElementCreateApplication(` and must not call `AXUIElementCreateSystemWide(`. Always runs, regardless of host state.
- Runtime check: when a simulator is booted and Simulator.app is not the frontmost macOS app, `ax-bridge dump` must return non-empty JSON. Skips gracefully (with a warning) when no simulator is booted, when Simulator.app happens to be frontmost locally, or when the bridge returns `SIMULATOR_NOT_RUNNING`.

Workflow doc block in `.github/workflows/private-api-sentinel.yml` is extended from "six probes" to "seven probes" so the daily sentinel run reports the new coverage.

## Why

The PR #587 body promises: *"A separate PR adds sentinel probe 7 that enforces the GUI-less property on every daily run, so the implicit guarantee cannot silently regress."* This is that PR.

Without this probe, a future refactor of `ax-bridge.swift` that switched to `AXUIElementCreateSystemWide()` (or otherwise keyed AX reads off the frontmost app) would pass all existing tests, pass probe 4, and break epic #540's "No job requires Simulator.app foreground" acceptance criterion.

## Test plan

- [x] `npx jest --config jest.sentinel.config.js -t "ax-bridge GUI-less"` — probe 7 static assertions pass; runtime probe skips cleanly on hosts without a booted simulator.
- [x] `npx eslint tests/sentinel/private-api-probe.test.ts` — clean.
- [ ] Scheduled `private-api-sentinel.yml` run — will be exercised on the next cron or `workflow_dispatch`.

Refs: #573, #540 · Follows: #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)