### PR TITLE
feat(app-notes-paste-and-tap-url): reviewer-equivalent UL tap via Notes (#641 T1)

### DIFF
--- a/src/tools/app-notes-paste-and-tap-url.ts
+++ b/src/tools/app-notes-paste-and-tap-url.ts
@@ -211,17 +211,30 @@ async function waitForDetectedLink(
         { role: 'AXLink' },
         { deviceId, maxResults: 20 },
       );
+      // Two-pass scan: prefer an exact URL-literal match over a host-only match.
+      // A user note may contain several links to the same host (for example
+      // `https://example.com` above the requested `https://example.com/detail/abc`);
+      // tapping the first host-containing label would route to the wrong path
+      // and still report success, which breaks deterministic deep-link
+      // verification.
       for (const match of res.matches) {
         const label = (match.label ?? '').toLowerCase();
-        if (label.includes(lowerUrl) || (host && label.includes(host))) {
+        if (label.includes(lowerUrl)) {
           return { path: match.path, label: match.label ?? url };
         }
       }
-      // Fallback: if exactly one AXLink is present, assume it's the one we pasted.
-      if (res.matches.length === 1) {
-        const sole = res.matches[0];
-        return { path: sole.path, label: sole.label ?? url };
+      if (host) {
+        for (const match of res.matches) {
+          const label = (match.label ?? '').toLowerCase();
+          if (label.includes(host)) {
+            return { path: match.path, label: match.label ?? url };
+          }
+        }
       }
+      // No single-link fallback: Notes is launched into prior state, so an
+      // unrelated pre-existing AXLink could satisfy a blanket `matches.length
+      // === 1` heuristic and yield a false-positive tap. Callers that need a
+      // looser match should widen the input URL (or host) themselves.
     } catch {
       /* tree may be mid-transition — retry */
     }

--- a/src/tools/app-notes-paste-and-tap-url.ts
+++ b/src/tools/app-notes-paste-and-tap-url.ts
@@ -1,0 +1,250 @@
+/**
+ * app_notes_paste_and_tap_url — reviewer-equivalent Universal Link tap through Notes.app.
+ *
+ * The iOS Simulator only exposes `xcrun simctl openurl` as a URL-opening
+ * channel, which Apple documentation does not treat as equivalent to a real
+ * Universal Link tap. This helper reproduces the "paste a URL into Notes and
+ * tap the auto-detected link" flow, which *is* a channel Apple reviewers
+ * actually use:
+ *
+ *   1. Launch Notes (`com.apple.mobilenotes`).
+ *   2. Focus the note body by pressing the first text-editor element.
+ *   3. Paste the URL via the pasteboard-input backend.
+ *   4. Poll the accessibility tree until iOS's Data Detector produces an
+ *      `AXLink` referencing the URL (or its host).
+ *   5. Press that link. If the app under test is installed and has a valid
+ *      `applinks:` association, the Universal Link handler opens it.
+ *
+ * All steps reuse infrastructure already in-tree (pasteboard-input,
+ * AccessibilityBridge, SimulatorManager, SimctlExecutor) so the surface area
+ * added here is glue + timing.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { SimulatorManager } from '../simulator';
+import { getAccessibilityBridge } from '../native';
+import type { AXQueryResult } from '../native/ax-types';
+import { typeViaPasteboard } from './pasteboard-input';
+import { resolveDeviceId } from './native-app-utils';
+
+const NOTES_BUNDLE_ID = 'com.apple.mobilenotes';
+const DEFAULT_FOCUS_TIMEOUT_MS = 4000;
+const DEFAULT_LINK_TAP_TIMEOUT_MS = 4000;
+const DEFAULT_SETTLE_MS = 500;
+const FOCUS_POLL_MS = 200;
+const LINK_POLL_MS = 200;
+
+/** Editor roles tried in order when focusing the note body. */
+const EDITOR_ROLES = ['AXTextArea', 'AXTextView', 'AXTextField'] as const;
+
+interface FocusedElement {
+  path: string;
+  role: string;
+  label: string | null;
+}
+
+interface DetectedLink {
+  path: string;
+  label: string;
+}
+
+export interface AppNotesPasteAndTapUrlResult {
+  url: string;
+  deviceId: string;
+  notesLaunchedAt: string;
+  linkTappedAt: string;
+  linkElement: DetectedLink;
+  durationMs: number;
+}
+
+export function registerAppNotesPasteAndTapUrlTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_notes_paste_and_tap_url',
+      description:
+        'Reviewer-equivalent Universal Link tap via Notes.app: launches Notes, paste-injects the URL, waits for iOS Data Detector to produce an AXLink, and taps it. Use this instead of app_open_url when Apple-review parity matters (see docs/recipes/universal-link-channels.md).',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          url: {
+            type: 'string',
+            description: 'Universal Link or HTTPS URL to paste (e.g. https://example.com/detail/abc).',
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Simulator UDID (uses active device if omitted).',
+          },
+          settleMs: {
+            type: 'number',
+            description: 'Ms to wait after paste before scanning for the detected link. Default: 500.',
+          },
+          focusTimeoutMs: {
+            type: 'number',
+            description: 'Max ms to wait for the Notes editor to be AX-queryable. Default: 4000.',
+          },
+          linkTapTimeoutMs: {
+            type: 'number',
+            description: 'Max ms to wait for iOS Data Detector to expose an AXLink. Default: 4000.',
+          },
+          restorePasteboard: {
+            type: 'boolean',
+            description: 'Restore the simulator pasteboard after paste. Default: true.',
+          },
+        },
+        required: ['url'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const startedAt = Date.now();
+        const url = params.url as string | undefined;
+        if (!url || typeof url !== 'string') {
+          throw new Error('url parameter is required');
+        }
+        if (!url.includes('://')) {
+          throw new Error(
+            'invalid URL — must include a scheme (e.g. https:// or myapp://)',
+          );
+        }
+
+        const deviceId = resolveDeviceId(params);
+        const settleMs = numberParam(params.settleMs, DEFAULT_SETTLE_MS);
+        const focusTimeoutMs = numberParam(params.focusTimeoutMs, DEFAULT_FOCUS_TIMEOUT_MS);
+        const linkTapTimeoutMs = numberParam(params.linkTapTimeoutMs, DEFAULT_LINK_TAP_TIMEOUT_MS);
+        const restorePasteboard = params.restorePasteboard !== false;
+
+        const manager = new SimulatorManager();
+        await manager.launchApp(deviceId, NOTES_BUNDLE_ID);
+        const notesLaunchedAt = new Date().toISOString();
+
+        const editor = await waitForEditor(deviceId, focusTimeoutMs);
+        if (!editor) {
+          throw new Error(
+            `Notes editor did not appear within ${focusTimeoutMs}ms ` +
+              `(tried roles: ${EDITOR_ROLES.join(', ')}).`,
+          );
+        }
+
+        // Focus the editor so the pasteboard paste lands there.
+        const bridge = getAccessibilityBridge();
+        await bridge.press(editor.path, deviceId).catch(() => undefined);
+
+        await typeViaPasteboard(deviceId, url, {
+          restorePasteboard,
+        });
+
+        await sleep(settleMs);
+
+        const link = await waitForDetectedLink(deviceId, url, linkTapTimeoutMs);
+        if (!link) {
+          throw new Error(
+            `Data Detector did not produce a link for "${url}" within ${linkTapTimeoutMs}ms.`,
+          );
+        }
+
+        const pressResult = await bridge.press(link.path, deviceId);
+        if (!pressResult.ok) {
+          throw new Error(
+            `Failed to press detected link (${pressResult.code}): ${pressResult.message ?? 'unknown'}`,
+          );
+        }
+
+        const result: AppNotesPasteAndTapUrlResult = {
+          url,
+          deviceId,
+          notesLaunchedAt,
+          linkTappedAt: new Date().toISOString(),
+          linkElement: { path: link.path, label: link.label },
+          durationMs: Date.now() - startedAt,
+        };
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[app_notes_paste_and_tap_url] ${message}`);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+async function waitForEditor(
+  deviceId: string,
+  timeoutMs: number,
+): Promise<FocusedElement | null> {
+  const deadline = Date.now() + timeoutMs;
+  const bridge = getAccessibilityBridge();
+  while (Date.now() < deadline) {
+    for (const role of EDITOR_ROLES) {
+      try {
+        const res: AXQueryResult = await bridge.query({ role }, { deviceId });
+        const match = res.matches[0];
+        if (match) {
+          return { path: match.path, role, label: match.label ?? null };
+        }
+      } catch {
+        /* tree may be mid-transition — retry */
+      }
+    }
+    await sleep(FOCUS_POLL_MS);
+  }
+  return null;
+}
+
+async function waitForDetectedLink(
+  deviceId: string,
+  url: string,
+  timeoutMs: number,
+): Promise<DetectedLink | null> {
+  const deadline = Date.now() + timeoutMs;
+  const bridge = getAccessibilityBridge();
+  const lowerUrl = url.toLowerCase();
+  const host = safeExtractHost(url);
+  while (Date.now() < deadline) {
+    try {
+      const res: AXQueryResult = await bridge.query(
+        { role: 'AXLink' },
+        { deviceId, maxResults: 20 },
+      );
+      for (const match of res.matches) {
+        const label = (match.label ?? '').toLowerCase();
+        if (label.includes(lowerUrl) || (host && label.includes(host))) {
+          return { path: match.path, label: match.label ?? url };
+        }
+      }
+      // Fallback: if exactly one AXLink is present, assume it's the one we pasted.
+      if (res.matches.length === 1) {
+        const sole = res.matches[0];
+        return { path: sole.path, label: sole.label ?? url };
+      }
+    } catch {
+      /* tree may be mid-transition — retry */
+    }
+    await sleep(LINK_POLL_MS);
+  }
+  return null;
+}
+
+function safeExtractHost(url: string): string | null {
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function numberParam(raw: unknown, fallback: number): number {
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
+    return raw;
+  }
+  return fallback;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -68,6 +68,7 @@ import { registerAppCrashReportsTool } from './app-crash-reports';
 import { registerAppRecordVideoTool } from './app-record-video';
 import { registerAppPermissionsTool } from './app-permissions';
 import { registerAppDeeplinkTool } from './app-deeplink';
+import { registerAppNotesPasteAndTapUrlTool } from './app-notes-paste-and-tap-url';
 import { registerAppPushNotificationTool } from './app-push-notification';
 import { registerAppHandleAlertTool } from './app-handle-alert';
 import { registerAppActivateTool } from './app-activate';
@@ -253,6 +254,7 @@ export function registerAllTools(server: MCPServer): void {
   // Tier 2: Native App System Surfaces
   registerAppPermissionsTool(server);
   registerAppDeeplinkTool(server);
+  registerAppNotesPasteAndTapUrlTool(server);
   registerAppPushNotificationTool(server);
   registerAppHandleAlertTool(server);
   registerAppActivateTool(server);

--- a/tests/unit/app-notes-paste-and-tap-url.test.ts
+++ b/tests/unit/app-notes-paste-and-tap-url.test.ts
@@ -124,8 +124,73 @@ describe('app_notes_paste_and_tap_url', () => {
     });
     expect(result.isError).toBeUndefined();
     const parsed = JSON.parse((result.content as unknown as Array<{ text: string }>)[0].text);
-    // The first AXLink whose label contains the host wins.
+    // No label contains the full URL literal, so the first AXLink whose
+    // label contains the host wins.
     expect(parsed.linkElement.path).toBe('link#0');
+  });
+
+  test('prefers exact URL match over a host-only match earlier in the list', async () => {
+    queryMock.mockImplementation((query: { role: string }) => {
+      if (query.role === 'AXTextArea') {
+        return Promise.resolve({ matches: [{ path: 'editor#0', role: 'AXTextArea', label: null }], total: 1 });
+      }
+      if (query.role === 'AXLink') {
+        return Promise.resolve({
+          matches: [
+            // Pre-existing host-only link on the same domain — would win under
+            // first-match semantics and tap the wrong route.
+            { path: 'link#stale', role: 'AXLink', label: 'https://example.com' },
+            // The link we actually pasted appears later in the tree.
+            { path: 'link#target', role: 'AXLink', label: 'https://example.com/detail/abc' },
+          ],
+          total: 2,
+        });
+      }
+      return Promise.resolve({ matches: [], total: 0 });
+    });
+
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', {
+      url: 'https://example.com/detail/abc',
+      settleMs: 0,
+      focusTimeoutMs: 500,
+      linkTapTimeoutMs: 500,
+    });
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse((result.content as unknown as Array<{ text: string }>)[0].text);
+    expect(parsed.linkElement.path).toBe('link#target');
+    expect(pressMock).toHaveBeenNthCalledWith(2, 'link#target', 'TEST-UDID-1234');
+  });
+
+  test('does not tap a sole unrelated AXLink as a fallback', async () => {
+    // Notes is launched into prior state: a pre-existing, completely unrelated
+    // AXLink is already on screen. The tool must treat this as "no match" and
+    // surface an error rather than tapping the wrong link.
+    queryMock.mockImplementation((query: { role: string }) => {
+      if (query.role === 'AXTextArea') {
+        return Promise.resolve({ matches: [{ path: 'editor#0', role: 'AXTextArea', label: null }], total: 1 });
+      }
+      if (query.role === 'AXLink') {
+        return Promise.resolve({
+          matches: [{ path: 'link#stale', role: 'AXLink', label: 'https://unrelated.test/stuff' }],
+          total: 1,
+        });
+      }
+      return Promise.resolve({ matches: [], total: 0 });
+    });
+
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', {
+      url: 'https://example.com/detail/abc',
+      settleMs: 0,
+      focusTimeoutMs: 500,
+      linkTapTimeoutMs: 200,
+    });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse((result.content as unknown as Array<{ text: string }>)[0].text);
+    expect(parsed.error).toMatch(/Data Detector did not produce a link/);
+    // The press for the detected link must never fire on a fallback candidate.
+    expect(pressMock).not.toHaveBeenCalledWith('link#stale', 'TEST-UDID-1234');
   });
 
   test('returns isError when url is missing', async () => {

--- a/tests/unit/app-notes-paste-and-tap-url.test.ts
+++ b/tests/unit/app-notes-paste-and-tap-url.test.ts
@@ -1,0 +1,218 @@
+import { MCPServer } from '../../src/mcp-server';
+import { registerAppNotesPasteAndTapUrlTool } from '../../src/tools/app-notes-paste-and-tap-url';
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn().mockReturnValue({
+    getSoleDeviceId: jest.fn().mockReturnValue('TEST-UDID-1234'),
+  }),
+}));
+
+const launchAppMock = jest.fn();
+jest.mock('../../src/simulator', () => ({
+  SimulatorManager: jest.fn().mockImplementation(() => ({
+    launchApp: launchAppMock,
+  })),
+}));
+
+const typeViaPasteboardMock = jest.fn();
+jest.mock('../../src/tools/pasteboard-input', () => ({
+  typeViaPasteboard: (...args: unknown[]) => typeViaPasteboardMock(...args),
+}));
+
+const queryMock = jest.fn();
+const pressMock = jest.fn();
+jest.mock('../../src/native', () => ({
+  getAccessibilityBridge: jest.fn().mockReturnValue({
+    query: (...args: unknown[]) => queryMock(...args),
+    press: (...args: unknown[]) => pressMock(...args),
+  }),
+}));
+
+describe('app_notes_paste_and_tap_url', () => {
+  let server: MCPServer;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerAppNotesPasteAndTapUrlTool(server);
+  });
+
+  beforeEach(() => {
+    launchAppMock.mockReset();
+    typeViaPasteboardMock.mockReset();
+    queryMock.mockReset();
+    pressMock.mockReset();
+    launchAppMock.mockResolvedValue({ ok: true });
+    typeViaPasteboardMock.mockResolvedValue({ backend: 'pasteboard', length: 10 });
+    pressMock.mockResolvedValue({ ok: true, code: 'OK', path: '', actions: [], role: null, identifier: null, label: null, message: null, axErrorCode: null });
+  });
+
+  test('registers with the expected name', () => {
+    expect(server.getRegisteredTools()).toContain('app_notes_paste_and_tap_url');
+  });
+
+  test('happy path: launches Notes, paste-injects URL, taps detected link', async () => {
+    // First query (editor role=AXTextArea) returns a match; subsequent calls
+    // (for AXLink) also return a match.
+    queryMock.mockImplementation((query: { role: string }) => {
+      if (query.role === 'AXTextArea') {
+        return Promise.resolve({
+          matches: [{ path: 'editor#0', role: 'AXTextArea', label: null }],
+          total: 1,
+        });
+      }
+      if (query.role === 'AXLink') {
+        return Promise.resolve({
+          matches: [
+            { path: 'link#0', role: 'AXLink', label: 'https://example.com/detail/abc' },
+          ],
+          total: 1,
+        });
+      }
+      return Promise.resolve({ matches: [], total: 0 });
+    });
+
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', {
+      url: 'https://example.com/detail/abc',
+      settleMs: 0,
+      focusTimeoutMs: 500,
+      linkTapTimeoutMs: 500,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse((result.content as unknown as Array<{ text: string }>)[0].text);
+    expect(parsed.url).toBe('https://example.com/detail/abc');
+    expect(parsed.deviceId).toBe('TEST-UDID-1234');
+    expect(parsed.linkElement.label).toBe('https://example.com/detail/abc');
+    expect(parsed.linkElement.path).toBe('link#0');
+
+    expect(launchAppMock).toHaveBeenCalledWith('TEST-UDID-1234', 'com.apple.mobilenotes');
+    expect(typeViaPasteboardMock).toHaveBeenCalledWith(
+      'TEST-UDID-1234',
+      'https://example.com/detail/abc',
+      expect.objectContaining({ restorePasteboard: true }),
+    );
+    // First press focuses editor; second presses link.
+    expect(pressMock).toHaveBeenCalledTimes(2);
+    expect(pressMock).toHaveBeenNthCalledWith(1, 'editor#0', 'TEST-UDID-1234');
+    expect(pressMock).toHaveBeenNthCalledWith(2, 'link#0', 'TEST-UDID-1234');
+  });
+
+  test('matches link by URL host when label only shows the host', async () => {
+    queryMock.mockImplementation((query: { role: string }) => {
+      if (query.role === 'AXTextArea') {
+        return Promise.resolve({ matches: [{ path: 'editor#0', role: 'AXTextArea', label: null }], total: 1 });
+      }
+      if (query.role === 'AXLink') {
+        return Promise.resolve({
+          matches: [
+            { path: 'link#0', role: 'AXLink', label: 'Detail · Example.com' },
+            { path: 'link#1', role: 'AXLink', label: 'example.com' },
+          ],
+          total: 2,
+        });
+      }
+      return Promise.resolve({ matches: [], total: 0 });
+    });
+
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', {
+      url: 'https://example.com/detail/abc',
+      settleMs: 0,
+      focusTimeoutMs: 500,
+      linkTapTimeoutMs: 500,
+    });
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse((result.content as unknown as Array<{ text: string }>)[0].text);
+    // The first AXLink whose label contains the host wins.
+    expect(parsed.linkElement.path).toBe('link#0');
+  });
+
+  test('returns isError when url is missing', async () => {
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', {});
+    expect(result.isError).toBe(true);
+  });
+
+  test('returns isError when url has no scheme', async () => {
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', { url: 'example.com/no-scheme' });
+    expect(result.isError).toBe(true);
+  });
+
+  test('returns isError when Notes editor never appears', async () => {
+    queryMock.mockResolvedValue({ matches: [], total: 0 });
+
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', {
+      url: 'https://example.com/detail/abc',
+      settleMs: 0,
+      focusTimeoutMs: 200,
+      linkTapTimeoutMs: 200,
+    });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse((result.content as unknown as Array<{ text: string }>)[0].text);
+    expect(parsed.error).toMatch(/Notes editor did not appear/);
+    expect(typeViaPasteboardMock).not.toHaveBeenCalled();
+  });
+
+  test('returns isError when Data Detector never produces a link', async () => {
+    queryMock.mockImplementation((query: { role: string }) => {
+      if (query.role === 'AXTextArea') {
+        return Promise.resolve({ matches: [{ path: 'editor#0', role: 'AXTextArea', label: null }], total: 1 });
+      }
+      return Promise.resolve({ matches: [], total: 0 });
+    });
+
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', {
+      url: 'https://example.com/detail/abc',
+      settleMs: 0,
+      focusTimeoutMs: 500,
+      linkTapTimeoutMs: 200,
+    });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse((result.content as unknown as Array<{ text: string }>)[0].text);
+    expect(parsed.error).toMatch(/Data Detector did not produce a link/);
+  });
+
+  test('returns isError when Notes launch fails', async () => {
+    launchAppMock.mockRejectedValueOnce(new Error('simctl launch failed: no such bundle'));
+
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', { url: 'https://example.com/x' });
+    expect(result.isError).toBe(true);
+  });
+
+  test('returns isError when pressing the detected link fails', async () => {
+    queryMock.mockImplementation((query: { role: string }) => {
+      if (query.role === 'AXTextArea') {
+        return Promise.resolve({ matches: [{ path: 'editor#0', role: 'AXTextArea', label: null }], total: 1 });
+      }
+      if (query.role === 'AXLink') {
+        return Promise.resolve({
+          matches: [{ path: 'link#0', role: 'AXLink', label: 'https://example.com/detail/abc' }],
+          total: 1,
+        });
+      }
+      return Promise.resolve({ matches: [], total: 0 });
+    });
+    pressMock.mockImplementation((path: string) => {
+      if (path === 'link#0') {
+        return Promise.resolve({ ok: false, code: 'PRESS_NOT_ACTIONABLE', path, actions: [], role: 'AXLink', identifier: null, label: null, message: 'link does not advertise AXPress', axErrorCode: null });
+      }
+      return Promise.resolve({ ok: true, code: 'OK', path, actions: [], role: null, identifier: null, label: null, message: null, axErrorCode: null });
+    });
+
+    const handler = server.getToolHandler('app_notes_paste_and_tap_url')!;
+    const result = await handler('test-session', {
+      url: 'https://example.com/detail/abc',
+      settleMs: 0,
+      focusTimeoutMs: 200,
+      linkTapTimeoutMs: 200,
+    });
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse((result.content as unknown as Array<{ text: string }>)[0].text);
+    expect(parsed.error).toMatch(/Failed to press detected link/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new MCP tool `app_notes_paste_and_tap_url` that drives the
**reviewer-equivalent Universal Link channel** — paste the URL into
Notes, let iOS Data Detector produce a tappable link, and press it —
through a single tool call. This covers the close-gate blocker in #641 (sub-task T1).

Apple documentation does not accept `xcrun simctl openurl` as
equivalent to a real Universal Link tap, so consumer teams (e.g.
Omofictions-App#26) have to reconstruct the Notes-paste flow manually.
This tool makes that channel deterministic from the MCP side.

## Implementation

- `src/tools/app-notes-paste-and-tap-url.ts` — glue that:
  1. Launches Notes (`com.apple.mobilenotes`) via `SimulatorManager.launchApp`.
  2. Waits for a focusable editor by polling the AX tree for role in
     `['AXTextArea', 'AXTextView', 'AXTextField']` (configurable `focusTimeoutMs`).
  3. Focuses the editor via `AccessibilityBridge.press`.
  4. Paste-injects the URL via the existing `typeViaPasteboard` from
     `src/tools/pasteboard-input.ts` (already handles the iOS 16+
     paste-permission dialog and restores the original pasteboard).
  5. Polls the AX tree for `AXLink` whose label contains the URL or its
     host (configurable `linkTapTimeoutMs`). If exactly one AXLink is
     present, we take it as a fallback (Data Detector's only link).
  6. Presses the detected link and returns the matched `linkElement` path + label.
- `src/tools/index.ts` — tool registered next to `app_deeplink`.
- `tests/unit/app-notes-paste-and-tap-url.test.ts` — 9 unit tests covering:
  - Happy path (URL literal match)
  - Host-only label match
  - Missing URL
  - Scheme-less URL
  - Editor never appears
  - Data Detector never produces a link
  - Notes launch failure
  - Press-detected-link fails (`PRESS_NOT_ACTIONABLE`)
  - Tool registration

No changes to the existing `app_open_url` / `app_deeplink` tools — this
PR is purely additive.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npx jest tests/unit/app-notes-paste-and-tap-url.test.ts` → 9/9 pass
- [ ] Manual repro (iPhone 17 Pro, iOS 26.4, Flutter app
      `com.omofictions.omofictionsApp`): invoke tool with
      `https://omofictions.com/detail/abc`, confirm app foregrounds at
      the expected route. *(pending — will be attached to #641 before merge)*

## Scope

This is T1 of four sub-tasks in #641:

- **T1 (this PR)** — `app_notes_paste_and_tap_url` tool
- T2 — Doc: UL channels + simulator limitations (separate PR)
- T3 — Safari Smart Banner spike (separate follow-up issue)
- T4 — `captureLogs` option on `app_open_url` / `app_deeplink` (separate PR)

Ref: #641

## Test plan

- [ ] CI green (build + unit tests)
- [ ] Manual repro on iOS 26.4 Simulator with `applinks:`-entitled Flutter app
- [ ] Fallback: confirm `isError: true` when Notes is force-uninstalled

🤖 Generated with [Claude Code](https://claude.com/claude-code)