### PR TITLE
feat(app-open-url,app-deeplink): opt-in captureLogs window (#641 T4)

### DIFF
--- a/src/observability/capture-logs-window.ts
+++ b/src/observability/capture-logs-window.ts
@@ -92,10 +92,18 @@ export async function captureLogsWindow(
 
   const collected: Array<Record<string, unknown>> = [];
   const seen = new Set<string>();
-  let lastNewEntryAt = preOpenAt;
+  // Anchor silence and max-duration on capture start, NOT on preOpenAt.
+  // preOpenAt is recorded before `simctl openurl`, so seeding either timer
+  // with it would charge the caller for however long the URL took to open:
+  // if openurl exceeded `silenceMs` (1500ms default), the very first poll
+  // would trip the silence exit and return 0 entries before we had a chance
+  // to observe any post-open log. `windowStart` still uses `preOpenAt -
+  // prerollMs` so the log *query* range covers the tap itself.
+  const captureStart = now();
+  let lastNewEntryAt = captureStart;
   let stopReason: 'silence' | 'max_duration' = 'silence';
 
-  const deadline = preOpenAt + maxDurationMs;
+  const deadline = captureStart + maxDurationMs;
 
   while (true) {
     const startArg = formatStartTime(windowStartMs);

--- a/src/observability/capture-logs-window.ts
+++ b/src/observability/capture-logs-window.ts
@@ -1,0 +1,214 @@
+/**
+ * capture-logs-window — capture `os_log` entries around a URL-open event so a
+ * caller can verify in one round-trip that the deep-link handler fired (e.g.
+ * `[UniversalLink] Resolved …`) without juggling `xcrun simctl log stream` by
+ * hand.
+ *
+ * iOS does not expose a kernel "app is quiescent" signal outside of
+ * Instruments / `dt_probe`, so we use a silence heuristic: keep fetching logs
+ * in the window `[preOpenTimestamp - prerollMs, now]`, and stop once no new
+ * matching entry has arrived for `silenceMs` (or we hit `maxDurationMs`).
+ *
+ * The shape mirrors the NSPredicate builder already used by `app_logs` so the
+ * filter semantics (bundleId, level, search) line up across tools.
+ */
+
+import { SimctlExecutor } from '../simulator/simctl';
+import { buildLogPredicate } from '../tools/app-logs';
+
+export interface CaptureLogsOptions {
+  /** Process filter (`process == <bundleId>`). */
+  bundleId?: string;
+  /** Minimum message severity. */
+  level?: 'default' | 'info' | 'debug' | 'error' | 'fault';
+  /** Substring filter applied to the composed message. */
+  search?: string;
+  /** How far back to pull logs relative to `preOpenAt`. Default 2000 ms. */
+  prerollMs?: number;
+  /** Stop once this many ms elapse with no new matching entry. Default 1500 ms. */
+  silenceMs?: number;
+  /** Hard upper bound on the collection window. Default 8000 ms. */
+  maxDurationMs?: number;
+  /** Poll cadence. Default 400 ms. */
+  pollIntervalMs?: number;
+}
+
+export interface CaptureLogsResult {
+  entries: Array<Record<string, unknown>>;
+  windowStart: string;
+  windowEnd: string;
+  truncated: false;
+  stopReason: 'silence' | 'max_duration';
+}
+
+export interface CaptureLogsError {
+  error: string;
+  stopReason: 'error';
+  windowStart: string;
+  windowEnd: string;
+}
+
+export interface CaptureLogsDeps {
+  simctl?: SimctlExecutor;
+  /** Injected now() for tests. */
+  now?: () => number;
+  /** Injected sleep() for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_PREROLL_MS = 2000;
+const DEFAULT_SILENCE_MS = 1500;
+const DEFAULT_MAX_DURATION_MS = 8000;
+const DEFAULT_POLL_INTERVAL_MS = 400;
+
+/**
+ * Capture unified-log entries around a URL-open event.
+ *
+ * `preOpenAt` must be captured by the caller **before** invoking
+ * `simctl openurl` so the preroll covers logs emitted by the URL tap itself.
+ */
+export async function captureLogsWindow(
+  deviceId: string,
+  preOpenAt: number,
+  opts: CaptureLogsOptions = {},
+  deps: CaptureLogsDeps = {},
+): Promise<CaptureLogsResult | CaptureLogsError> {
+  const simctl = deps.simctl ?? new SimctlExecutor();
+  const now = deps.now ?? Date.now;
+  const sleep = deps.sleep ?? defaultSleep;
+
+  const prerollMs = positive(opts.prerollMs, DEFAULT_PREROLL_MS);
+  const silenceMs = positive(opts.silenceMs, DEFAULT_SILENCE_MS);
+  const maxDurationMs = positive(opts.maxDurationMs, DEFAULT_MAX_DURATION_MS);
+  const pollIntervalMs = positive(opts.pollIntervalMs, DEFAULT_POLL_INTERVAL_MS);
+
+  const windowStartMs = preOpenAt - prerollMs;
+  const windowStartIso = new Date(windowStartMs).toISOString();
+  const predicate = buildLogPredicate({
+    bundleId: opts.bundleId,
+    level: opts.level,
+    search: opts.search,
+  });
+
+  const collected: Array<Record<string, unknown>> = [];
+  const seen = new Set<string>();
+  let lastNewEntryAt = preOpenAt;
+  let stopReason: 'silence' | 'max_duration' = 'silence';
+
+  const deadline = preOpenAt + maxDurationMs;
+
+  while (true) {
+    const startArg = formatStartTime(windowStartMs);
+    const args: string[] = [
+      'spawn',
+      deviceId,
+      'log',
+      'show',
+      '--start',
+      startArg,
+      '--style',
+      'json',
+    ];
+    if (predicate) {
+      args.push('--predicate', predicate);
+    }
+
+    let output: string;
+    try {
+      output = await simctl.exec(args, { timeout: 15000 });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        error: message,
+        stopReason: 'error',
+        windowStart: windowStartIso,
+        windowEnd: new Date(now()).toISOString(),
+      };
+    }
+
+    const parsed = parseLogOutput(output);
+    let addedThisPoll = 0;
+    for (const entry of parsed) {
+      const key = entryKey(entry);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      collected.push(entry);
+      addedThisPoll++;
+    }
+
+    const tNow = now();
+    if (addedThisPoll > 0) {
+      lastNewEntryAt = tNow;
+    }
+
+    if (tNow >= deadline) {
+      stopReason = 'max_duration';
+      break;
+    }
+    if (tNow - lastNewEntryAt >= silenceMs) {
+      stopReason = 'silence';
+      break;
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  return {
+    entries: collected,
+    windowStart: windowStartIso,
+    windowEnd: new Date(now()).toISOString(),
+    truncated: false,
+    stopReason,
+  };
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function positive(value: number | undefined, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  return fallback;
+}
+
+/**
+ * Format a timestamp for `log show --start`. `log show` accepts either
+ * `YYYY-MM-DD HH:MM:SS` (local time) or an ISO-ish form; the safer bet across
+ * shells is a local-time string, which `log show` documents as accepted.
+ */
+function formatStartTime(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+  );
+}
+
+function parseLogOutput(output: string): Array<Record<string, unknown>> {
+  try {
+    const parsed = JSON.parse(output);
+    return Array.isArray(parsed) ? (parsed as Array<Record<string, unknown>>) : [];
+  } catch {
+    // Some simctl builds return newline-delimited entries instead of a JSON array.
+    const lines = output.split('\n').filter((l) => l.trim().length > 0);
+    return lines.map((line) => ({ message: line }));
+  }
+}
+
+/**
+ * Stable deduplication key. Prefers `timestamp + messageID + composedMessage`
+ * but falls back to the raw serialisation so we never collapse distinct
+ * entries.
+ */
+function entryKey(entry: Record<string, unknown>): string {
+  const timestamp = (entry.timestamp as string) ?? '';
+  const messageID = (entry.traceID ?? entry.messageID ?? '') as string | number;
+  const composed = (entry.composedMessage as string) ?? (entry.message as string) ?? '';
+  if (timestamp || composed) {
+    return `${timestamp}|${messageID}|${composed}`;
+  }
+  return JSON.stringify(entry);
+}

--- a/src/tools/app-deeplink.ts
+++ b/src/tools/app-deeplink.ts
@@ -1,13 +1,17 @@
 import { MCPServer } from '../mcp-server';
 import { SimctlExecutor } from '../simulator/simctl';
 import { resolveDeviceId } from './native-app-helpers';
+import {
+  captureLogsWindow,
+  type CaptureLogsOptions,
+} from '../observability/capture-logs-window';
 
 export function registerAppDeeplinkTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_deeplink',
       description:
-        'Open deep links or universal links in the iOS Simulator. Supports custom URL schemes (myapp://path) and universal links (https://...).',
+        'Open deep links or universal links in the iOS Simulator. Supports custom URL schemes (myapp://path) and universal links (https://...). Optionally returns unified-log entries around the open event via `captureLogs` (see docs/recipes/universal-link-channels.md).',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -18,6 +22,19 @@ export function registerAppDeeplinkTool(server: MCPServer): void {
           deviceId: {
             type: 'string',
             description: 'Simulator UDID (uses active device if omitted)',
+          },
+          captureLogs: {
+            type: 'object',
+            description:
+              'If provided, synchronously captures os_log entries around the deep-link open. Collection stops after `silenceMs` with no new matching entry, or `maxDurationMs` elapses.',
+            properties: {
+              bundleId: { type: 'string' },
+              level: { type: 'string', enum: ['default', 'info', 'debug', 'error', 'fault'] },
+              search: { type: 'string' },
+              prerollMs: { type: 'number' },
+              silenceMs: { type: 'number' },
+              maxDurationMs: { type: 'number' },
+            },
           },
         },
         required: ['url'],
@@ -58,13 +75,25 @@ export function registerAppDeeplinkTool(server: MCPServer): void {
 
       try {
         const simctl = new SimctlExecutor();
+        const preOpenAt = Date.now();
         await simctl.exec(['openurl', deviceId, url]);
+
+        const result: Record<string, unknown> = {
+          url,
+          deviceId,
+          openedAt: new Date(preOpenAt).toISOString(),
+        };
+
+        const captureLogsOpts = params.captureLogs as CaptureLogsOptions | undefined;
+        if (captureLogsOpts && typeof captureLogsOpts === 'object') {
+          result.logs = await captureLogsWindow(deviceId, preOpenAt, captureLogsOpts, { simctl });
+        }
 
         return {
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify({ url, deviceId, openedAt: new Date().toISOString() }),
+              text: JSON.stringify(result),
             },
           ],
         };

--- a/src/tools/app-open-url.ts
+++ b/src/tools/app-open-url.ts
@@ -1,13 +1,17 @@
 import { MCPServer } from '../mcp-server';
 import { SimctlExecutor } from '../simulator/simctl';
 import { resolveDeviceId } from './native-app-utils';
+import {
+  captureLogsWindow,
+  type CaptureLogsOptions,
+} from '../observability/capture-logs-window';
 
 export function registerAppOpenUrlTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_open_url',
       description:
-        'Open a URL or deep link on an iOS Simulator. Routes to the appropriate app handler (e.g. Safari for https://, or a custom scheme like myapp://).',
+        'Open a URL or deep link on an iOS Simulator. Routes to the appropriate app handler (e.g. Safari for https://, or a custom scheme like myapp://). Optionally returns unified-log entries around the open event via `captureLogs` (see docs/recipes/universal-link-channels.md).',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -18,6 +22,19 @@ export function registerAppOpenUrlTool(server: MCPServer): void {
           deviceId: {
             type: 'string',
             description: 'Simulator UDID (uses active device if omitted)',
+          },
+          captureLogs: {
+            type: 'object',
+            description:
+              'If provided, synchronously captures os_log entries around the URL-open. Collection stops after `silenceMs` with no new matching entry, or `maxDurationMs` elapses.',
+            properties: {
+              bundleId: { type: 'string' },
+              level: { type: 'string', enum: ['default', 'info', 'debug', 'error', 'fault'] },
+              search: { type: 'string' },
+              prerollMs: { type: 'number' },
+              silenceMs: { type: 'number' },
+              maxDurationMs: { type: 'number' },
+            },
           },
         },
         required: ['url'],
@@ -33,13 +50,19 @@ export function registerAppOpenUrlTool(server: MCPServer): void {
         }
 
         const simctl = new SimctlExecutor();
+        const preOpenAt = Date.now();
         await simctl.exec(['openurl', deviceId, url]);
 
-        const result = {
+        const result: Record<string, unknown> = {
           url,
           deviceId,
-          openedAt: new Date().toISOString(),
+          openedAt: new Date(preOpenAt).toISOString(),
         };
+
+        const captureLogsOpts = params.captureLogs as CaptureLogsOptions | undefined;
+        if (captureLogsOpts && typeof captureLogsOpts === 'object') {
+          result.logs = await captureLogsWindow(deviceId, preOpenAt, captureLogsOpts, { simctl });
+        }
 
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],

--- a/tests/unit/capture-logs-window.test.ts
+++ b/tests/unit/capture-logs-window.test.ts
@@ -1,0 +1,188 @@
+import { captureLogsWindow } from '../../src/observability/capture-logs-window';
+
+interface MockSimctl {
+  exec: jest.Mock;
+}
+
+function makeSimctl(responses: Array<string | Error>): MockSimctl {
+  const exec = jest.fn().mockImplementation(() => {
+    const next = responses.shift();
+    if (next === undefined) return Promise.resolve('[]');
+    if (next instanceof Error) return Promise.reject(next);
+    return Promise.resolve(next);
+  });
+  return { exec };
+}
+
+function controlledClock(startMs: number) {
+  let t = startMs;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+/** A fake sleep that advances a clock. */
+function makeSleep(clock: { advance: (ms: number) => void }) {
+  return (ms: number): Promise<void> => {
+    clock.advance(ms);
+    return Promise.resolve();
+  };
+}
+
+function logEntry(timestamp: string, composedMessage: string): Record<string, unknown> {
+  return {
+    timestamp,
+    process: 'Runner',
+    messageType: 'info',
+    composedMessage,
+    traceID: `${timestamp}-${composedMessage}`,
+  };
+}
+
+describe('captureLogsWindow', () => {
+  test('stops on silence once no new matching entry arrives for silenceMs', async () => {
+    const clock = controlledClock(1_000_000);
+    const preOpenAt = clock.now();
+    const first = [logEntry('2026-04-23T00:00:00Z', '[UniversalLink] Resolved /detail/abc')];
+    const stillFirst = [...first];
+    // First poll → 1 new entry. Second poll → same entry (already seen).
+    // Third poll → same entry. After `silenceMs`, stop.
+    const simctl = makeSimctl([
+      JSON.stringify(first),
+      JSON.stringify(stillFirst),
+      JSON.stringify(stillFirst),
+      JSON.stringify(stillFirst),
+    ]);
+
+    const result = await captureLogsWindow(
+      'TEST-UDID',
+      preOpenAt,
+      { prerollMs: 2000, silenceMs: 1000, maxDurationMs: 10_000, pollIntervalMs: 400 },
+      { simctl: simctl as unknown as import('../../src/simulator/simctl').SimctlExecutor, now: clock.now, sleep: makeSleep(clock) },
+    );
+
+    if ('error' in result) {
+      throw new Error('unexpected error: ' + result.error);
+    }
+    expect(result.stopReason).toBe('silence');
+    expect(result.entries).toHaveLength(1);
+    expect((result.entries[0] as { composedMessage: string }).composedMessage).toMatch(
+      /UniversalLink/,
+    );
+  });
+
+  test('stops on max_duration when entries keep arriving', async () => {
+    const clock = controlledClock(1_000_000);
+    const preOpenAt = clock.now();
+    // Each poll adds a new entry so silence never triggers.
+    let counter = 0;
+    const responses: string[] = [];
+    for (let i = 0; i < 30; i++) {
+      counter++;
+      responses.push(
+        JSON.stringify([logEntry(`2026-04-23T00:00:0${counter}Z`, `entry-${counter}`)]),
+      );
+    }
+    const simctl = makeSimctl(responses);
+
+    const result = await captureLogsWindow(
+      'TEST-UDID',
+      preOpenAt,
+      { prerollMs: 2000, silenceMs: 10_000, maxDurationMs: 3000, pollIntervalMs: 400 },
+      { simctl: simctl as unknown as import('../../src/simulator/simctl').SimctlExecutor, now: clock.now, sleep: makeSleep(clock) },
+    );
+
+    if ('error' in result) {
+      throw new Error('unexpected error: ' + result.error);
+    }
+    expect(result.stopReason).toBe('max_duration');
+    expect(result.entries.length).toBeGreaterThan(0);
+  });
+
+  test('windowStart includes the preroll', async () => {
+    const clock = controlledClock(2_000_000);
+    const preOpenAt = clock.now();
+    const simctl = makeSimctl([JSON.stringify([])]);
+
+    const result = await captureLogsWindow(
+      'TEST-UDID',
+      preOpenAt,
+      { prerollMs: 2500, silenceMs: 100, maxDurationMs: 500, pollIntervalMs: 10 },
+      { simctl: simctl as unknown as import('../../src/simulator/simctl').SimctlExecutor, now: clock.now, sleep: makeSleep(clock) },
+    );
+
+    if ('error' in result) {
+      throw new Error('unexpected error: ' + result.error);
+    }
+    const windowStartMs = Date.parse(result.windowStart);
+    expect(preOpenAt - windowStartMs).toBe(2500);
+  });
+
+  test('returns error object when simctl rejects (no throw)', async () => {
+    const clock = controlledClock(0);
+    const simctl = makeSimctl([new Error('simctl spawn failed: permissions')]);
+
+    const result = await captureLogsWindow(
+      'TEST-UDID',
+      clock.now(),
+      { silenceMs: 100, maxDurationMs: 500, pollIntervalMs: 10 },
+      { simctl: simctl as unknown as import('../../src/simulator/simctl').SimctlExecutor, now: clock.now, sleep: makeSleep(clock) },
+    );
+
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.stopReason).toBe('error');
+      expect(result.error).toMatch(/simctl spawn failed/);
+    }
+  });
+
+  test('passes --predicate when bundleId / search are provided', async () => {
+    const clock = controlledClock(5_000_000);
+    const simctl = makeSimctl([JSON.stringify([])]);
+
+    await captureLogsWindow(
+      'TEST-UDID',
+      clock.now(),
+      {
+        bundleId: 'com.omofictions.omofictionsApp',
+        search: '[UniversalLink]',
+        silenceMs: 100,
+        maxDurationMs: 500,
+        pollIntervalMs: 10,
+      },
+      { simctl: simctl as unknown as import('../../src/simulator/simctl').SimctlExecutor, now: clock.now, sleep: makeSleep(clock) },
+    );
+
+    expect(simctl.exec).toHaveBeenCalled();
+    const firstCallArgs = simctl.exec.mock.calls[0][0] as string[];
+    const predicateIdx = firstCallArgs.indexOf('--predicate');
+    expect(predicateIdx).toBeGreaterThan(-1);
+    const predicate = firstCallArgs[predicateIdx + 1];
+    expect(predicate).toContain('process == "com.omofictions.omofictionsApp"');
+    expect(predicate).toContain('composedMessage CONTAINS "[UniversalLink]"');
+  });
+
+  test('deduplicates entries across polls using traceID + composedMessage', async () => {
+    const clock = controlledClock(0);
+    const preOpenAt = clock.now();
+    const entry = logEntry('2026-04-23T00:00:00Z', '[UniversalLink] Resolved');
+    const simctl = makeSimctl([
+      JSON.stringify([entry]),
+      JSON.stringify([entry, logEntry('2026-04-23T00:00:01Z', '[Auth] refreshed')]),
+      JSON.stringify([entry, logEntry('2026-04-23T00:00:01Z', '[Auth] refreshed')]),
+    ]);
+
+    const result = await captureLogsWindow(
+      'TEST-UDID',
+      preOpenAt,
+      { silenceMs: 400, maxDurationMs: 5000, pollIntervalMs: 200, prerollMs: 0 },
+      { simctl: simctl as unknown as import('../../src/simulator/simctl').SimctlExecutor, now: clock.now, sleep: makeSleep(clock) },
+    );
+
+    if ('error' in result) throw new Error(result.error);
+    expect(result.entries).toHaveLength(2);
+  });
+});

--- a/tests/unit/capture-logs-window.test.ts
+++ b/tests/unit/capture-logs-window.test.ts
@@ -165,6 +165,41 @@ describe('captureLogsWindow', () => {
     expect(predicate).toContain('composedMessage CONTAINS "[UniversalLink]"');
   });
 
+  test('does not trip silence exit when simctl openurl took longer than silenceMs before capture began', async () => {
+    // preOpenAt is recorded *before* simctl openurl; the capture helper is
+    // invoked only after openurl returns. If openurl takes longer than
+    // silenceMs (1500ms default), a naive baseline anchored on preOpenAt
+    // would fire the silence exit on the very first poll and miss every
+    // post-open log. The baseline must therefore be anchored on capture
+    // start — this test freezes that invariant.
+    const openurlDelayMs = 3000;
+    const preOpenAt = 1_000_000;
+    const clock = controlledClock(preOpenAt + openurlDelayMs);
+    const entries = [logEntry('2026-04-23T00:00:00Z', '[UniversalLink] Resolved /x')];
+    const simctl = makeSimctl([
+      JSON.stringify(entries),
+      JSON.stringify(entries),
+      JSON.stringify(entries),
+      JSON.stringify(entries),
+    ]);
+
+    const result = await captureLogsWindow(
+      'TEST-UDID',
+      preOpenAt,
+      { prerollMs: 2000, silenceMs: 1500, maxDurationMs: 8000, pollIntervalMs: 400 },
+      { simctl: simctl as unknown as import('../../src/simulator/simctl').SimctlExecutor, now: clock.now, sleep: makeSleep(clock) },
+    );
+
+    if ('error' in result) {
+      throw new Error('unexpected error: ' + result.error);
+    }
+    // The capture must observe the entry at least once — if silence were
+    // anchored on preOpenAt, the first-poll delta (openurlDelayMs = 3000ms)
+    // would already exceed silenceMs (1500ms) and return an empty entries
+    // array with stopReason "silence" before any new-entry observation.
+    expect(result.entries.length).toBeGreaterThan(0);
+  });
+
   test('deduplicates entries across polls using traceID + composedMessage', async () => {
     const clock = controlledClock(0);
     const preOpenAt = clock.now();


### PR DESCRIPTION
## Summary

Adds an optional `captureLogs` parameter to `app_open_url` and
`app_deeplink` so callers can assert — in a single MCP call — that the
deep-link handler emitted its diagnostic logs (e.g.
`[UniversalLink] Resolved …`) around a URL-open event. Resolves sub-task T4 of #641.

Today we have to juggle `xcrun simctl log stream` from the host to
correlate a Universal Link open against its log output. This PR folds
that correlation into the tool that opens the URL.

## Contract

`captureLogs` is additive — omit it and the tools behave exactly as before.

```jsonc
{
  "url": "https://example.com/detail/abc",
  "captureLogs": {
    "bundleId": "com.example.myapp",   // optional — maps to `process == …` NSPredicate clause
    "level":    "info",                 // optional — 'default' | 'info' | 'debug' | 'error' | 'fault'
    "search":   "[UniversalLink]",      // optional — substring filter on composedMessage
    "prerollMs":     2000,              // optional — default 2000
    "silenceMs":     1500,              // optional — default 1500 (stop after this much silence)
    "maxDurationMs": 8000               // optional — default 8000 (hard upper bound)
  }
}
```

On success the tool response adds:

```jsonc
"logs": {
  "entries":     [ { "timestamp": "…", "process": "Runner", "messageType": "info", "composedMessage": "…" }, … ],
  "windowStart": "ISO8601 (preOpenAt - prerollMs)",
  "windowEnd":   "ISO8601",
  "truncated":   false,
  "stopReason":  "silence" | "max_duration"
}
```

If `simctl` rejects during collection (e.g. permissions), `logs` becomes
`{ error: "…", stopReason: "error", windowStart, windowEnd }` — the
URL-open itself still succeeds and is reported normally.

## Implementation

- **New shared helper** `src/observability/capture-logs-window.ts` — handles the
  silence-heuristic polling, NSPredicate reuse (via the existing
  `buildLogPredicate` from `app-logs.ts`), and dedup across polls.
- `src/tools/app-open-url.ts` — captures `preOpenAt` **before**
  `simctl openurl`, threads the `captureLogs` param through the helper.
- `src/tools/app-deeplink.ts` — same.
- `tests/unit/capture-logs-window.test.ts` — 6 unit tests with a scripted
  fake `SimctlExecutor` + a controlled clock:
  - silence stop
  - max_duration stop
  - preroll applied
  - simctl rejection surfaces as `{error, stopReason:'error'}` (no throw)
  - NSPredicate threading (bundleId + search)
  - dedup across polls

iOS does not expose a kernel "app is quiescent" signal outside of
Instruments / private APIs, so the helper documents and uses a silence
heuristic rather than the "until quiescent" language from the original
request (#641 Problem 4).

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npx jest tests/unit/capture-logs-window.test.ts tests/unit/app-open-url.test.ts` → 12/12 pass
- [x] Pre-existing `app_open_url` tests still pass (behaviour preserved when `captureLogs` is omitted)
- [ ] Manual repro on iOS 26.4 Simulator with a Flutter app — attach to #641 before merge

## Scope

Sub-task T4 of #641. Other sub-tasks:

- T1 — `app_notes_paste_and_tap_url` tool — PR #654
- T2 — UL-channels recipe doc — separate PR (incoming)
- T3 — Safari Smart App Banner spike — follow-up issue

Ref: #641

## Test plan

- [ ] CI green (build + unit tests)
- [ ] Manual repro: `app_deeplink { url, captureLogs: { bundleId, search: "[UniversalLink]" } }` returns a log entry demonstrating the Universal Link handler fired
- [ ] Regression: existing `app_open_url` / `app_deeplink` callers without `captureLogs` see identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)