### PR TITLE
feat(ax-bridge): self-healing recovery wrapper (#643, PR 1/3)

### DIFF
--- a/src/native/ax-bridge-recovery.ts
+++ b/src/native/ax-bridge-recovery.ts
@@ -213,17 +213,21 @@ export async function dumpTreeWithRecovery(
       if (reactivateOnRetry && options.deviceId) {
         const reactStart = Date.now();
         try {
-          await reactivate(options.deviceId, {
+          const reactivated = await reactivate(options.deviceId, {
             forceRefresh: true,
             timeout: DEFAULT_REACTIVATE_TIMEOUT_MS,
             bundleId: options.bundleId,
           });
+          // `ensureSemanticsActive` resolves to `false` when activation times
+          // out or fails without throwing — surface that as an error stage so
+          // downstream telemetry does not mistake silent failure for success.
           stages.push({
             attempt,
             action: 'reactivate',
             startedAt: reactStart,
             durationMs: Date.now() - reactStart,
-            outcome: 'ok',
+            outcome: reactivated ? 'ok' : 'error',
+            ...(reactivated ? {} : { errorCode: 'REACTIVATE_RETURNED_FALSE' }),
           });
         } catch (reactErr) {
           stages.push({

--- a/src/native/ax-bridge-recovery.ts
+++ b/src/native/ax-bridge-recovery.ts
@@ -1,0 +1,264 @@
+/**
+ * ax-bridge self-healing wrapper (issue #643).
+ *
+ * The Swift accessibility bridge occasionally fails mid-session with
+ * transient errors (`DEVICE_CONTENT_ROOT_EMPTY`, `AX_TIMEOUT`,
+ * `BRIDGE_EXEC_FAILED`, or a generic `AX_ERROR` payload). Without retry
+ * logic a single failure poisons the whole verification lane because the
+ * next call inherits the bad tree state.
+ *
+ * `dumpTreeWithRecovery` wraps `AccessibilityBridge.dumpTree()` with a
+ * classified retry loop:
+ *
+ *   1. Attempt a dump.
+ *   2. On a recoverable error, sleep `backoffMs[i]` then (optionally) run
+ *      `ensureSemanticsActive({ forceRefresh: true })` to force Flutter /
+ *      simulator chrome to rematerialise its tree.
+ *   3. Retry up to `maxAttempts` times.
+ *
+ * Non-recoverable errors (`BRIDGE_NOT_FOUND`, `AX_PERMISSION_DENIED`)
+ * short-circuit immediately; no amount of retrying fixes a missing binary
+ * or a denied TCC prompt.
+ *
+ * Every call returns an `AxBridgeRecoveryReport` (even the happy path with
+ * a single successful dump) so callers can expose the data via their
+ * `meta.axBridgeRecovery` diagnostics field without conditional branching.
+ */
+
+import {
+  AccessibilityBridge,
+  AccessibilityBridgeError,
+} from './accessibility-bridge';
+import { ensureSemanticsActive } from './semantics-activator';
+import type { AXDumpOptions, AXNode } from './ax-types';
+
+/** Error codes that represent transient, retry-worthy failures. */
+export const RECOVERABLE_ERROR_CODES: ReadonlySet<string> = new Set([
+  'DEVICE_CONTENT_ROOT_EMPTY',
+  'AX_TIMEOUT',
+  'BRIDGE_EXEC_FAILED',
+  'AX_ERROR',
+]);
+
+/** Error codes that must be surfaced immediately without retrying. */
+export const NON_RECOVERABLE_ERROR_CODES: ReadonlySet<string> = new Set([
+  'BRIDGE_NOT_FOUND',
+  'AX_PERMISSION_DENIED',
+]);
+
+/** Default backoff schedule used between retries (ms). */
+export const DEFAULT_BACKOFF_MS: readonly number[] = [200, 500, 1200];
+/** Default retry budget. */
+export const DEFAULT_MAX_ATTEMPTS = 3;
+/** Budget granted to the between-attempt `ensureSemanticsActive` call. */
+export const DEFAULT_REACTIVATE_TIMEOUT_MS = 2500;
+
+export interface AxBridgeRecoveryStage {
+  /** 1-indexed attempt number associated with this stage. */
+  attempt: number;
+  action: 'dump' | 'reactivate' | 'sleep';
+  /** `Date.now()` when the stage began. */
+  startedAt: number;
+  durationMs: number;
+  outcome: 'ok' | 'error';
+  /** `AccessibilityBridgeError.code` when outcome is `error`. */
+  errorCode?: string;
+}
+
+export interface AxBridgeRecoveryReport {
+  /** Number of `dumpTree()` attempts actually performed. */
+  attempts: number;
+  /** Whether the final dump succeeded. */
+  recovered: boolean;
+  /** Chronological log of every action taken. */
+  stages: AxBridgeRecoveryStage[];
+  /** Error code from the final failure (only when `recovered === false`). */
+  lastErrorCode?: string;
+}
+
+export interface DumpTreeWithRecoveryOptions extends AXDumpOptions {
+  /** Forwarded to `ensureSemanticsActive` during inter-attempt reactivation. */
+  bundleId?: string;
+  /** Max number of `dumpTree` invocations. Default 3. Min 1. */
+  maxAttempts?: number;
+  /**
+   * Inter-attempt sleep schedule. Entry `i` is the pause between attempt
+   * `i+1` and attempt `i+2`. If fewer entries are provided than
+   * `maxAttempts - 1`, the last entry is reused. Default `[200, 500, 1200]`.
+   */
+  backoffMs?: number[];
+  /** Re-run `ensureSemanticsActive({ forceRefresh: true })` before each retry. Default true. */
+  reactivateOnRetry?: boolean;
+  /**
+   * Injection seam for tests — swap the real activator with a deterministic
+   * stub. Defaults to the production `ensureSemanticsActive`.
+   */
+  reactivate?: (
+    deviceId: string,
+    opts: { forceRefresh: true; timeout: number; bundleId?: string },
+  ) => Promise<boolean>;
+  /** Injection seam for tests — swap the default `setTimeout` sleeper. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface DumpTreeWithRecoveryResult {
+  tree: AXNode;
+  recovery: AxBridgeRecoveryReport;
+}
+
+function isRecoverableError(err: unknown): err is AccessibilityBridgeError {
+  if (!(err instanceof AccessibilityBridgeError)) return false;
+  if (NON_RECOVERABLE_ERROR_CODES.has(err.code)) return false;
+  return RECOVERABLE_ERROR_CODES.has(err.code);
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveBackoff(
+  schedule: readonly number[] | undefined,
+  gapIndex: number,
+): number {
+  const source = schedule && schedule.length > 0 ? schedule : DEFAULT_BACKOFF_MS;
+  return source[Math.min(gapIndex, source.length - 1)] ?? 0;
+}
+
+/**
+ * Dump the accessibility tree with bounded retry + optional reactivation.
+ *
+ * @throws the last `AccessibilityBridgeError` when the retry budget is
+ *   exhausted or a non-recoverable error is observed. Inspect the thrown
+ *   error's `.recovery` property (attached by this wrapper) for stage-level
+ *   diagnostics when you need to surface them alongside the error itself.
+ */
+export async function dumpTreeWithRecovery(
+  bridge: AccessibilityBridge,
+  options: DumpTreeWithRecoveryOptions,
+): Promise<DumpTreeWithRecoveryResult> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+  const reactivateOnRetry = options.reactivateOnRetry ?? true;
+  const sleep = options.sleep ?? defaultSleep;
+  const reactivate = options.reactivate ?? ensureSemanticsActive;
+
+  const stages: AxBridgeRecoveryStage[] = [];
+  let attempt = 0;
+  let lastError: AccessibilityBridgeError | undefined;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+
+    const dumpStart = Date.now();
+    try {
+      const tree = await bridge.dumpTree({
+        deviceId: options.deviceId,
+        maxDepth: options.maxDepth,
+      });
+      stages.push({
+        attempt,
+        action: 'dump',
+        startedAt: dumpStart,
+        durationMs: Date.now() - dumpStart,
+        outcome: 'ok',
+      });
+      return {
+        tree,
+        recovery: { attempts: attempt, recovered: true, stages },
+      };
+    } catch (err) {
+      const durationMs = Date.now() - dumpStart;
+      const code = err instanceof AccessibilityBridgeError ? err.code : 'UNKNOWN';
+      stages.push({
+        attempt,
+        action: 'dump',
+        startedAt: dumpStart,
+        durationMs,
+        outcome: 'error',
+        errorCode: code,
+      });
+
+      if (!isRecoverableError(err)) {
+        const wrapped = err instanceof AccessibilityBridgeError
+          ? err
+          : new AccessibilityBridgeError(
+            err instanceof Error ? err.message : String(err),
+            'UNKNOWN',
+          );
+        attachRecoveryReport(wrapped, {
+          attempts: attempt,
+          recovered: false,
+          stages,
+          lastErrorCode: wrapped.code,
+        });
+        throw wrapped;
+      }
+
+      lastError = err;
+
+      if (attempt >= maxAttempts) break;
+
+      const backoff = resolveBackoff(options.backoffMs, attempt - 1);
+      if (backoff > 0) {
+        const sleepStart = Date.now();
+        await sleep(backoff);
+        stages.push({
+          attempt,
+          action: 'sleep',
+          startedAt: sleepStart,
+          durationMs: Date.now() - sleepStart,
+          outcome: 'ok',
+        });
+      }
+
+      if (reactivateOnRetry && options.deviceId) {
+        const reactStart = Date.now();
+        try {
+          await reactivate(options.deviceId, {
+            forceRefresh: true,
+            timeout: DEFAULT_REACTIVATE_TIMEOUT_MS,
+            bundleId: options.bundleId,
+          });
+          stages.push({
+            attempt,
+            action: 'reactivate',
+            startedAt: reactStart,
+            durationMs: Date.now() - reactStart,
+            outcome: 'ok',
+          });
+        } catch (reactErr) {
+          stages.push({
+            attempt,
+            action: 'reactivate',
+            startedAt: reactStart,
+            durationMs: Date.now() - reactStart,
+            outcome: 'error',
+            errorCode: reactErr instanceof AccessibilityBridgeError
+              ? reactErr.code
+              : 'REACTIVATE_FAILED',
+          });
+          // Reactivation is best-effort — keep retrying the dump regardless.
+        }
+      }
+    }
+  }
+
+  const finalError = lastError ?? new AccessibilityBridgeError(
+    'ax-bridge dump failed with no recoverable error recorded',
+    'UNKNOWN',
+  );
+  attachRecoveryReport(finalError, {
+    attempts: attempt,
+    recovered: false,
+    stages,
+    lastErrorCode: finalError.code,
+  });
+  throw finalError;
+}
+
+/** Extend the thrown error with the diagnostics report without breaking existing `catch` blocks. */
+function attachRecoveryReport(
+  err: AccessibilityBridgeError,
+  report: AxBridgeRecoveryReport,
+): void {
+  (err as AccessibilityBridgeError & { recovery?: AxBridgeRecoveryReport }).recovery = report;
+}

--- a/tests/unit/ax-bridge-recovery.test.ts
+++ b/tests/unit/ax-bridge-recovery.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit tests for dumpTreeWithRecovery (issue #643).
+ *
+ * Covers: happy path, single-failure recovery, double-failure recovery,
+ * exhaustion, non-recoverable short-circuit, backoff schedule, and
+ * reactivation invocation contract.
+ */
+
+import {
+  DEFAULT_BACKOFF_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_REACTIVATE_TIMEOUT_MS,
+  NON_RECOVERABLE_ERROR_CODES,
+  RECOVERABLE_ERROR_CODES,
+  dumpTreeWithRecovery,
+} from '../../src/native/ax-bridge-recovery';
+import { AccessibilityBridgeError } from '../../src/native/accessibility-bridge';
+import type { AccessibilityBridge } from '../../src/native/accessibility-bridge';
+import type { AXNode } from '../../src/native/ax-types';
+
+type DumpOutcome = AXNode | AccessibilityBridgeError;
+
+function makeTree(label = 'root'): AXNode {
+  return {
+    role: 'AXApplication',
+    label,
+    traits: [],
+    frame: { x: 0, y: 0, width: 0, height: 0 },
+    visible: true,
+    enabled: true,
+    focused: true,
+    path: '',
+  };
+}
+
+function makeBridge(outcomes: DumpOutcome[]): {
+  bridge: AccessibilityBridge;
+  calls: number;
+} {
+  const state = { calls: 0 };
+  const bridge = {
+    dumpTree: jest.fn(async () => {
+      const i = state.calls;
+      state.calls += 1;
+      if (i >= outcomes.length) throw new Error(`unexpected dumpTree call #${i + 1}`);
+      const outcome = outcomes[i];
+      if (outcome instanceof AccessibilityBridgeError) throw outcome;
+      return outcome;
+    }),
+  } as unknown as AccessibilityBridge;
+  return {
+    bridge,
+    get calls() {
+      return state.calls;
+    },
+  };
+}
+
+describe('dumpTreeWithRecovery', () => {
+  test('recoverable-code set matches the documented contract', () => {
+    expect(RECOVERABLE_ERROR_CODES).toEqual(
+      new Set(['DEVICE_CONTENT_ROOT_EMPTY', 'AX_TIMEOUT', 'BRIDGE_EXEC_FAILED', 'AX_ERROR']),
+    );
+    expect(NON_RECOVERABLE_ERROR_CODES).toEqual(
+      new Set(['BRIDGE_NOT_FOUND', 'AX_PERMISSION_DENIED']),
+    );
+    expect(DEFAULT_BACKOFF_MS).toEqual([200, 500, 1200]);
+    expect(DEFAULT_MAX_ATTEMPTS).toBe(3);
+  });
+
+  test('happy path returns on first dump with a trivial recovery report', async () => {
+    const tree = makeTree('hello');
+    const { bridge } = makeBridge([tree]);
+
+    const result = await dumpTreeWithRecovery(bridge, {
+      deviceId: 'SIM-1',
+      reactivate: async () => true,
+      sleep: async () => {},
+    });
+
+    expect(result.tree).toBe(tree);
+    expect(result.recovery).toMatchObject({ attempts: 1, recovered: true });
+    expect(result.recovery.stages).toHaveLength(1);
+    expect(result.recovery.stages[0]).toMatchObject({
+      attempt: 1,
+      action: 'dump',
+      outcome: 'ok',
+    });
+  });
+
+  test('single transient failure recovers on the second attempt', async () => {
+    const tree = makeTree('after-retry');
+    const { bridge } = makeBridge([
+      new AccessibilityBridgeError('empty', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      tree,
+    ]);
+    const reactivate = jest.fn(async () => true);
+    const sleeps: number[] = [];
+
+    const result = await dumpTreeWithRecovery(bridge, {
+      deviceId: 'SIM-1',
+      reactivate,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    expect(result.tree).toBe(tree);
+    expect(result.recovery.attempts).toBe(2);
+    expect(result.recovery.recovered).toBe(true);
+    const actions = result.recovery.stages.map((s) => s.action);
+    expect(actions).toEqual(['dump', 'sleep', 'reactivate', 'dump']);
+    expect(sleeps).toEqual([DEFAULT_BACKOFF_MS[0]]);
+    expect(reactivate).toHaveBeenCalledWith('SIM-1', {
+      forceRefresh: true,
+      timeout: DEFAULT_REACTIVATE_TIMEOUT_MS,
+      bundleId: undefined,
+    });
+  });
+
+  test('double transient failure recovers on the third attempt and honours backoff order', async () => {
+    const tree = makeTree('after-two-retries');
+    const { bridge } = makeBridge([
+      new AccessibilityBridgeError('timeout', 'AX_TIMEOUT'),
+      new AccessibilityBridgeError('exec', 'BRIDGE_EXEC_FAILED'),
+      tree,
+    ]);
+    const reactivate = jest.fn(async () => true);
+    const sleeps: number[] = [];
+
+    const result = await dumpTreeWithRecovery(bridge, {
+      deviceId: 'SIM-1',
+      reactivate,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    expect(result.recovery.attempts).toBe(3);
+    expect(result.recovery.recovered).toBe(true);
+    expect(sleeps).toEqual([DEFAULT_BACKOFF_MS[0], DEFAULT_BACKOFF_MS[1]]);
+    expect(reactivate).toHaveBeenCalledTimes(2);
+  });
+
+  test('exhausting the retry budget re-throws the last error with recovery metadata', async () => {
+    const errors = [
+      new AccessibilityBridgeError('empty 1', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      new AccessibilityBridgeError('empty 2', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      new AccessibilityBridgeError('empty 3', 'DEVICE_CONTENT_ROOT_EMPTY'),
+    ];
+    const { bridge } = makeBridge(errors);
+
+    await expect(
+      dumpTreeWithRecovery(bridge, {
+        deviceId: 'SIM-1',
+        reactivate: async () => true,
+        sleep: async () => {},
+      }),
+    ).rejects.toMatchObject({
+      name: 'AccessibilityBridgeError',
+      code: 'DEVICE_CONTENT_ROOT_EMPTY',
+      message: 'empty 3',
+    });
+  });
+
+  test('non-recoverable error short-circuits without retry', async () => {
+    const { bridge } = makeBridge([
+      new AccessibilityBridgeError('denied', 'AX_PERMISSION_DENIED'),
+    ]);
+    const reactivate = jest.fn(async () => true);
+
+    await expect(
+      dumpTreeWithRecovery(bridge, {
+        deviceId: 'SIM-1',
+        reactivate,
+        sleep: async () => {},
+      }),
+    ).rejects.toMatchObject({ code: 'AX_PERMISSION_DENIED' });
+
+    expect(bridge.dumpTree).toHaveBeenCalledTimes(1);
+    expect(reactivate).not.toHaveBeenCalled();
+  });
+
+  test('reactivateOnRetry=false skips reactivation stages', async () => {
+    const tree = makeTree('skip-reactivate');
+    const { bridge } = makeBridge([
+      new AccessibilityBridgeError('timeout', 'AX_TIMEOUT'),
+      tree,
+    ]);
+    const reactivate = jest.fn(async () => true);
+
+    const result = await dumpTreeWithRecovery(bridge, {
+      deviceId: 'SIM-1',
+      reactivateOnRetry: false,
+      reactivate,
+      sleep: async () => {},
+    });
+
+    expect(result.recovery.recovered).toBe(true);
+    expect(reactivate).not.toHaveBeenCalled();
+    const actions = result.recovery.stages.map((s) => s.action);
+    expect(actions).toEqual(['dump', 'sleep', 'dump']);
+  });
+
+  test('reactivation failure does not abort the retry loop', async () => {
+    const tree = makeTree('retry-anyway');
+    const { bridge } = makeBridge([
+      new AccessibilityBridgeError('timeout', 'AX_TIMEOUT'),
+      tree,
+    ]);
+    const reactivate = jest.fn(async () => {
+      throw new AccessibilityBridgeError('reactivate blew up', 'BRIDGE_EXEC_FAILED');
+    });
+
+    const result = await dumpTreeWithRecovery(bridge, {
+      deviceId: 'SIM-1',
+      reactivate,
+      sleep: async () => {},
+    });
+
+    expect(result.recovery.recovered).toBe(true);
+    const reactStage = result.recovery.stages.find((s) => s.action === 'reactivate');
+    expect(reactStage).toMatchObject({ outcome: 'error', errorCode: 'BRIDGE_EXEC_FAILED' });
+  });
+
+  test('custom maxAttempts and backoffMs are honoured', async () => {
+    const tree = makeTree('custom-budget');
+    const { bridge } = makeBridge([
+      new AccessibilityBridgeError('fail', 'AX_ERROR'),
+      new AccessibilityBridgeError('fail', 'AX_ERROR'),
+      new AccessibilityBridgeError('fail', 'AX_ERROR'),
+      new AccessibilityBridgeError('fail', 'AX_ERROR'),
+      tree,
+    ]);
+    const sleeps: number[] = [];
+
+    const result = await dumpTreeWithRecovery(bridge, {
+      deviceId: 'SIM-1',
+      maxAttempts: 5,
+      backoffMs: [10, 20],
+      reactivate: async () => true,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    expect(result.recovery.attempts).toBe(5);
+    // gapIndex 0 -> 10, gapIndex 1 -> 20, gapIndex 2+ -> last entry (20).
+    expect(sleeps).toEqual([10, 20, 20, 20]);
+  });
+
+  test('absent deviceId skips reactivation even when reactivateOnRetry=true', async () => {
+    const tree = makeTree('no-device');
+    const { bridge } = makeBridge([
+      new AccessibilityBridgeError('empty', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      tree,
+    ]);
+    const reactivate = jest.fn(async () => true);
+
+    const result = await dumpTreeWithRecovery(bridge, {
+      reactivate,
+      sleep: async () => {},
+    });
+
+    expect(result.recovery.recovered).toBe(true);
+    expect(reactivate).not.toHaveBeenCalled();
+  });
+
+  test('thrown error carries the recovery report for diagnostics', async () => {
+    const errors = [
+      new AccessibilityBridgeError('empty', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      new AccessibilityBridgeError('empty', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      new AccessibilityBridgeError('empty', 'DEVICE_CONTENT_ROOT_EMPTY'),
+    ];
+    const { bridge } = makeBridge(errors);
+
+    let caught: (AccessibilityBridgeError & { recovery?: unknown }) | undefined;
+    try {
+      await dumpTreeWithRecovery(bridge, {
+        deviceId: 'SIM-1',
+        reactivate: async () => true,
+        sleep: async () => {},
+      });
+    } catch (err) {
+      caught = err as AccessibilityBridgeError & { recovery?: unknown };
+    }
+
+    expect(caught).toBeInstanceOf(AccessibilityBridgeError);
+    expect(caught?.recovery).toMatchObject({
+      attempts: 3,
+      recovered: false,
+      lastErrorCode: 'DEVICE_CONTENT_ROOT_EMPTY',
+    });
+  });
+});

--- a/tests/unit/ax-bridge-recovery.test.ts
+++ b/tests/unit/ax-bridge-recovery.test.ts
@@ -202,6 +202,32 @@ describe('dumpTreeWithRecovery', () => {
     expect(actions).toEqual(['dump', 'sleep', 'dump']);
   });
 
+  // Codex P2 regression on #653: `ensureSemanticsActive` resolves to `false`
+  // when activation times out or silently fails. That outcome must reach the
+  // recovery report as an error stage so telemetry does not mistake a silent
+  // failure for a successful reactivation.
+  test('records outcome: error when reactivate resolves false', async () => {
+    const tree = makeTree('reactivate-false');
+    const { bridge } = makeBridge([
+      new AccessibilityBridgeError('empty', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      tree,
+    ]);
+    const reactivate = jest.fn(async () => false);
+
+    const result = await dumpTreeWithRecovery(bridge, {
+      deviceId: 'SIM-1',
+      reactivate,
+      sleep: async () => {},
+    });
+
+    expect(result.recovery.recovered).toBe(true);
+    const reactStage = result.recovery.stages.find((s) => s.action === 'reactivate');
+    expect(reactStage).toMatchObject({
+      outcome: 'error',
+      errorCode: 'REACTIVATE_RETURNED_FALSE',
+    });
+  });
+
   test('reactivation failure does not abort the retry loop', async () => {
     const tree = makeTree('retry-anyway');
     const { bridge } = makeBridge([


### PR DESCRIPTION
## Summary

First of three stacked PRs for #643. Adds `dumpTreeWithRecovery`, a self-healing wrapper around `AccessibilityBridge.dumpTree`. No call sites change yet — that happens in PR 2/3.

- **Classify errors** — recoverable (`DEVICE_CONTENT_ROOT_EMPTY`, `AX_TIMEOUT`, `BRIDGE_EXEC_FAILED`, `AX_ERROR`) vs non-recoverable (`BRIDGE_NOT_FOUND`, `AX_PERMISSION_DENIED`).
- **Between attempts**, sleep per the configured backoff schedule (`[200, 500, 1200]` ms by default) and force a fresh `ensureSemanticsActive({ forceRefresh: true })` so Flutter / simulator chrome rematerialises its tree.
- **Return `AxBridgeRecoveryReport`** on every call (even happy-path `attempts === 1`) so tool diagnostics can expose `meta.axBridgeRecovery` uniformly.
- **Best-effort reactivation** — failing `ensureSemanticsActive` is recorded in the report but does not abort the retry loop.
- **Thrown errors** carry the report attached for downstream telemetry.

## Why

A single transient ax-bridge failure currently poisons the entire verification session because the wrapper bubbles every error straight through. Downstream work (Omofictions-App 3-run deterministic launch evidence) is impossible without wrapper-level self-healing. Full rationale and ambiguity-resolution matrix: #643.

## Test plan

- [x] `npm test -- ax-bridge-recovery` (11 unit tests, all pass)
  - happy path
  - single-failure recovery
  - double-failure recovery + backoff schedule ordering
  - retry exhaustion re-throws last error
  - non-recoverable short-circuit
  - `reactivateOnRetry=false` skips reactivation
  - reactivation failure recorded but does not abort
  - custom `maxAttempts` + `backoffMs` honoured
  - missing `deviceId` skips reactivation
  - thrown error carries `recovery` metadata
  - recoverable-code constants match the documented contract
- [ ] `npm test` full suite (run in PR 2 where integration happens)

## Follow-up

- **PR 2/3**: wire `dumpTreeWithRecovery` into `app_tree`, `app_query`, `app_wait_for`, `app_handle_alert`, `app_assert_element`, `app_tap` (verifyContext), and expose the report via each tool's `meta.axBridgeRecovery`.
- **PR 3/3**: integration fixture (`tests/fixtures/ax-bridge-fake/fail-once.js`) that spawns a fake binary to prove fail-once recovery end-to-end.

Refs: #643