### PR TITLE
fix(ci): align v0.5.0 sentinel exec timeout with suite budget

### DIFF
--- a/tests/ci/sim-hid-sentinel.test.ts
+++ b/tests/ci/sim-hid-sentinel.test.ts
@@ -75,7 +75,7 @@ async function runBridge(
     // SLOW_BRIDGE_TIMEOUT_MS so the execFile budget matches the jest
     // per-test budget.
     const { stdout, stderr } = await execFileAsync(cmd, cmdArgs, {
-      timeout: 30_000,
+      timeout: SLOW_BRIDGE_TIMEOUT_MS,
     });
     return { exitCode: 0, stdout, stderr };
   } catch (err) {


### PR DESCRIPTION
## Summary
- align the sim-hid sentinel subprocess timeout with SLOW_BRIDGE_TIMEOUT_MS
- fix the empty-stdout failure seen on the v0.5.0 release workflow on slower macOS runners

## Verification
- npm ci
- npx jest tests/ci/sim-hid-sentinel.test.ts --runTestsByPath --testPathIgnorePatterns=/node_modules/ --runInBand

## Context
The failing release runs for commit 6d0664e1685fe533f0b142950a4f7e01d5259925 timed out the bridge at 30s even though the suite budget was already 45s.