### PR TITLE
fix(573): keep AX tree live for backgrounded Simulator.app

### DIFF
--- a/src/native/ax-bridge.swift
+++ b/src/native/ax-bridge.swift
@@ -401,6 +401,21 @@ func main() {
 
     let app = AXUIElementCreateApplication(pid)
 
+    // Wake up the AX server on the target process.
+    //
+    // Empirically, after Simulator.app spends ~1s as a non-frontmost macOS
+    // process, its AX server degrades and subsequent
+    // `AXUIElementCopyAttributeValue` calls return `kAXErrorCannotComplete`
+    // (-25204) for every attribute — `kAXChildren`, `kAXWindows`,
+    // `kAXFocusedWindow`, `kAXMainWindow`. This is the foreground dependency
+    // issue #573 surfaced. Setting `AXManualAccessibility = true` once
+    // forces the target app to keep its AX tree live even while backgrounded;
+    // the SET call itself can return `-25204` in the degraded state, but
+    // the side effect is applied and the following reads succeed. Public AX
+    // API only, no private frameworks involved — same mechanism Electron /
+    // other Chromium hosts use for the inverse direction (opt-in to AX).
+    _ = AXUIElementSetAttributeValue(app, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+
     // Find the device content area
     guard let (content, originX, originY) = findDeviceContent(app, deviceUDID: deviceUDID) else {
         outputError("Could not find device window for UDID: \(deviceUDID)", code: "DEVICE_NOT_FOUND")


### PR DESCRIPTION
## Summary
- Adds `AXUIElementSetAttributeValue(app, "AXManualAccessibility", true)` once after creating the AX root for Simulator.app's PID, before `findDeviceContent`.
- Fixes the foreground dependency surfaced by issue #573 / epic #540: after Simulator.app spends ~1s as a non-frontmost macOS process, its AX server degrades and every `AXUIElementCopyAttributeValue` returns `kAXErrorCannotComplete` (-25204).
- Public AX API only — same mechanism Electron / Chromium hosts use for the inverse direction. No private frameworks added.
- Pairs with PR #616 (sentinel probe 7), which enforces the GUI-less invariant in CI; this PR is the runtime half that makes the invariant hold.

## Test plan
- [ ] `npm run build` succeeds (Swift bridge rebuilds).
- [ ] On a workstation with a booted simulator, `tests/sentinel/private-api-probe.test.ts` probe 7 passes once #616 lands (Simulator.app NOT macOS frontmost → ax-bridge dump returns non-empty JSON).
- [ ] Manual: activate Finder so Simulator.app drops to background, then run `node dist/cli/index.js inspect <udid>` — should still return AX tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)