### PR TITLE
fix(540): admit pointer-service to audit-log backendKind allow-list

### DIFF
--- a/src/ci/audit-log-posture.ts
+++ b/src/ci/audit-log-posture.ts
@@ -13,7 +13,7 @@
  *   2. `backendKinds` — the set of backend identifiers we can extract from
  *      the log, regardless of whether they live at the top level or inside
  *      a stringified `args_summary`. The allowed set is
- *      `{'flutter-vm','simhid','webkit'}`.
+ *      `{'ax-press','flutter-vm','pointer-service','simhid','webkit'}`.
  */
 
 import * as fs from 'node:fs';
@@ -29,10 +29,17 @@ import * as fs from 'node:fs';
  * frontmost application. `app-tap-element` stamps `headless: true` on every
  * ax-press result (src/tools/app-tap-element.ts), so the posture check
  * treats it as a first-class headless backend.
+ *
+ * `pointer-service` is the Phase-1 opt-in backend introduced in PR #615 for
+ * Xcode 26+ coordinate taps. It shells out to `sim-hid-bridge tap-ps`, which
+ * routes through `CoreSimulator.framework`'s PointerService IPC with no
+ * foreground dependency on Simulator.app — the PR's live harness (#629) and
+ * the sentinel symbol probe (#621) both attest to the headless posture.
  */
 export const ALLOWED_BACKEND_KINDS: readonly string[] = Object.freeze([
   'ax-press',
   'flutter-vm',
+  'pointer-service',
   'simhid',
   'webkit',
 ]);

--- a/tests/unit/audit-log-posture.test.ts
+++ b/tests/unit/audit-log-posture.test.ts
@@ -45,6 +45,7 @@ describe('src/ci/audit-log-posture', () => {
       '{"tool":"navigate","backendKind":"webkit"}',
       '{"tool":"flutter_tap","backendKind":"flutter-vm"}',
       '{"tool":"app_tap_element","backendKind":"ax-press"}',
+      '{"tool":"app_tap","backendKind":"pointer-service"}',
     ]);
     const report = scanAuditLog(file);
     expect(report.backendKinds).toEqual(
@@ -80,6 +81,16 @@ describe('src/ci/audit-log-posture', () => {
     ]);
     const report = scanAuditLog(file);
     expect(report.backendKinds).toEqual(['ax-press']);
+    expect(report.disallowedBackendKinds).toEqual([]);
+    expect(report.applescriptHits).toBe(0);
+  });
+
+  it('treats pointer-service as an allowed headless backend', () => {
+    const file = writeLog('pointer-service.log', [
+      '{"tool":"app_tap","backendKind":"pointer-service"}',
+    ]);
+    const report = scanAuditLog(file);
+    expect(report.backendKinds).toEqual(['pointer-service']);
     expect(report.disallowedBackendKinds).toEqual([]);
     expect(report.applescriptHits).toBe(0);
   });


### PR DESCRIPTION
## Summary

- Adds `pointer-service` to `ALLOWED_BACKEND_KINDS` in `src/ci/audit-log-posture.ts` alongside `ax-press`, `flutter-vm`, `simhid`, and `webkit`.
- Keeps `applescript` and `simctl` rejected — the allow-list stays narrow, just now correct for the Phase-1 opt-in backend that shipped in #615.
- Extends `tests/unit/audit-log-posture.test.ts` with a positive case for `pointer-service` and widens the top-level extraction fixture so the test that diffs against `ALLOWED_BACKEND_KINDS` reflects the new entry.

## Why

PR #615 introduced `PointerServiceInputBackend` with `kind = 'pointer-service' as const` as the Phase-1 opt-in Tier-1 backend for Xcode 26+ coordinate taps (gated behind `OPENSAFARI_ENABLE_POINTERSERVICE=1`). PR #612 admitted `ax-press` to the #540 posture allow-list but did not enumerate `pointer-service`, so any CI job that opts into the backend and then calls `assertAuditLogPosture` fails with:

```
disallowed backendKind(s) present: pointer-service (allowed: ax-press, flutter-vm, simhid, webkit)
```

This blocks the PointerService promotion path (#590 Phase 1 → Phase 2) in every pipeline that enforces the #540 acceptance criterion.

The backend itself is headless by design: it shells out to `sim-hid-bridge tap-ps`, which routes through `CoreSimulator.framework`'s PointerService IPC with no foreground dependency on Simulator.app. That posture is attested by the sentinel symbol probe (PR #621) and the live integration harness (PR #629), so treating `pointer-service` as a first-class headless backend matches the observed behaviour — the same fork PR #612 took for `ax-press`.

## Test plan

- [x] `npx jest tests/unit/audit-log-posture.test.ts --runInBand` — 12/12 passing (was 11/11; +1 positive case for `pointer-service`).
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint src/ci/audit-log-posture.ts tests/unit/audit-log-posture.test.ts` clean.

## Related

- Refs: #540
- Follows: #612 (ax-press allow-list admission), #615 (PointerService Phase 1), #590 (PointerService epic), #621 (sentinel symbol probe), #629 (live integration harness).