### PR TITLE
docs(flutter): fix simulator QA recipe (use --debug); split device profile path (#596)

### DIFF
--- a/docs/ci-recipes.md
+++ b/docs/ci-recipes.md
@@ -485,13 +485,19 @@ export OPENSAFARI_HEADLESS_ONLY=1
 
 ### QA-ready Flutter build
 
-**Recommendation:** build "QA" simulator artifacts with `flutter build ios --simulator --profile` instead of `--release`. Profile mode runs close to release performance **and** keeps the Dart VM Service online, so `FlutterVMInputBackend` (Tier 0) stays the active input path.
-
 Release builds compile Dart to AOT and reject runtime `evaluate` calls with `code 113`, which surfaces as `FlutterVMInputBackendError { code: 'VM_NO_EVALUATE' }`. The router then falls through to Tier 1.5 AX-press (element-targeted tools only) and ultimately AppleScript for coordinate gestures — the slowest and most fragile path, and — on Xcode 26+ where Tier-1 SimHID tap/swipe is disabled pending #491 — the only remaining coordinate fallback. See [Build-mode × Xcode tier matrix](./flutter-inspector.md#build-mode--xcode-tier-matrix-596) for the full routing table.
 
+The right "QA-ready" build differs by target. The Flutter toolchain blocks `--profile` for simulator targets, so simulator QA must use `--debug`; profile mode is reserved for physical-device QA.
+
+#### iOS Simulator — use `--debug`
+
+**Recommendation:** build simulator QA artifacts with `flutter build ios --simulator --debug`. This is the only mode the Flutter toolchain accepts for `--simulator` targets and keeps `FlutterVMInputBackend` (Tier 0) active.
+
+Trying `--profile` against the simulator fails fast — Flutter exits with *"Profile mode is not supported for simulators."* (verified against Flutter 3.41.5 / Dart 3.11.3 on iPhone 17 Pro Sim, iOS 26.4). Use `--debug` for the simulator and reserve `--profile` for physical-device runs.
+
 ```bash
-# Build a profile-mode simulator bundle (keeps VM Service; runs near release perf).
-flutter build ios --simulator --profile --target lib/main_qa.dart
+# Build a debug-mode simulator bundle (only mode the Flutter toolchain accepts; keeps Tier 0).
+flutter build ios --simulator --debug --target lib/main_qa.dart
 
 # Install and launch so flutter_connect lands on Tier 0.
 APP=build/ios/iphonesimulator/Runner.app
@@ -501,8 +507,8 @@ xcrun simctl launch --console booted "$(plutil -extract CFBundleIdentifier raw "
 
 ```yaml
 # GitHub Actions — QA-ready Flutter simulator build
-- name: Build Flutter (profile mode)
-  run: flutter build ios --simulator --profile --target lib/main_qa.dart
+- name: Build Flutter (debug mode for simulator)
+  run: flutter build ios --simulator --debug --target lib/main_qa.dart
 
 - name: Install + launch on booted simulator
   run: |
@@ -512,7 +518,18 @@ xcrun simctl launch --console booted "$(plutil -extract CFBundleIdentifier raw "
     xcrun simctl launch booted "$BUNDLE"
 ```
 
-> **Why not `--release`?** The Dart AOT runtime in release mode has no expression compiler, so Tier 0 probes fail and every subsequent tap/swipe degrades to AppleScript (or silently fails under `OPENSAFARI_HEADLESS_ONLY=1`). Profile mode keeps the tree-shaker and AOT-compatible optimisations while preserving the VM Service — the same trade-off that `flutter run --profile` makes for Flutter's own tooling.
+#### Physical iOS device — use `--profile`
+
+**Recommendation:** for physical-device QA where you want perf parity with release, use `flutter build ios --profile`. Profile mode keeps the Dart VM Service online (so Tier 0 remains active) while running close to release performance — the same trade-off `flutter run --profile` makes for Flutter's own tooling.
+
+```bash
+# Build a profile-mode IPA for a physical device (keeps VM Service; runs near release perf).
+flutter build ios --profile --target lib/main_qa.dart
+
+# Install and launch via your usual device tooling (Xcode, ios-deploy, devicectl, etc.).
+```
+
+> **Why not `--release` on either target?** The Dart AOT runtime in release mode has no expression compiler, so Tier 0 probes fail and every subsequent tap/swipe degrades to AppleScript (or silently fails under `OPENSAFARI_HEADLESS_ONLY=1`). Choose `--debug` for simulator QA and `--profile` for device QA to keep Tier 0 alive.
 
 ### Reading `_meta._telemetry` in CI
 

--- a/docs/flutter-inspector.md
+++ b/docs/flutter-inspector.md
@@ -13,13 +13,23 @@ Both tools require an active Flutter VM Service connection via `flutter_connect`
 
 Flutter build mode determines which input tier the router lands on. **Release builds on Xcode 26+ land on the slowest and most fragile path** — AX-press for element-targeted tools only, AppleScript for coordinate tools — because Tier 0 (`FlutterVMInputBackend`) requires `evaluate` support (Dart AOT cannot compile expressions at runtime) and Tier 1 SimHID tap/swipe is disabled on Xcode 26+ pending the `IndigoHIDMessageForMouseNSEvent` regression fix (#491, #537).
 
-Consumers often pick release mode for "QA" simulator builds to match production performance — and silently forfeit headless coverage. Use `flutter build ios --simulator --profile` instead: it keeps the VM Service online so Tier 0 stays available, while running close to release perf. See the [QA-ready Flutter build recipe](./ci-recipes.md#qa-ready-flutter-build).
+Consumers often pick release mode for "QA" simulator builds to match production performance — and silently forfeit headless coverage. The Flutter toolchain blocks `--profile` for simulator targets (`flutter build ios --simulator --profile` exits with *"Profile mode is not supported for simulators."*), so the only Tier-0-keeping mode on the simulator is `--debug`. Profile mode still applies to physical-device QA. See the [QA-ready Flutter build recipe](./ci-recipes.md#qa-ready-flutter-build) for both flows.
+
+**iOS Simulator (Xcode Simulator runtimes):**
 
 | Build mode | Xcode ≤ 25 | Xcode 26+ | VM Service | Tier 0 (`FlutterVMInputBackend`) |
 | --- | --- | --- | --- | --- |
 | `debug` | **Tier 0** (all gestures via VM Service) | **Tier 0** (all gestures via VM Service) | ✅ | ✅ `evaluate` available |
-| `profile` | **Tier 0** (recommended for perf-parity QA) | **Tier 0** (recommended for perf-parity QA) | ✅ | ✅ `evaluate` available |
+| `profile` | n/a — *"Profile mode is not supported for simulators."* | n/a — same toolchain block | n/a | n/a — use `--debug` instead |
 | `release` | Tier 1/2/3 (SimHID → simctl → WebKit) | ⚠️ **AX-press for element, AppleScript for coords** | ❌ (AOT) | ❌ falls through (`VM_NO_EVALUATE`) |
+
+**Physical iOS devices:**
+
+| Build mode | VM Service | Tier 0 (`FlutterVMInputBackend`) | Notes |
+| --- | --- | --- | --- |
+| `debug` | ✅ | ✅ `evaluate` available | Slowest runtime; use only when you need full inspector tooling. |
+| `profile` | ✅ | ✅ `evaluate` available | **Recommended for perf-parity device QA** — keeps Tier 0 while running close to release perf. |
+| `release` | ❌ (AOT) | ❌ falls through (`VM_NO_EVALUATE`) | Same fall-through behaviour as a release-mode simulator build. |
 
 Legend:
 

--- a/src/tools/flutter-vm-input-backend.ts
+++ b/src/tools/flutter-vm-input-backend.ts
@@ -73,8 +73,9 @@ export class FlutterVMInputBackendError extends Error {
           `with \`simctl launch\` instead of \`flutter run\`. ` +
           `Use Tier 1.5 AX press (app_tap_element / app_type_element) or ` +
           `relaunch under \`flutter run --debug\` for full gesture coverage. ` +
-          `See docs/ci-recipes.md#qa-ready-flutter-build for a CI-ready ` +
-          `--profile recipe that keeps Tier 0 available.`
+          `See docs/ci-recipes.md#qa-ready-flutter-build for the ` +
+          `simulator (--debug) and physical-device (--profile) recipes ` +
+          `that keep Tier 0 available.`
         : `FlutterVMInputBackend.${op} failed: ${msg}`;
     super(userMessage);
     this.op = op;


### PR DESCRIPTION
## Summary
- Fix the `docs/ci-recipes.md` "QA-ready Flutter build" recipe so the simulator command actually works — the previous `flutter build ios --simulator --profile` is rejected by the Flutter toolchain (*"Profile mode is not supported for simulators."*). Pin simulator QA to `--debug` (the only Tier-0-keeping mode the toolchain accepts for `--simulator`) and add a separate physical-device sub-section that keeps the existing `--profile` guidance.
- Split the `docs/flutter-inspector.md` Build-mode × Xcode tier matrix into a simulator table (with `n/a` for `profile`) and a physical-device table so the published routing claims match what Flutter actually allows.
- Update the `FlutterVMInputBackendError { code: 'VM_NO_EVALUATE' }` remediation message in `src/tools/flutter-vm-input-backend.ts` to point at both flows instead of advertising a `--profile` recipe to simulator users.

## Why
Issue #596 verification (https://github.com/shaun0927/opensafari/issues/596#issuecomment-4268163964) showed the shipped recipe is unrunnable on a simulator target — `flutter build ios --simulator --profile` and `flutter run --profile -d <sim>` both exit non-zero on Flutter 3.41.5 / Dart 3.11.3 / iPhone 17 Pro Sim (iOS 26.4). Consumers following the docs would see `Profile mode is not supported for simulators.` and bounce. The fixture's own `tests/fixtures/flutter-qa-app/build.sh:7-10,57-60` already documented this constraint, but the public docs hadn't caught up.

## Test plan
- [x] `npx jest tests/unit/flutter-vm-input-backend.test.ts` → 23/23 passed (canonical recipe-link assertion at line 303 still holds; anchor `#qa-ready-flutter-build` unchanged).
- [x] `npm run build` → succeeds (TypeScript compiles).
- [x] Real verification on `tests/fixtures/flutter-qa-app` against booted simulator `D7D26213-C3E9-4623-BCCB-984CDF5D0793` (iPhone 17 Pro, iOS 26.4):
  - `bash tests/fixtures/flutter-qa-app/build.sh --mode debug --install` → `✓ Built …/Debug-iphonesimulator/Runner.app`, install OK.
  - `mcp__opensafari__app_launch` → app launched (pid 83759).
  - `mcp__opensafari__flutter_connect` → `status: connected`, `dartVersion 3.11.3`, `flutterMajor 3`, VM Service URL acquired — confirming Tier 0 is available with the documented `--debug` build.

## Out of scope
Re-verifying and closing issue #596 lands in a follow-up (per autopilot work-unit B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)