### PR TITLE
feat(ax-bridge): integrate recovery wrapper into app_tree + shared context helper (#643, PR 2/3)

### DIFF
--- a/src/tools/app-tree.ts
+++ b/src/tools/app-tree.ts
@@ -1,5 +1,6 @@
 import { MCPServer } from '../mcp-server';
 import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import { dumpTreeWithRecovery } from '../native/ax-bridge-recovery';
 import { getSessionManager } from '../session-manager';
 import {
   createContextMismatchError,
@@ -54,7 +55,12 @@ export function registerAppTreeTool(server: MCPServer): void {
           }
         } else {
           await ensureSemanticsActive(deviceId, { bundleId });
-          tree = await bridge.dumpTree({ deviceId, maxDepth });
+          const dump = await dumpTreeWithRecovery(bridge, {
+            deviceId,
+            maxDepth,
+            bundleId,
+          });
+          tree = dump.tree;
           meta = {
             requestedBundleId: undefined,
             deviceId: deviceId ?? '',
@@ -62,6 +68,7 @@ export function registerAppTreeTool(server: MCPServer): void {
             heuristics: ['not-requested'],
             activationAttempted: false,
             activationRetries: 0,
+            axBridgeRecovery: dump.recovery,
           };
         }
 

--- a/src/tools/native-app-context.ts
+++ b/src/tools/native-app-context.ts
@@ -1,5 +1,9 @@
 import type { AXNode } from '../native';
 import type { AccessibilityBridge } from '../native/accessibility-bridge';
+import {
+  dumpTreeWithRecovery,
+  type AxBridgeRecoveryReport,
+} from '../native/ax-bridge-recovery';
 import { SimulatorManager } from '../simulator';
 
 export type NativeContextSourceKind =
@@ -15,6 +19,13 @@ export interface NativeContextMeta {
   heuristics: string[];
   activationAttempted: boolean;
   activationRetries: number;
+  /**
+   * Self-healing report from the AX bridge dump (#643). The most recent
+   * invocation wins when the helper performs multiple dumps (activation
+   * retry). Callers that need history should stream per-call reports
+   * directly from `dumpTreeWithRecovery`.
+   */
+  axBridgeRecovery?: AxBridgeRecoveryReport;
 }
 
 interface EnsureTargetContextParams {
@@ -122,7 +133,13 @@ export async function ensureTargetAppContext(
     await manager.activateApp(deviceId, bundleId);
   }
   await ensureSemanticsActive();
-  let tree = await bridge.dumpTree({ deviceId, maxDepth });
+  const firstDump = await dumpTreeWithRecovery(bridge, {
+    deviceId,
+    maxDepth,
+    bundleId,
+  });
+  let tree = firstDump.tree;
+  meta.axBridgeRecovery = firstDump.recovery;
   let classification = classifyNativeContext(tree);
 
   if (bundleId && classification.sourceKind !== 'target-app' && manager) {
@@ -130,7 +147,13 @@ export async function ensureTargetAppContext(
     await sleep(250);
     await manager.activateApp(deviceId, bundleId);
     await ensureSemanticsActive();
-    tree = await bridge.dumpTree({ deviceId, maxDepth });
+    const secondDump = await dumpTreeWithRecovery(bridge, {
+      deviceId,
+      maxDepth,
+      bundleId,
+    });
+    tree = secondDump.tree;
+    meta.axBridgeRecovery = secondDump.recovery;
     classification = classifyNativeContext(tree);
   }
 


### PR DESCRIPTION
## Summary

Second of three stacked PRs for #643. Wires `dumpTreeWithRecovery` (added in #653) into the two strategic dump call sites:

- `src/tools/app-tree.ts` direct-dump branch (when `bundle_id` is omitted).
- `src/tools/native-app-context.ts::ensureTargetAppContext` — the shared helper used by `app_tree` (bundle_id branch), `app_query`, `app_wait_for`, `app_handle_alert`, `app_assert_element`, `app_tap` (verifyContext), `app_tap_element`, and `app_inspect` (via `activateAndClassify`).

Integrating at the shared helper — rather than touching every tool individually — keeps the recovery policy centralised and ensures any future tool that uses `ensureTargetAppContext` / `activateAndClassify` inherits self-healing by default.

## What users see

Each tool's `_meta.context` payload now carries an optional `axBridgeRecovery: AxBridgeRecoveryReport` field:

```json
"_meta": {
  "context": {
    "requestedBundleId": "com.example.app",
    "sourceKind": "target-app",
    "axBridgeRecovery": {
      "attempts": 2,
      "recovered": true,
      "stages": [
        { "attempt": 1, "action": "dump", "outcome": "error", "errorCode": "DEVICE_CONTENT_ROOT_EMPTY" },
        { "attempt": 1, "action": "sleep", "durationMs": 200, "outcome": "ok" },
        { "attempt": 1, "action": "reactivate", "durationMs": 145, "outcome": "ok" },
        { "attempt": 2, "action": "dump", "outcome": "ok" }
      ]
    }
  }
}
```

The trivial happy-path (`attempts: 1`) still emits a minimal one-stage report so downstream consumers never have to branch on its presence.

## Stacking

- Base: `fix/643-ax-bridge-recovery` (PR #653).
- Rebase to `develop` once PR #653 merges.

## Test plan

- [x] `npx jest ax-bridge-recovery app-accessibility-tools app-query-tool app-interaction native-app-context` → **89 pass, 0 fail**.
- [x] `npm run build` succeeds (exit 0).
- [x] `npx tsc --noEmit` clean.
- [ ] Full `npm test`: **4 suites fail** but all are pre-existing on `develop` (`ax-bridge-help`-style tests that spawn the native binary — unrelated to this TS-only change; confirmed by running the same suite on `git stash` of these changes and observing identical failures).

## Follow-up

PR 3/3 adds the end-to-end fixture: a fake ax-bridge binary that fails on the first invocation and succeeds on the second, driven from `tests/integration/ax-bridge-recovery.live.test.ts`.

Refs: #643