### PR TITLE
fix(app-screenshot-native): retry transient surface timeout, drop informational stderr (#651)

### DIFF
--- a/src/tools/app-screenshot-native.ts
+++ b/src/tools/app-screenshot-native.ts
@@ -3,6 +3,14 @@
  *
  * Uses simctl io to capture the full simulator screen, independent of Safari/WebKit.
  * Useful for native app testing and debugging.
+ *
+ * Retry behavior: `simctl io … screenshot` emits a transient
+ * `Timeout waiting for screen surfaces` right after high-velocity input
+ * events (large-distance swipes / rapid scrolls) while the simulator is
+ * still compositing. We retry up to SCREENSHOT_MAX_RETRIES times with a
+ * short backoff before surfacing the error. Informational lines printed
+ * on stderr (e.g. `Note: No display specified.`) are filtered out of the
+ * error message so operators see the actual failure signal.
  */
 
 import * as fs from 'fs/promises';
@@ -10,12 +18,67 @@ import { MCPServer } from '../mcp-server';
 import { SimctlExecutor } from '../simulator/simctl';
 import { resolveDeviceId, tempPath } from './native-observability-utils';
 
+const SCREENSHOT_TIMEOUT_MS = 20_000;
+const SCREENSHOT_MAX_RETRIES = 2;
+const SCREENSHOT_RETRY_DELAY_MS = 1500;
+const TRANSIENT_TIMEOUT_PATTERN = /Timeout waiting for screen surfaces/i;
+const STDERR_NOISE_PATTERNS: RegExp[] = [
+  // The "Note: No display specified." line is emitted by simctl as an
+  // informational message. It can appear at the start of stderr or after
+  // the `simctl … failed:` prefix injected by SimctlError, so we match
+  // the substring rather than anchoring to line starts.
+  /Note: No display specified\.[^\n]*/g,
+];
+
+function isTransientScreenshotError(message: string): boolean {
+  return TRANSIENT_TIMEOUT_PATTERN.test(message);
+}
+
+export function stripInformationalStderr(message: string): string {
+  let cleaned = message;
+  for (const pattern of STDERR_NOISE_PATTERNS) {
+    cleaned = cleaned.replace(pattern, '');
+  }
+  // Collapse whitespace runs left behind after noise removal.
+  return cleaned
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{2,}/g, '\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function captureWithRetry(
+  simctl: SimctlExecutor,
+  args: string[],
+): Promise<{ attempts: number; retries: number }> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= SCREENSHOT_MAX_RETRIES; attempt++) {
+    try {
+      await simctl.exec(args, { timeout: SCREENSHOT_TIMEOUT_MS });
+      return { attempts: attempt + 1, retries: attempt };
+    } catch (err) {
+      lastError = err;
+      const msg = (err as Error).message ?? '';
+      if (!isTransientScreenshotError(msg) || attempt === SCREENSHOT_MAX_RETRIES) {
+        throw err;
+      }
+      await sleep(SCREENSHOT_RETRY_DELAY_MS);
+    }
+  }
+  // Unreachable — loop either returns or throws — but keeps TS happy.
+  throw lastError as Error;
+}
+
 export function registerAppScreenshotNativeTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_screenshot_native',
       description:
-        'Capture a native app screenshot at the device level (full simulator screen, not browser-only). Supports PNG/JPEG and optional status bar masking.',
+        'Capture a native app screenshot at the device level (full simulator screen, not browser-only). Supports PNG/JPEG and optional status bar masking. Retries transient simctl "Timeout waiting for screen surfaces" errors up to 2 times with a short backoff.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -66,9 +129,13 @@ export function registerAppScreenshotNativeTool(server: MCPServer): void {
           }
         }
 
-        await simctl.exec(['io', deviceId, 'screenshot', `--type=${format}`, tmpFile], {
-          timeout: 15000,
-        });
+        const { retries } = await captureWithRetry(simctl, [
+          'io',
+          deviceId,
+          'screenshot',
+          `--type=${format}`,
+          tmpFile,
+        ]);
 
         const buffer = await fs.readFile(tmpFile);
         const base64Data = buffer.toString('base64');
@@ -92,13 +159,20 @@ export function registerAppScreenshotNativeTool(server: MCPServer): void {
                 format,
                 mask: mask ?? 'none',
                 capturedAt: new Date().toISOString(),
+                retries,
               }),
             },
           ],
         };
       } catch (err) {
+        const raw = (err as Error).message ?? String(err);
         return {
-          content: [{ type: 'text' as const, text: `Error capturing screenshot: ${(err as Error).message}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error capturing screenshot: ${stripInformationalStderr(raw)}`,
+            },
+          ],
           isError: true,
         };
       } finally {
@@ -107,3 +181,12 @@ export function registerAppScreenshotNativeTool(server: MCPServer): void {
     },
   );
 }
+
+/** @internal — exposed for tests only. */
+export const _internal = {
+  SCREENSHOT_TIMEOUT_MS,
+  SCREENSHOT_MAX_RETRIES,
+  SCREENSHOT_RETRY_DELAY_MS,
+  isTransientScreenshotError,
+  stripInformationalStderr,
+};

--- a/tests/unit/app-screenshot-native.test.ts
+++ b/tests/unit/app-screenshot-native.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for `app_screenshot_native` — retry + stderr filter behavior.
+ *
+ * Covers the fix for issue #651:
+ *   - Retry on transient `Timeout waiting for screen surfaces` simctl errors.
+ *   - Strip informational `Note: No display specified.` line from error output.
+ *   - Surface a clean error when retries are exhausted.
+ */
+
+const readFileMock = jest.fn();
+const unlinkMock = jest.fn();
+
+jest.mock('fs/promises', () => {
+  const actual = jest.requireActual('fs/promises');
+  return {
+    ...actual,
+    readFile: (...args: unknown[]) => readFileMock(...args),
+    unlink: (...args: unknown[]) => unlinkMock(...args),
+  };
+});
+
+const execMock = jest.fn();
+
+jest.mock('../../src/simulator/simctl', () => ({
+  SimctlExecutor: jest.fn().mockImplementation(() => ({
+    exec: execMock,
+  })),
+}));
+
+const listBootedMock = jest.fn();
+jest.mock('../../src/simulator', () => ({
+  SimulatorManager: jest.fn().mockImplementation(() => ({
+    listBooted: listBootedMock,
+  })),
+}));
+
+const getSoleDeviceIdMock = jest.fn();
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: getSoleDeviceIdMock,
+  }),
+}));
+
+jest.mock('../../src/mcp-server', () => ({
+  MCPServer: jest.fn(),
+  getWebKitClient: jest.fn().mockReturnValue(null),
+}));
+
+// Capture the tool handler during registration
+let toolHandler: (sessionId: string, params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+  isError?: boolean;
+}>;
+const registerToolMock = jest.fn((_schema: unknown, handler: unknown) => {
+  toolHandler = handler as typeof toolHandler;
+});
+
+// Import after mocks
+import { registerAppScreenshotNativeTool, _internal } from '../../src/tools/app-screenshot-native';
+
+const DEVICE_ID = 'AAAA-BBBB-CCCC';
+
+describe('app_screenshot_native — retry + stderr filter (issue #651)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listBootedMock.mockResolvedValue([{ udid: DEVICE_ID }]);
+    getSoleDeviceIdMock.mockReturnValue(null);
+    readFileMock.mockResolvedValue(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    unlinkMock.mockResolvedValue(undefined);
+
+    const fakeServer = { registerTool: registerToolMock } as unknown;
+    registerAppScreenshotNativeTool(
+      fakeServer as Parameters<typeof registerAppScreenshotNativeTool>[0],
+    );
+  });
+
+  it('registers tool with correct name', () => {
+    expect(registerToolMock).toHaveBeenCalledTimes(1);
+    const schema = registerToolMock.mock.calls[0][0] as { name: string };
+    expect(schema.name).toBe('app_screenshot_native');
+  });
+
+  it('retries once when simctl emits "Timeout waiting for screen surfaces", then succeeds', async () => {
+    execMock
+      .mockRejectedValueOnce(
+        new Error(
+          'simctl io DEV screenshot --type=png /tmp/x failed: The operation couldn’t be completed. Timeout waiting for screen surfaces',
+        ),
+      )
+      .mockResolvedValueOnce('');
+
+    const result = await toolHandler('s1', { deviceId: DEVICE_ID });
+
+    expect(result.isError).toBeUndefined();
+    expect(execMock).toHaveBeenCalledTimes(2);
+    const meta = JSON.parse(result.content[1].text!);
+    expect(meta.retries).toBe(1);
+    expect(meta.format).toBe('png');
+  }, 15_000);
+
+  it('retries up to SCREENSHOT_MAX_RETRIES then surfaces a clean error', async () => {
+    const transient = new Error(
+      'simctl io DEV screenshot failed: Timeout waiting for screen surfaces',
+    );
+    execMock.mockRejectedValue(transient);
+
+    const result = await toolHandler('s1', { deviceId: DEVICE_ID });
+
+    expect(result.isError).toBe(true);
+    expect(execMock).toHaveBeenCalledTimes(_internal.SCREENSHOT_MAX_RETRIES + 1);
+    expect(result.content[0].text).toContain('Error capturing screenshot:');
+    expect(result.content[0].text).toContain('Timeout waiting for screen surfaces');
+  }, 15_000);
+
+  it('does not retry on non-transient simctl errors', async () => {
+    execMock.mockRejectedValue(
+      new Error('simctl io DEV screenshot failed: Invalid device state: Shutdown'),
+    );
+
+    const result = await toolHandler('s1', { deviceId: DEVICE_ID });
+
+    expect(result.isError).toBe(true);
+    expect(execMock).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toContain('Invalid device state: Shutdown');
+  });
+
+  it('filters informational "Note: No display specified." line from error output', async () => {
+    execMock.mockRejectedValue(
+      new Error(
+        'simctl io DEV screenshot failed: Note: No display specified. Defaulting to display: <uuid> (screenID: 1, name: LCD)\nInvalid device state: Shutdown',
+      ),
+    );
+
+    const result = await toolHandler('s1', { deviceId: DEVICE_ID });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text!;
+    expect(text).toContain('Invalid device state: Shutdown');
+    expect(text).not.toContain('Note: No display specified.');
+  });
+
+  it('succeeds on first attempt without retry when simctl returns OK', async () => {
+    execMock.mockResolvedValue('');
+
+    const result = await toolHandler('s1', { deviceId: DEVICE_ID, format: 'jpeg' });
+
+    expect(result.isError).toBeUndefined();
+    expect(execMock).toHaveBeenCalledTimes(1);
+    const meta = JSON.parse(result.content[1].text!);
+    expect(meta.retries).toBe(0);
+    expect(meta.format).toBe('jpeg');
+  });
+});
+
+describe('stripInformationalStderr', () => {
+  it('removes the Note: No display specified. line', () => {
+    const input =
+      'simctl io DEV screenshot failed: Note: No display specified. Defaulting to display: abc\nTimeout waiting for screen surfaces';
+    const cleaned = _internal.stripInformationalStderr(input);
+    expect(cleaned).not.toContain('Note: No display specified.');
+    expect(cleaned).toContain('Timeout waiting for screen surfaces');
+  });
+
+  it('leaves messages without noise untouched', () => {
+    const input = 'simctl io DEV screenshot failed: Invalid device state: Shutdown';
+    expect(_internal.stripInformationalStderr(input)).toBe(input);
+  });
+});
+
+describe('isTransientScreenshotError', () => {
+  it('matches the documented transient message', () => {
+    expect(_internal.isTransientScreenshotError('Timeout waiting for screen surfaces')).toBe(true);
+    expect(
+      _internal.isTransientScreenshotError(
+        "simctl io DEV screenshot failed: The operation couldn’t be completed. Timeout waiting for screen surfaces",
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects unrelated simctl errors', () => {
+    expect(_internal.isTransientScreenshotError('Invalid device state: Shutdown')).toBe(false);
+    expect(_internal.isTransientScreenshotError('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Retry `simctl io … screenshot` up to 2 times with 1.5s backoff when it emits `Timeout waiting for screen surfaces` — a known-transient error after high-velocity input events while the simulator composites.
- Strip the informational `Note: No display specified.` line from stderr before surfacing it as an error so operators see the actual failure signal.
- Surface a `retries` counter in the response metadata for diagnostics.

Addresses bug #2 from #651.

## Test plan
- [x] `npx jest tests/unit/app-screenshot-native.test.ts` — 10/10 pass
- [x] `npm run build` — green
- [ ] Manual: stress swipe loop (5× `app_swipe_native distance=2500`) + `app_screenshot_native` loop — expect ≥0 absorbed retries (reflected in `retries` metadata), all calls succeed

## Notes for reviewer
- No behavior change on the happy path: a first-attempt success still returns immediately with `retries: 0`.
- Non-transient simctl errors (`Invalid device state: Shutdown`, unknown device UDID, etc.) are not retried.
- Retry budget is deliberately small (2 retries × 1.5s = 3s) so a persistently broken simulator still fails fast rather than hanging the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)