### PR TITLE
test(ci): sentinel probe for PointerService symbols (#590 Phase 1)

### DIFF
--- a/.github/workflows/sim-hid-sentinel.yml
+++ b/.github/workflows/sim-hid-sentinel.yml
@@ -10,6 +10,7 @@ name: SimulatorKit HID Sentinel
 #   exit 78 CORESIMULATOR_MISSING     — CoreSimulator.framework moved or gone
 #   exit 78 HID_CLIENT_FAILED         — SimDeviceLegacyHIDClient class gone
 #   exit 78 HID_FUNCTIONS_MISSING     — IndigoHIDMessage* symbols gone
+#   diag indigoSymbols false/missing  — IndigoHIDMessageToCreate/RemovePointerService gone (#590 Phase 1)
 #
 # When the job fails we open (or update) a tracking issue so the on-call
 # engineer sees it on github.com without needing Slack access.

--- a/tests/ci/sim-hid-sentinel.test.ts
+++ b/tests/ci/sim-hid-sentinel.test.ts
@@ -188,3 +188,56 @@ describe('SimulatorKit HID Sentinel', () => {
     expect(result.exitCode).toBe(64);
   }, SLOW_BRIDGE_TIMEOUT_MS);
 });
+
+describe('SimulatorKit HID Sentinel — PointerService probe (#590 Phase 1)', () => {
+  test(
+    'IndigoHIDMessageToCreatePointerService and IndigoHIDMessageToRemovePointerService resolve via diag',
+    async () => {
+      const result = await runBridge(['diag']);
+
+      let parsed: {
+        simulatorKit?: { loaded?: boolean };
+        indigoSymbols?: Record<string, boolean>;
+      } = {};
+      try {
+        parsed = JSON.parse(result.stdout);
+      } catch {
+        fail(
+          'sim-hid-bridge diag did not produce valid JSON. ' +
+            'stdout: ' +
+            result.stdout +
+            ' stderr: ' +
+            result.stderr,
+        );
+      }
+
+      // Precondition: SimulatorKit must be loaded for symbol probes to be meaningful.
+      expect(parsed.simulatorKit?.loaded).toBe(true);
+
+      const createPS = parsed.indigoSymbols?.IndigoHIDMessageToCreatePointerService;
+      const removePS = parsed.indigoSymbols?.IndigoHIDMessageToRemovePointerService;
+
+      if (createPS !== true) {
+        fail(
+          'IndigoHIDMessageToCreatePointerService did not resolve (#590 Phase 1). ' +
+            'Apple may have removed or renamed this PointerService symbol. ' +
+            'indigoSymbols: ' +
+            JSON.stringify(parsed.indigoSymbols),
+        );
+      }
+
+      if (removePS !== true) {
+        fail(
+          'IndigoHIDMessageToRemovePointerService did not resolve (#590 Phase 1). ' +
+            'Apple may have removed or renamed this PointerService symbol. ' +
+            'indigoSymbols: ' +
+            JSON.stringify(parsed.indigoSymbols),
+        );
+      }
+
+      expect(createPS).toBe(true);
+      expect(removePS).toBe(true);
+    },
+    SLOW_BRIDGE_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
## Summary
- Extends `tests/ci/sim-hid-sentinel.test.ts` with a new probe that asserts `IndigoHIDMessageToCreatePointerService` and `IndigoHIDMessageToRemovePointerService` resolve via `sim-hid-bridge diag`.
- Adds one bullet to the `.github/workflows/sim-hid-sentinel.yml` comment header documenting the new failure mode.
- Flips the `- [ ] Sentinel workflow adds a PointerService probe` row in the #590 Pre-Deploy checklist.

## Why use `diag` instead of `tap-ps`
The sentinel runs across `macos-14`, `macos-15`, and `macos-latest` on a daily cron — these runners do not always have a booted simulator. The bridge's `diag` subcommand (already shipped) returns a JSON manifest of every `IndigoHIDMessage*` symbol's dlsym state and requires no UDID, which is exactly the contract the sentinel needs. Running `tap-ps` against a fake UDID would fail at the SimDevice lookup (exit 69) before the PointerService symbols are ever resolved, so it would be a false negative.

## Checklist row this flips
> - [x] Sentinel workflow adds a PointerService probe

## How it was verified
- Local run on macOS / Xcode on this workstation:
  ```
  $ npm run build && npx jest --config jest.config.js tests/ci/sim-hid-sentinel.test.ts --runTestsByPath --testPathIgnorePatterns=/node_modules/
  Test Suites: 1 passed, 1 total
  Tests:       6 passed, 6 total
  ```
- The new `describe` block added 1 test; existing 5 tests continue to pass.
- If Apple removes or renames either PS symbol, the `fail()` call names the specific symbol plus `#590 Phase 1` so the auto-filed sentinel issue is immediately actionable.

## Test plan
- [ ] Daily sentinel workflow run on `macos-latest`, `macos-15`, `macos-14` passes with the new probe.
- [ ] If either PS symbol is removed upstream, the sentinel fails with a message naming the specific symbol + #590 Phase 1.

Refs #590 (Phase 1 Pre-Deploy). Does NOT close #590 — partial-progress PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)