### PR TITLE
fix(webkit): resolve listTargets redirects per-entry (#648)

### DIFF
--- a/src/webkit/client.ts
+++ b/src/webkit/client.ts
@@ -163,25 +163,23 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
     // ios-webkit-debug-proxy device-list mode: the top-level /json returns
     // redirect entries of the form { url: "host:PORT" } with no
     // webSocketDebuggerUrl. Follow each redirect to get real page targets.
+    // A single /json response may mix redirect stubs with inline page targets,
+    // so resolve per-entry rather than all-or-nothing.
     const isDeviceRedirect = (t: WebKitTarget) =>
       !t.webSocketDebuggerUrl && typeof t.url === 'string' && /^\S+:\d+$/.test(t.url);
 
-    let targets: WebKitTarget[];
-    if (parsed.length > 0 && parsed.every(isDeviceRedirect)) {
-      const followed = await Promise.all(
-        parsed.map(async (t) => {
-          try {
-            const redirectJson = await this.httpGet(`http://${t.url}/json`);
-            return JSON.parse(redirectJson) as WebKitTarget[];
-          } catch {
-            return [] as WebKitTarget[];
-          }
-        }),
-      );
-      targets = followed.flat();
-    } else {
-      targets = parsed;
-    }
+    const expanded = await Promise.all(
+      parsed.map(async (t) => {
+        if (!isDeviceRedirect(t)) return [t];
+        try {
+          const redirectJson = await this.httpGet(`http://${t.url}/json`);
+          return JSON.parse(redirectJson) as WebKitTarget[];
+        } catch {
+          return [] as WebKitTarget[];
+        }
+      }),
+    );
+    const targets = expanded.flat();
 
     // ios-webkit-debug-proxy doesn't include an `id` field — derive from webSocketDebuggerUrl
     for (const t of targets) {

--- a/tests/unit/webkit-client-list-targets.test.ts
+++ b/tests/unit/webkit-client-list-targets.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for WebKitClient.listTargets redirect resolution (Issue #648).
+ *
+ * Covers:
+ * - All-inline input: no redirect HTTP call is issued.
+ * - All-redirect input: every stub is expanded.
+ * - Mixed input: redirect stubs are expanded, inline targets pass through.
+ * - Mixed input with one failing redirect: that entry contributes [], others resolve.
+ * - Empty input: returns [] with no redirect calls.
+ */
+
+import { WebKitClient } from '../../src/webkit/client';
+
+type ClientPrivate = {
+  httpGet: (url: string) => Promise<string>;
+  listTargets: () => Promise<Array<{ id?: string; url?: string; webSocketDebuggerUrl?: string }>>;
+};
+
+function asPrivate(client: WebKitClient): ClientPrivate {
+  return client as unknown as ClientPrivate;
+}
+
+describe('WebKitClient.listTargets redirect resolution', () => {
+  let client: WebKitClient;
+
+  beforeEach(() => {
+    client = new WebKitClient({ host: 'localhost', port: 9221 });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('passes through inline targets without issuing redirect requests', async () => {
+    const inline = [
+      {
+        id: 'page-1',
+        title: 'Inline A',
+        url: 'https://example.com/a',
+        webSocketDebuggerUrl: 'ws://localhost:9322/devtools/page/page-1',
+      },
+      {
+        id: 'page-2',
+        title: 'Inline B',
+        url: 'https://example.com/b',
+        webSocketDebuggerUrl: 'ws://localhost:9322/devtools/page/page-2',
+      },
+    ];
+
+    const spy = jest
+      .spyOn(asPrivate(client), 'httpGet')
+      .mockResolvedValueOnce(JSON.stringify(inline));
+
+    const targets = await client.listTargets();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('http://localhost:9221/json');
+    expect(targets).toHaveLength(2);
+    expect(targets.map((t) => t.id)).toEqual(['page-1', 'page-2']);
+    expect(targets.every((t) => typeof t.webSocketDebuggerUrl === 'string')).toBe(true);
+  });
+
+  it('expands every redirect stub when the top-level /json is all redirects', async () => {
+    const topLevel = [{ url: 'localhost:9322' }, { url: 'localhost:9323' }];
+    const firstDevice = [
+      {
+        id: 'page-a',
+        title: 'Device 1 page',
+        url: 'https://a.example',
+        webSocketDebuggerUrl: 'ws://localhost:9322/devtools/page/page-a',
+      },
+    ];
+    const secondDevice = [
+      {
+        id: 'page-b',
+        title: 'Device 2 page',
+        url: 'https://b.example',
+        webSocketDebuggerUrl: 'ws://localhost:9323/devtools/page/page-b',
+      },
+    ];
+
+    const spy = jest
+      .spyOn(asPrivate(client), 'httpGet')
+      .mockImplementation(async (url: string) => {
+        if (url === 'http://localhost:9221/json') return JSON.stringify(topLevel);
+        if (url === 'http://localhost:9322/json') return JSON.stringify(firstDevice);
+        if (url === 'http://localhost:9323/json') return JSON.stringify(secondDevice);
+        throw new Error(`unexpected url ${url}`);
+      });
+
+    const targets = await client.listTargets();
+
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(targets.map((t) => t.id)).toEqual(['page-a', 'page-b']);
+    expect(targets.every((t) => typeof t.webSocketDebuggerUrl === 'string')).toBe(true);
+  });
+
+  it('resolves mixed redirect + inline entries per-entry, not all-or-nothing', async () => {
+    const topLevel = [
+      { url: 'localhost:9322' },
+      {
+        id: 'page-inline',
+        title: 'Inline next to redirect',
+        url: 'https://example.com',
+        webSocketDebuggerUrl: 'ws://localhost:9322/devtools/page/page-inline',
+      },
+    ];
+    const redirected = [
+      {
+        id: 'page-device',
+        title: 'Inside redirect',
+        url: 'https://device.example',
+        webSocketDebuggerUrl: 'ws://localhost:9322/devtools/page/page-device',
+      },
+    ];
+
+    const spy = jest
+      .spyOn(asPrivate(client), 'httpGet')
+      .mockImplementation(async (url: string) => {
+        if (url === 'http://localhost:9221/json') return JSON.stringify(topLevel);
+        if (url === 'http://localhost:9322/json') return JSON.stringify(redirected);
+        throw new Error(`unexpected url ${url}`);
+      });
+
+    const targets = await client.listTargets();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(targets).toHaveLength(2);
+    expect(targets.map((t) => t.id).sort()).toEqual(['page-device', 'page-inline']);
+    // No redirect stub leaks to callers — every entry has a webSocketDebuggerUrl.
+    expect(targets.every((t) => typeof t.webSocketDebuggerUrl === 'string')).toBe(true);
+    expect(
+      targets.some((t) => t.webSocketDebuggerUrl === undefined && t.url === 'localhost:9322'),
+    ).toBe(false);
+  });
+
+  it('keeps other entries when one redirect fails to resolve', async () => {
+    const topLevel = [
+      { url: 'localhost:9322' }, // will fail
+      { url: 'localhost:9323' }, // will succeed
+      {
+        id: 'page-inline',
+        title: 'Inline survivor',
+        url: 'https://example.com',
+        webSocketDebuggerUrl: 'ws://localhost:9324/devtools/page/page-inline',
+      },
+    ];
+    const secondDevice = [
+      {
+        id: 'page-ok',
+        title: 'Resolved page',
+        url: 'https://ok.example',
+        webSocketDebuggerUrl: 'ws://localhost:9323/devtools/page/page-ok',
+      },
+    ];
+
+    jest
+      .spyOn(asPrivate(client), 'httpGet')
+      .mockImplementation(async (url: string) => {
+        if (url === 'http://localhost:9221/json') return JSON.stringify(topLevel);
+        if (url === 'http://localhost:9322/json') throw new Error('ECONNREFUSED');
+        if (url === 'http://localhost:9323/json') return JSON.stringify(secondDevice);
+        throw new Error(`unexpected url ${url}`);
+      });
+
+    const targets = await client.listTargets();
+
+    expect(targets.map((t) => t.id).sort()).toEqual(['page-inline', 'page-ok']);
+    expect(targets.every((t) => typeof t.webSocketDebuggerUrl === 'string')).toBe(true);
+  });
+
+  it('returns [] for empty top-level /json without further requests', async () => {
+    const spy = jest
+      .spyOn(asPrivate(client), 'httpGet')
+      .mockResolvedValueOnce('[]');
+
+    const targets = await client.listTargets();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(targets).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #648. Replaces the all-or-nothing `parsed.every(isDeviceRedirect)` branch in `WebKitClient.listTargets()` with per-entry resolution so a mixed `/json` response (redirect stubs + inline page targets) no longer leaks stubs with `undefined` `webSocketDebuggerUrl` to callers.
- Each entry is handled independently: redirect stubs are expanded via their inner `/json`, inline targets pass through, and a failure on one redirect only contributes `[]` — the rest of the array still resolves.
- Adds `tests/unit/webkit-client-list-targets.test.ts` with five cases (all-inline / all-redirect / mixed / mixed-with-failure / empty) that exercise the real code path by spying on private `httpGet`, not by stubbing `listTargets` at the interface level.

## Why

`app_webview_connect` and other callers consume `listTargets()` results directly. Under the old guard, a mixed `/json` shape from `ios-webkit-debug-proxy` caused the `else` branch to run and return redirect stubs untouched, producing an opaque WebSocket error with no diagnostic pointing back at the unresolved redirect. See #648 for full evidence, reproduction, and success criteria.

## Test plan

- [x] `npm test -- tests/unit/webkit-client-list-targets.test.ts` — 5/5 pass.
- [x] `npm test -- tests/unit/proxy-timing.test.ts tests/unit/multi-tab.test.ts tests/unit/app-webview-connect.test.ts tests/unit/set-active-context.test.ts` — pass, no regression.
- [x] `npm run build` — exits 0.
- [ ] Post-merge live smoke: `app_webview_connect` against a real `ios-webkit-debug-proxy` session to confirm no behavior change in the standard single-device path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)