### PR TITLE
fix(webview-fixture): align bundle ID with test expectation (#593)

### DIFF
--- a/tests/fixtures/webview_flutter_bridge/README.md
+++ b/tests/fixtures/webview_flutter_bridge/README.md
@@ -33,6 +33,15 @@ mkdir -p assets
 cp assets/index.html <generated>/assets/index.html
 ```
 
+> **Note:** Flutter camelCases the project name when deriving the bundle ID
+> (`webview_flutter_bridge` → `webviewFlutterBridge`), so the generated
+> `ios/Runner.xcodeproj/project.pbxproj` contains
+> `com.opensafari.fixtures.webviewFlutterBridge` instead of the canonical
+> `com.opensafari.fixtures.webviewbridge`. Running `build.sh` automatically
+> rewrites those occurrences before the Xcode build, so the installed `.app`
+> always carries the correct bundle ID. You do **not** need to patch the
+> pbxproj manually.
+
 ## Building and installing
 
 ```sh
@@ -41,8 +50,11 @@ cp assets/index.html <generated>/assets/index.html
 
 `build.sh` will:
 1. Run `flutter pub get`.
-2. Build for the iOS Simulator (`flutter build ios --simulator --debug --no-codesign`).
-3. Install the `.app` bundle onto the simulator identified by `<UDID>` using
+2. Rewrite `PRODUCT_BUNDLE_IDENTIFIER` in `ios/Runner.xcodeproj/project.pbxproj`
+   from the Flutter-generated `com.opensafari.fixtures.webviewFlutterBridge` to
+   the canonical `com.opensafari.fixtures.webviewbridge`.
+3. Build for the iOS Simulator (`flutter build ios --simulator --debug --no-codesign`).
+4. Install the `.app` bundle onto the simulator identified by `<UDID>` using
    `xcrun simctl install`.
 
 ## Screen layout

--- a/tests/fixtures/webview_flutter_bridge/build.sh
+++ b/tests/fixtures/webview_flutter_bridge/build.sh
@@ -37,6 +37,20 @@ fi
 echo "==> flutter pub get"
 (cd "$SCRIPT_DIR" && flutter pub get)
 
+# Flutter derives the bundle ID from the project name using camelCase
+# (webview_flutter_bridge → webviewFlutterBridge), producing
+# com.opensafari.fixtures.webviewFlutterBridge in the generated pbxproj.
+# Rewrite it to the canonical ID used by build.sh, the README, and the
+# integration test so that `simctl launch` finds the installed app.
+PBXPROJ="$SCRIPT_DIR/ios/Runner.xcodeproj/project.pbxproj"
+if [ -f "$PBXPROJ" ]; then
+  echo "==> Rewriting PRODUCT_BUNDLE_IDENTIFIER in $PBXPROJ"
+  sed -i '' \
+    -e 's/PRODUCT_BUNDLE_IDENTIFIER = com\.opensafari\.fixtures\.webviewFlutterBridge\.RunnerTests;/PRODUCT_BUNDLE_IDENTIFIER = com.opensafari.fixtures.webviewbridge.RunnerTests;/g' \
+    -e 's/PRODUCT_BUNDLE_IDENTIFIER = com\.opensafari\.fixtures\.webviewFlutterBridge;/PRODUCT_BUNDLE_IDENTIFIER = com.opensafari.fixtures.webviewbridge;/g' \
+    "$PBXPROJ"
+fi
+
 echo "==> flutter build ios --simulator --debug --no-codesign"
 (cd "$SCRIPT_DIR" && flutter build ios --simulator --debug --no-codesign)
 


### PR DESCRIPTION
## Root cause

Flutter camelCases the project name when deriving the iOS bundle ID: `webview_flutter_bridge` → `webviewFlutterBridge`. So `flutter create --org com.opensafari.fixtures --project-name webview_flutter_bridge` generates `com.opensafari.fixtures.webviewFlutterBridge` in `ios/Runner.xcodeproj/project.pbxproj`. Three files expected the canonical `com.opensafari.fixtures.webviewbridge`, causing `xcrun simctl launch` to fail with `FBSOpenApplicationServiceErrorDomain code=4` because the installed `.app` carried the wrong bundle ID.

## Fix

Added a `sed` step in `build.sh` (runs after `flutter pub get`, before `flutter build ios`) that rewrites all six `PRODUCT_BUNDLE_IDENTIFIER` occurrences in the generated pbxproj — three for the Runner target and three for RunnerTests — from the Flutter-generated camelCase ID to the canonical `com.opensafari.fixtures.webviewbridge`. The step is guarded with `[ -f "$PBXPROJ" ]` so it is a no-op when the iOS scaffold has not yet been generated.

Updated `README.md` to document this behaviour in both the "Generating the Flutter scaffold" and "Building and installing" sections. No changes were required in `tests/integration/webview-native-context.live.test.ts` — it already uses the correct bundle ID (`com.opensafari.fixtures.webviewbridge` at line 46).

## Verification

```
# 1. Regenerate scaffold
cd tests/fixtures/webview_flutter_bridge
rm -rf ios build
flutter create --org com.opensafari.fixtures --project-name webview_flutter_bridge --platforms=ios .

# 2. Build + install (triggers the sed rewrite)
./build.sh --install --device-id D7D26213-C3E9-4623-BCCB-984CDF5D0793
```

Output:
```
==> Rewriting PRODUCT_BUNDLE_IDENTIFIER in .../ios/Runner.xcodeproj/project.pbxproj
Building com.opensafari.fixtures.webviewbridge for simulator (ios)...
✓ Built build/ios/iphonesimulator/Runner.app
Installed com.opensafari.fixtures.webviewbridge on D7D26213-C3E9-4623-BCCB-984CDF5D0793
```

```
# 3. Confirm installed bundle ID
xcrun simctl listapps D7D26213-C3E9-4623-BCCB-984CDF5D0793 | grep -A1 webviewbridge
```

Output:
```
    "com.opensafari.fixtures.webviewbridge" =     {
        ApplicationType = User;
--
        CFBundleIdentifier = "com.opensafari.fixtures.webviewbridge";
        CFBundleName = "webview_flutter_bridge";
```

```
# 4. Launch succeeds with a PID
xcrun simctl launch D7D26213-C3E9-4623-BCCB-984CDF5D0793 com.opensafari.fixtures.webviewbridge
```

Output:
```
com.opensafari.fixtures.webviewbridge: 77787
```

## Changes

- `tests/fixtures/webview_flutter_bridge/build.sh` — add `sed` rewrite step between `flutter pub get` and `flutter build ios`
- `tests/fixtures/webview_flutter_bridge/README.md` — document the Flutter camelCase behaviour and the auto-rewrite in build.sh

Closes part of #593 — fixes the bundle-ID half of the live-verification blockers reported in https://github.com/shaun0927/opensafari/issues/593#issuecomment-4268137986