### PR TITLE
fix(ci): restore ax-bridge import safety + sentinel timeout budget

### DIFF
--- a/cli/ax-bridge.ts
+++ b/cli/ax-bridge.ts
@@ -383,14 +383,23 @@ async function main(): Promise<void> {
 
 // Reminder: stdout is the structured-JSON contract consumed by AccessibilityBridge — do not write non-JSON here.
 // Webpack bundles this file as the CLI entry; `require.main === module` does
-// not survive the webpack transform (the resulting guard never evaluates true
-// when run as `node dist/ax-bridge`), so we invoke `main()` unconditionally.
-main().catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  const payload: ErrorJSON = {
-    error: `ax-bridge wrapper failed: ${message}`,
-    code: 'AX_WRAPPER_FAILED',
-  };
-  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-  process.exit(1);
-});
+// not survive that transform, so we detect CLI invocation by inspecting
+// `process.argv[1]`. Jest/ts-jest imports run with `argv[1]` pointing at the
+// jest worker, so `main()` is only invoked when the ax-bridge binary itself
+// is the entry — keeping `decidePromotion` importable by unit tests.
+function isCliEntry(): boolean {
+  const entry = process.argv[1] ?? '';
+  return /(^|\/)ax-bridge(\.js)?$/.test(entry);
+}
+
+if (isCliEntry()) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const payload: ErrorJSON = {
+      error: `ax-bridge wrapper failed: ${message}`,
+      code: 'AX_WRAPPER_FAILED',
+    };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    process.exit(1);
+  });
+}

--- a/tests/ci/sim-hid-sentinel.test.ts
+++ b/tests/ci/sim-hid-sentinel.test.ts
@@ -75,7 +75,7 @@ async function runBridge(
     // SLOW_BRIDGE_TIMEOUT_MS so the execFile budget matches the jest
     // per-test budget.
     const { stdout, stderr } = await execFileAsync(cmd, cmdArgs, {
-      timeout: 30_000,
+      timeout: SLOW_BRIDGE_TIMEOUT_MS,
     });
     return { exitCode: 0, stdout, stderr };
   } catch (err) {


### PR DESCRIPTION
## Summary
- restore a webpack-safe `ax-bridge` entry guard that still lets Jest import helper exports without executing the CLI
- align the HID sentinel subprocess timeout with `SLOW_BRIDGE_TIMEOUT_MS` so slow macOS runners do not fail the JSON-output probe on timeout

## Root causes
1. `fix(ax-bridge): invoke main unconditionally so CLI help prints` fixed the bundled CLI help path, but it also executed `main()` during `ts-jest` imports of `cli/ax-bridge.ts`, breaking `tests/unit/ax-bridge-wrapper.test.ts` with `BRIDGE_NOT_FOUND`.
2. `tests/ci/sim-hid-sentinel.test.ts` raised the suite/test timeout to 45s but still hard-coded a 30s `execFile` timeout inside `runBridge()`. On slower macOS runners, the fake-UDID probe could time out with empty stdout, failing `bridge produces valid JSON output`.

## Verification
- `npm test -- --runInBand tests/unit/ax-bridge-wrapper.test.ts tests/unit/ax-bridge-help.test.ts`
- `npx jest tests/ci/sim-hid-sentinel.test.ts --runTestsByPath --testPathIgnorePatterns=/node_modules/ --runInBand`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test:ci`
- workflow-equivalent sentinel command with `--json --outputFile=sim-hid-sentinel-report.json`
