### PR TITLE
fix(webview-fixture): expose AX identifiers on Flutter buttons (#593)

### DIFF
--- a/src/webkit/client.ts
+++ b/src/webkit/client.ts
@@ -158,7 +158,30 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
   async listTargets(): Promise<WebKitTarget[]> {
     const url = `http://${this.options.host}:${this.options.port}/json`;
     const json = await this.httpGet(url);
-    const targets = JSON.parse(json) as WebKitTarget[];
+    const parsed = JSON.parse(json) as WebKitTarget[];
+
+    // ios-webkit-debug-proxy device-list mode: the top-level /json returns
+    // redirect entries of the form { url: "host:PORT" } with no
+    // webSocketDebuggerUrl. Follow each redirect to get real page targets.
+    const isDeviceRedirect = (t: WebKitTarget) =>
+      !t.webSocketDebuggerUrl && typeof t.url === 'string' && /^\S+:\d+$/.test(t.url);
+
+    let targets: WebKitTarget[];
+    if (parsed.length > 0 && parsed.every(isDeviceRedirect)) {
+      const followed = await Promise.all(
+        parsed.map(async (t) => {
+          try {
+            const redirectJson = await this.httpGet(`http://${t.url}/json`);
+            return JSON.parse(redirectJson) as WebKitTarget[];
+          } catch {
+            return [] as WebKitTarget[];
+          }
+        }),
+      );
+      targets = followed.flat();
+    } else {
+      targets = parsed;
+    }
 
     // ios-webkit-debug-proxy doesn't include an `id` field — derive from webSocketDebuggerUrl
     for (const t of targets) {

--- a/tests/fixtures/webview_flutter_bridge/README.md
+++ b/tests/fixtures/webview_flutter_bridge/README.md
@@ -33,6 +33,15 @@ mkdir -p assets
 cp assets/index.html <generated>/assets/index.html
 ```
 
+> **Note:** Flutter camelCases the project name when deriving the bundle ID
+> (`webview_flutter_bridge` → `webviewFlutterBridge`), so the generated
+> `ios/Runner.xcodeproj/project.pbxproj` contains
+> `com.opensafari.fixtures.webviewFlutterBridge` instead of the canonical
+> `com.opensafari.fixtures.webviewbridge`. Running `build.sh` automatically
+> rewrites those occurrences before the Xcode build, so the installed `.app`
+> always carries the correct bundle ID. You do **not** need to patch the
+> pbxproj manually.
+
 ## Building and installing
 
 ```sh
@@ -41,8 +50,11 @@ cp assets/index.html <generated>/assets/index.html
 
 `build.sh` will:
 1. Run `flutter pub get`.
-2. Build for the iOS Simulator (`flutter build ios --simulator --debug --no-codesign`).
-3. Install the `.app` bundle onto the simulator identified by `<UDID>` using
+2. Rewrite `PRODUCT_BUNDLE_IDENTIFIER` in `ios/Runner.xcodeproj/project.pbxproj`
+   from the Flutter-generated `com.opensafari.fixtures.webviewFlutterBridge` to
+   the canonical `com.opensafari.fixtures.webviewbridge`.
+3. Build for the iOS Simulator (`flutter build ios --simulator --debug --no-codesign`).
+4. Install the `.app` bundle onto the simulator identified by `<UDID>` using
    `xcrun simctl install`.
 
 ## Screen layout

--- a/tests/fixtures/webview_flutter_bridge/build.sh
+++ b/tests/fixtures/webview_flutter_bridge/build.sh
@@ -37,6 +37,20 @@ fi
 echo "==> flutter pub get"
 (cd "$SCRIPT_DIR" && flutter pub get)
 
+# Flutter derives the bundle ID from the project name using camelCase
+# (webview_flutter_bridge → webviewFlutterBridge), producing
+# com.opensafari.fixtures.webviewFlutterBridge in the generated pbxproj.
+# Rewrite it to the canonical ID used by build.sh, the README, and the
+# integration test so that `simctl launch` finds the installed app.
+PBXPROJ="$SCRIPT_DIR/ios/Runner.xcodeproj/project.pbxproj"
+if [ -f "$PBXPROJ" ]; then
+  echo "==> Rewriting PRODUCT_BUNDLE_IDENTIFIER in $PBXPROJ"
+  sed -i '' \
+    -e 's/PRODUCT_BUNDLE_IDENTIFIER = com\.opensafari\.fixtures\.webviewFlutterBridge\.RunnerTests;/PRODUCT_BUNDLE_IDENTIFIER = com.opensafari.fixtures.webviewbridge.RunnerTests;/g' \
+    -e 's/PRODUCT_BUNDLE_IDENTIFIER = com\.opensafari\.fixtures\.webviewFlutterBridge;/PRODUCT_BUNDLE_IDENTIFIER = com.opensafari.fixtures.webviewbridge;/g' \
+    "$PBXPROJ"
+fi
+
 echo "==> flutter build ios --simulator --debug --no-codesign"
 (cd "$SCRIPT_DIR" && flutter build ios --simulator --debug --no-codesign)
 

--- a/tests/fixtures/webview_flutter_bridge/lib/main.dart
+++ b/tests/fixtures/webview_flutter_bridge/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -38,6 +39,11 @@ class _BridgePageState extends State<BridgePage> {
     super.initState();
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted);
+    // Enable Web Inspector so ios-webkit-debug-proxy can see the WKWebView
+    // (required on iOS 16.4+ / WKWebView — isInspectable defaults to false).
+    if (_controller.platform is WebKitWebViewController) {
+      (_controller.platform as WebKitWebViewController).setInspectable(true);
+    }
   }
 
   Future<void> _loadWebView() async {
@@ -64,11 +70,12 @@ class _BridgePageState extends State<BridgePage> {
         children: [
           Padding(
             padding: const EdgeInsets.all(16.0),
-            child: Semantics(
-              identifier: 'load_webview_btn',
-              child: ElevatedButton(
-                key: const Key('load_webview_btn'),
-                onPressed: _loadWebView,
+            child: ElevatedButton(
+              key: const Key('load_webview_btn'),
+              onPressed: _loadWebView,
+              child: Semantics(
+                container: false,
+                identifier: 'load_webview_btn',
                 child: const Text('Load WebView'),
               ),
             ),
@@ -79,11 +86,12 @@ class _BridgePageState extends State<BridgePage> {
             ),
           Padding(
             padding: const EdgeInsets.all(16.0),
-            child: Semantics(
-              identifier: 'native_confirm_btn',
-              child: ElevatedButton(
-                key: const Key('native_confirm_btn'),
-                onPressed: _confirmNative,
+            child: ElevatedButton(
+              key: const Key('native_confirm_btn'),
+              onPressed: _confirmNative,
+              child: Semantics(
+                container: false,
+                identifier: 'native_confirm_btn',
                 child: const Text('Confirm Native'),
               ),
             ),


### PR DESCRIPTION
## Summary

- **Depends on PR #625** (`fix/593-bundle-id-mismatch`) — merge after #625; the live verification below assumed #625's bundle-ID fix is also present.
- Fixes the AX-identifier half of the live-verification blockers reported in https://github.com/shaun0927/opensafari/issues/593#issuecomment-4268137986

## Root Cause

On Flutter 3.41.5 / iOS, wrapping an `ElevatedButton` in a parent `Semantics(identifier: ...)` does **not** propagate the identifier to iOS UIAccessibility. `ElevatedButton` renders its own internal `Semantics` widget that shadows/replaces the parent — the button appears as `AXButton label=Load WebView` with no identifier.

The sibling `Semantics(identifier: 'native_status_text', child: Text(...))` worked correctly because `Text` has no internal Semantics wrapper.

## Fix

**`tests/fixtures/webview_flutter_bridge/lib/main.dart`**

Move `Semantics` *inside* the button as its `child`, with `container: false` so the identifier merges upward into the button's own semantics node:

```dart
// Before (broken — ElevatedButton's internal Semantics shadows parent)
Semantics(
  identifier: 'load_webview_btn',
  child: ElevatedButton(
    child: const Text('Load WebView'),
  ),
)

// After (fix — identifier merges up from child into button's semantics node)
ElevatedButton(
  child: Semantics(
    container: false,
    identifier: 'load_webview_btn',
    child: const Text('Load WebView'),
  ),
)
```

Also adds `setInspectable(true)` on `WebKitWebViewController` so the `WKWebView` is visible to `ios-webkit-debug-proxy` (required on iOS 16.4+, defaults to `false`).

**`src/webkit/client.ts`**

`listTargets()` now follows `ios-webkit-debug-proxy` device-redirect entries (`{ url: "host:PORT", webSocketDebuggerUrl: undefined }`) so callers using the device-list port (9360) receive real page targets instead of the unresolvable redirect entry.

## AX Tree Before / After

**Before** (parent Semantics shadowed):
```
AXButton label="Load WebView"        ← no identifier
AXButton label="Confirm Native"      ← no identifier
AXStaticText id=native_status_text label="idle"
```

**After** (identifier merges up from child):
```
AXButton id=load_webview_btn label="Load WebView"
AXButton id=native_confirm_btn label="Confirm Native"
AXStaticText id=native_status_text label="idle"
```

## Live Verification

```
PASS tests/integration/webview-native-context.live.test.ts (24.145 s)
  issue #593 — WebView↔Native cross-context E2E
    ✓ AX press on load_webview_btn launches the embedded WebView (2179 ms)
    ✓ context-switch + DOM eval round-trip — heading text is "WebView Bridge" (51 ms)
    ✓ in-WebView click mutates DOM — web-info becomes "clicked" (5 ms)
    ✓ bounce back to native — native_confirm_btn sets native_status_text to "confirmed" (1679 ms)

Tests: 4 passed, 4 total
```

Device: iPhone 17 Pro (D7D26213-C3E9-4623-BCCB-984CDF5D0793) / iOS 26.4 / Flutter 3.41.5

---

Closes part of #593 — fixes the AX-identifier half of the live-verification blockers reported in https://github.com/shaun0927/opensafari/issues/593#issuecomment-4268137986