### PR TITLE
docs(readme): qualify WebView-in-Native partial status (#592)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ OpenSafari runs fully headless on CI — no display server, no mouse focus, no `
 | Native iOS App (Xcode ≤ 16) | ✅ | ✅ | ✅ | SimulatorKitHID (Tier 1) / `simctl` |
 | Native iOS App (Xcode 26+, element-targeted `app_tap_element` / `app_type_element`) | ✅ | ✅ | ✅ | AX-press (Tier 1.5) when the element advertises `AXPress` — see [docs/headless-architecture.md](docs/headless-architecture.md) |
 | Native iOS App (Xcode 26+, coordinate `app_tap({x,y})` / `app_swipe_native`) | ✅ | ⚠️ Experimental (opt-in) | ⚠️ | PointerService opt-in via `OPENSAFARI_ENABLE_POINTERSERVICE=1` — see [#590](https://github.com/shaun0927/opensafari/issues/590); AppleScript fallback otherwise ([#491](https://github.com/shaun0927/opensafari/issues/491)) |
-| WebView in Native | ✅ | ⚠️ Partial | ⚠️ | WebKit + Native |
+| WebView in Native | ✅ | ⚠️ Partial | ⚠️ | Bundle metadata (`appId`&#124;`bundleId`) requires a newer `ios-webkit-debug-proxy` build — older proxies fall back to URL-scheme heuristics. HTTPS WebViews (e.g. payment-return pages) must pass `bundleId` to `app_webview_connect` for `bundle_match` classification; without it they default to `safari` via `url_scheme` — see [#592](https://github.com/shaun0927/opensafari/issues/592) |
 
 > ✅ Supported and stable. ⚠️ Partially supported — see linked docs for current status and limitations.
 


### PR DESCRIPTION
## Summary
- Replace the vague "WebKit + Native" cell in the Headless Capabilities table with concrete partial-status notes: bundle metadata requires a newer `ios-webkit-debug-proxy` build, and HTTPS WebViews must pass `bundleId` to `app_webview_connect` for `bundle_match` classification.
- Addresses the README row gap from issue #592 post-deploy validation checklist.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (1721/1721, no source changes)
- [x] Markdown table still renders as 5 columns

Refs: #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)