### PR TITLE
feat(device-network): NetworkBlocker mechanism abstraction (#640 PR 2/6)

### DIFF
--- a/src/simulator/network-blockers/auto.ts
+++ b/src/simulator/network-blockers/auto.ts
@@ -1,0 +1,86 @@
+/**
+ * AutoBlocker — picks pfctl first (reliable, deterministic) and falls back
+ * to NLC when pfctl is unavailable (no passwordless sudoers rule).
+ *
+ * Selection is lazy: the first `isAvailable()`, `apply()`, or `status()`
+ * call chooses and caches a backend. Subsequent calls route to the same
+ * backend unless `reset()` is called (used by tests).
+ */
+
+import { NetworkBlocker, NetworkBlockerStatus, NetworkBlockerUnavailableError } from './types';
+
+export interface AutoBlockerOptions {
+  /** Ordered list of candidates; the first available one wins. */
+  candidates: NetworkBlocker[];
+}
+
+export class AutoBlocker implements NetworkBlocker {
+  readonly kind = 'pfctl' as const; // placeholder; actual kind is reported by the selected backend via status().detail
+  private readonly candidates: NetworkBlocker[];
+  private selected: NetworkBlocker | null = null;
+
+  constructor(opts: AutoBlockerOptions) {
+    if (!opts.candidates.length) {
+      throw new Error('AutoBlocker requires at least one candidate');
+    }
+    this.candidates = opts.candidates;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await this.select()) !== null;
+  }
+
+  async apply(deviceId: string): Promise<void> {
+    const backend = await this.requireBackend();
+    return backend.apply(deviceId);
+  }
+
+  async revert(deviceId: string): Promise<void> {
+    if (!this.selected) {
+      // Nothing to revert — caller asked for a revert before any apply.
+      return;
+    }
+    return this.selected.revert(deviceId);
+  }
+
+  async status(): Promise<NetworkBlockerStatus> {
+    if (!this.selected) {
+      return { active: false, activeSince: null, detail: null };
+    }
+    return this.selected.status();
+  }
+
+  /** Return the selected backend's kind, or null if selection has not run yet. */
+  selectedKind(): NetworkBlocker['kind'] | null {
+    return this.selected?.kind ?? null;
+  }
+
+  /** Test-only: clear the cached selection so the next call re-probes. */
+  reset(): void {
+    this.selected = null;
+  }
+
+  private async select(): Promise<NetworkBlocker | null> {
+    if (this.selected) return this.selected;
+    for (const c of this.candidates) {
+      if (await c.isAvailable()) {
+        this.selected = c;
+        return c;
+      }
+    }
+    return null;
+  }
+
+  private async requireBackend(): Promise<NetworkBlocker> {
+    const backend = await this.select();
+    if (!backend) {
+      throw new NetworkBlockerUnavailableError(
+        'pfctl',
+        'no candidate backend is available on this host (tried: ' +
+          this.candidates.map((c) => c.kind).join(', ') +
+          '). Install Network Link Conditioner or configure passwordless pfctl sudo — see docs/tools/device-network.md (PR 5).',
+      );
+    }
+    return backend;
+  }
+}

--- a/src/simulator/network-blockers/host-exec.ts
+++ b/src/simulator/network-blockers/host-exec.ts
@@ -1,0 +1,33 @@
+/**
+ * Production HostExec backed by child_process.execFile.
+ *
+ * Kept isolated from the blocker modules so unit tests can import the
+ * blockers without pulling in any Node child-process code and so tests
+ * can mock the interface with an ordinary object literal.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+import { HostExec, HostExecOptions } from './types';
+
+const execFileAsync = promisify(execFile);
+
+export class RealHostExec implements HostExec {
+  async run(cmd: string, args: string[], options: HostExecOptions = {}): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync(cmd, args, {
+        timeout: options.timeoutMs ?? 10_000,
+        env: options.env ? { ...process.env, ...options.env } : process.env,
+        encoding: 'utf8',
+      });
+      return stdout;
+    } catch (err) {
+      if (options.allowNonZero) {
+        const e = err as Error & { stdout?: string; stderr?: string };
+        return e.stdout ?? '';
+      }
+      throw err;
+    }
+  }
+}

--- a/src/simulator/network-blockers/index.ts
+++ b/src/simulator/network-blockers/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Public surface for the simulator network-blocker layer (issue #640).
+ *
+ * Consumers should import from this module only, so future mechanism
+ * additions don't require call-site churn.
+ */
+
+export { AutoBlocker } from './auto';
+export type { AutoBlockerOptions } from './auto';
+export { NlcBlocker } from './nlc';
+export type { NlcBlockerOptions } from './nlc';
+export { PfctlBlocker, PFCTL_ANCHOR_NAME } from './pfctl';
+export type { PfctlBlockerOptions } from './pfctl';
+export { RealHostExec } from './host-exec';
+export type {
+  HostExec,
+  HostExecOptions,
+  NetworkBlocker,
+  NetworkBlockerKind,
+  NetworkBlockerStatus,
+} from './types';
+export {
+  NetworkBlockerNotImplementedError,
+  NetworkBlockerUnavailableError,
+} from './types';

--- a/src/simulator/network-blockers/nlc.ts
+++ b/src/simulator/network-blockers/nlc.ts
@@ -1,0 +1,76 @@
+/**
+ * NlcBlocker — stub for the Network Link Conditioner fallback. PR 2 only
+ * wires the interface skeleton; real profile activation lands in PR 4.
+ */
+
+import {
+  HostExec,
+  NetworkBlocker,
+  NetworkBlockerNotImplementedError,
+  NetworkBlockerStatus,
+  NetworkBlockerUnavailableError,
+} from './types';
+
+const NLC_PREF_PANE = '/Library/PreferencePanes/Network Link Conditioner.prefPane';
+
+export interface NlcBlockerOptions {
+  exec: HostExec;
+  /** Force availability answer for tests. */
+  assumeAvailable?: boolean;
+  /** Override the path we probe for NLC installation. */
+  prefPanePath?: string;
+}
+
+export class NlcBlocker implements NetworkBlocker {
+  readonly kind = 'nlc' as const;
+  private readonly exec: HostExec;
+  private readonly assumeAvailable?: boolean;
+  private readonly prefPanePath: string;
+  private active = false;
+  private activeSince: string | null = null;
+
+  constructor(opts: NlcBlockerOptions) {
+    this.exec = opts.exec;
+    this.assumeAvailable = opts.assumeAvailable;
+    this.prefPanePath = opts.prefPanePath ?? NLC_PREF_PANE;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    if (this.assumeAvailable !== undefined) return this.assumeAvailable;
+    try {
+      await this.exec.run('/bin/test', ['-d', this.prefPanePath], { timeoutMs: 1000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async apply(_deviceId: string): Promise<void> {
+    if (!(await this.isAvailable())) {
+      throw new NetworkBlockerUnavailableError(
+        'nlc',
+        `Network Link Conditioner is not installed at ${this.prefPanePath}; install via Xcode's "Additional Tools for Xcode" package`,
+      );
+    }
+    if (this.active) return;
+    throw new NetworkBlockerNotImplementedError('nlc', 'apply');
+  }
+
+  async revert(_deviceId: string): Promise<void> {
+    if (!this.active) return;
+    throw new NetworkBlockerNotImplementedError('nlc', 'revert');
+  }
+
+  async status(): Promise<NetworkBlockerStatus> {
+    return {
+      active: this.active,
+      activeSince: this.activeSince,
+      detail: this.active ? 'Network Link Conditioner profile "100% Loss"' : null,
+    };
+  }
+
+  __setActiveForTests(active: boolean, sinceIso: string | null = null): void {
+    this.active = active;
+    this.activeSince = active ? sinceIso ?? new Date().toISOString() : null;
+  }
+}

--- a/src/simulator/network-blockers/pfctl.ts
+++ b/src/simulator/network-blockers/pfctl.ts
@@ -1,0 +1,88 @@
+/**
+ * PfctlBlocker — stub that will install/remove a dedicated `pf` anchor to
+ * block simulator-bound traffic at the host level. Issue #640, PR 2 only
+ * wires the interface and an in-memory state machine; the real anchor
+ * rules land in PR 3.
+ */
+
+import {
+  HostExec,
+  NetworkBlocker,
+  NetworkBlockerNotImplementedError,
+  NetworkBlockerStatus,
+  NetworkBlockerUnavailableError,
+} from './types';
+
+export const PFCTL_ANCHOR_NAME = 'opensafari-simdevnet';
+
+export interface PfctlBlockerOptions {
+  exec: HostExec;
+  /**
+   * When true, `isAvailable()` resolves true without probing (used by tests).
+   * In production, availability is decided by whether `sudo -n pfctl -sr`
+   * succeeds without a password prompt.
+   */
+  assumeAvailable?: boolean;
+  /** Override anchor name for tests. */
+  anchorName?: string;
+}
+
+export class PfctlBlocker implements NetworkBlocker {
+  readonly kind = 'pfctl' as const;
+  private readonly exec: HostExec;
+  private readonly assumeAvailable: boolean;
+  private readonly anchor: string;
+  private active = false;
+  private activeSince: string | null = null;
+
+  constructor(opts: PfctlBlockerOptions) {
+    this.exec = opts.exec;
+    this.assumeAvailable = opts.assumeAvailable === true;
+    this.anchor = opts.anchorName ?? PFCTL_ANCHOR_NAME;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    if (this.assumeAvailable) return true;
+    try {
+      await this.exec.run('/usr/bin/sudo', ['-n', '/sbin/pfctl', '-sr'], {
+        timeoutMs: 2000,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async apply(_deviceId: string): Promise<void> {
+    if (!(await this.isAvailable())) {
+      throw new NetworkBlockerUnavailableError(
+        'pfctl',
+        'sudo pfctl requires a passwordless sudoers rule; see docs/tools/device-network.md (pending PR 5)',
+      );
+    }
+    if (this.active) return; // idempotent
+    // Real anchor install lands in PR 3.
+    // For PR 2 we deliberately raise NotImplemented so CI surfaces the
+    // missing backend rather than silently "blocking" traffic.
+    throw new NetworkBlockerNotImplementedError('pfctl', 'apply');
+  }
+
+  async revert(_deviceId: string): Promise<void> {
+    if (!this.active) return; // idempotent
+    throw new NetworkBlockerNotImplementedError('pfctl', 'revert');
+  }
+
+  async status(): Promise<NetworkBlockerStatus> {
+    return {
+      active: this.active,
+      activeSince: this.activeSince,
+      detail: this.active ? `pf anchor ${this.anchor}` : null,
+    };
+  }
+
+  /** Test-only helper to inject state without going through apply(). */
+  __setActiveForTests(active: boolean, sinceIso: string | null = null): void {
+    this.active = active;
+    this.activeSince = active ? sinceIso ?? new Date().toISOString() : null;
+  }
+}

--- a/src/simulator/network-blockers/types.ts
+++ b/src/simulator/network-blockers/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared types for the simulator-level network blocking layer (issue #640).
+ *
+ * Each concrete backend (pfctl, Network Link Conditioner, …) implements
+ * {@link NetworkBlocker}. The `device_network_set` / `device_network_get`
+ * tools consume blockers through this interface only — they do not know
+ * which mechanism is in use, so selection logic lives in `AutoBlocker`.
+ *
+ * This file is PR 2 (#640) and is intentionally side-effect-free:
+ * concrete blockers accept an injectable {@link HostExec} so unit tests
+ * can drive them with mocks. Real system calls land in PRs 3 / 4.
+ */
+
+export type NetworkBlockerKind = 'pfctl' | 'nlc';
+
+export interface NetworkBlockerStatus {
+  /** Whether this blocker currently has a rule installed. */
+  active: boolean;
+  /** ISO-8601 timestamp of the last successful `apply`, or null. */
+  activeSince: string | null;
+  /** Opaque detail string for diagnostics (e.g. anchor name, NLC profile). */
+  detail: string | null;
+}
+
+export interface NetworkBlocker {
+  readonly kind: NetworkBlockerKind;
+
+  /**
+   * Returns true if this mechanism is usable in the current environment.
+   * Must not mutate system state. Implementations decide how to probe
+   * (e.g. pfctl checks sudoers, nlc checks for installed preference pane).
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Install a block rule. Must be idempotent: calling `apply` twice in
+   * a row is a no-op and must not accumulate rules.
+   *
+   * @param deviceId simulator UDID the block is associated with (the
+   *   current mechanisms are host-wide, but the UDID is recorded for
+   *   diagnostics and future per-device backends).
+   */
+  apply(deviceId: string): Promise<void>;
+
+  /**
+   * Remove the rule installed by `apply`. Must be idempotent:
+   * calling `revert` with no rule present must succeed silently.
+   */
+  revert(deviceId: string): Promise<void>;
+
+  /** Return the current blocker state for diagnostics / `device_network_get`. */
+  status(): Promise<NetworkBlockerStatus>;
+}
+
+/**
+ * Minimal shell-exec surface injected into blockers for testability.
+ * Production code wires this to `child_process.execFile`; tests pass a mock.
+ */
+export interface HostExec {
+  /**
+   * Run a program with args and return stdout. Must reject with an Error
+   * whose `.stderr` / `.code` fields match Node's child_process shape on
+   * non-zero exit, so blockers can pattern-match on the cause.
+   */
+  run(cmd: string, args: string[], options?: HostExecOptions): Promise<string>;
+}
+
+export interface HostExecOptions {
+  timeoutMs?: number;
+  env?: Record<string, string>;
+  /** If true, non-zero exit is returned as {stdout, code, stderr} instead of throwing. */
+  allowNonZero?: boolean;
+}
+
+export class NetworkBlockerUnavailableError extends Error {
+  constructor(kind: NetworkBlockerKind, reason: string) {
+    super(`network blocker "${kind}" is unavailable: ${reason}`);
+    this.name = 'NetworkBlockerUnavailableError';
+  }
+}
+
+export class NetworkBlockerNotImplementedError extends Error {
+  constructor(kind: NetworkBlockerKind, op: 'apply' | 'revert') {
+    super(
+      `network blocker "${kind}" ${op}() is not wired yet — tracked in issue #640 (PR ${kind === 'pfctl' ? '3' : '4'})`,
+    );
+    this.name = 'NetworkBlockerNotImplementedError';
+  }
+}

--- a/tests/unit/network-blockers.test.ts
+++ b/tests/unit/network-blockers.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the simulator network-blocker abstraction layer
+ * (issue #640, PR 2). No real system calls — all exec is mocked.
+ */
+
+import {
+  AutoBlocker,
+  HostExec,
+  NetworkBlocker,
+  NetworkBlockerNotImplementedError,
+  NetworkBlockerUnavailableError,
+  NlcBlocker,
+  PFCTL_ANCHOR_NAME,
+  PfctlBlocker,
+} from '../../src/simulator/network-blockers';
+
+function makeMockExec(): jest.Mocked<HostExec> {
+  return { run: jest.fn().mockResolvedValue('') };
+}
+
+const DEVICE_ID = 'test-device-udid';
+
+describe('PfctlBlocker', () => {
+  it('reports kind "pfctl"', () => {
+    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true });
+    expect(b.kind).toBe('pfctl');
+  });
+
+  it('isAvailable returns true when sudo pfctl -sr succeeds', async () => {
+    const exec = makeMockExec();
+    exec.run.mockResolvedValueOnce('scrub in all');
+    const b = new PfctlBlocker({ exec });
+    await expect(b.isAvailable()).resolves.toBe(true);
+    expect(exec.run).toHaveBeenCalledWith(
+      '/usr/bin/sudo',
+      ['-n', '/sbin/pfctl', '-sr'],
+      expect.objectContaining({ timeoutMs: 2000 }),
+    );
+  });
+
+  it('isAvailable returns false when sudo pfctl fails', async () => {
+    const exec = makeMockExec();
+    exec.run.mockRejectedValueOnce(new Error('sudo: a password is required'));
+    const b = new PfctlBlocker({ exec });
+    await expect(b.isAvailable()).resolves.toBe(false);
+  });
+
+  it('assumeAvailable bypasses probing', async () => {
+    const exec = makeMockExec();
+    const b = new PfctlBlocker({ exec, assumeAvailable: true });
+    await expect(b.isAvailable()).resolves.toBe(true);
+    expect(exec.run).not.toHaveBeenCalled();
+  });
+
+  it('apply throws NetworkBlockerUnavailableError when mechanism is unavailable', async () => {
+    const exec = makeMockExec();
+    exec.run.mockRejectedValueOnce(new Error('sudo required'));
+    const b = new PfctlBlocker({ exec });
+    await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerUnavailableError);
+  });
+
+  it('apply throws NotImplemented in scaffold PR 2 even when available', async () => {
+    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true });
+    await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerNotImplementedError);
+  });
+
+  it('apply is idempotent when already active (no throw, no exec call)', async () => {
+    const exec = makeMockExec();
+    const b = new PfctlBlocker({ exec, assumeAvailable: true });
+    b.__setActiveForTests(true);
+    await expect(b.apply(DEVICE_ID)).resolves.toBeUndefined();
+    expect(exec.run).not.toHaveBeenCalled();
+  });
+
+  it('revert is a no-op when nothing is active', async () => {
+    const exec = makeMockExec();
+    const b = new PfctlBlocker({ exec, assumeAvailable: true });
+    await expect(b.revert(DEVICE_ID)).resolves.toBeUndefined();
+    expect(exec.run).not.toHaveBeenCalled();
+  });
+
+  it('revert throws NotImplemented when active (scaffold)', async () => {
+    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true });
+    b.__setActiveForTests(true);
+    await expect(b.revert(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerNotImplementedError);
+  });
+
+  it('status reports active+detail when active, inactive otherwise', async () => {
+    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true });
+    await expect(b.status()).resolves.toEqual({ active: false, activeSince: null, detail: null });
+    b.__setActiveForTests(true, '2026-04-23T00:00:00.000Z');
+    await expect(b.status()).resolves.toEqual({
+      active: true,
+      activeSince: '2026-04-23T00:00:00.000Z',
+      detail: `pf anchor ${PFCTL_ANCHOR_NAME}`,
+    });
+  });
+
+  it('anchorName option overrides the default anchor', async () => {
+    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true, anchorName: 'custom' });
+    b.__setActiveForTests(true);
+    const s = await b.status();
+    expect(s.detail).toBe('pf anchor custom');
+  });
+});
+
+describe('NlcBlocker', () => {
+  it('reports kind "nlc"', () => {
+    const b = new NlcBlocker({ exec: makeMockExec(), assumeAvailable: true });
+    expect(b.kind).toBe('nlc');
+  });
+
+  it('isAvailable true when /bin/test -d succeeds', async () => {
+    const exec = makeMockExec();
+    exec.run.mockResolvedValueOnce('');
+    const b = new NlcBlocker({ exec, prefPanePath: '/tmp/fake.prefPane' });
+    await expect(b.isAvailable()).resolves.toBe(true);
+    expect(exec.run).toHaveBeenCalledWith(
+      '/bin/test',
+      ['-d', '/tmp/fake.prefPane'],
+      expect.objectContaining({ timeoutMs: 1000 }),
+    );
+  });
+
+  it('isAvailable false when /bin/test -d fails', async () => {
+    const exec = makeMockExec();
+    exec.run.mockRejectedValueOnce(new Error('no such directory'));
+    const b = new NlcBlocker({ exec });
+    await expect(b.isAvailable()).resolves.toBe(false);
+  });
+
+  it('assumeAvailable=false short-circuits probing to false', async () => {
+    const exec = makeMockExec();
+    const b = new NlcBlocker({ exec, assumeAvailable: false });
+    await expect(b.isAvailable()).resolves.toBe(false);
+    expect(exec.run).not.toHaveBeenCalled();
+  });
+
+  it('apply throws NetworkBlockerUnavailableError when NLC is missing', async () => {
+    const b = new NlcBlocker({ exec: makeMockExec(), assumeAvailable: false });
+    await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerUnavailableError);
+  });
+
+  it('apply throws NotImplemented when NLC is available (scaffold)', async () => {
+    const b = new NlcBlocker({ exec: makeMockExec(), assumeAvailable: true });
+    await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerNotImplementedError);
+  });
+
+  it('status surfaces the NLC profile name when active', async () => {
+    const b = new NlcBlocker({ exec: makeMockExec(), assumeAvailable: true });
+    b.__setActiveForTests(true);
+    const s = await b.status();
+    expect(s.detail).toMatch(/100% Loss/);
+    expect(s.active).toBe(true);
+  });
+});
+
+describe('AutoBlocker selection order', () => {
+  function makeBackend(kind: 'pfctl' | 'nlc', available: boolean): NetworkBlocker {
+    return {
+      kind,
+      isAvailable: jest.fn().mockResolvedValue(available),
+      apply: jest.fn().mockResolvedValue(undefined),
+      revert: jest.fn().mockResolvedValue(undefined),
+      status: jest.fn().mockResolvedValue({ active: false, activeSince: null, detail: kind }),
+    };
+  }
+
+  it('throws when no candidates provided', () => {
+    expect(() => new AutoBlocker({ candidates: [] })).toThrow(/at least one candidate/);
+  });
+
+  it('picks the first available candidate (pfctl first)', async () => {
+    const pfctl = makeBackend('pfctl', true);
+    const nlc = makeBackend('nlc', true);
+    const auto = new AutoBlocker({ candidates: [pfctl, nlc] });
+    await auto.isAvailable();
+    expect(auto.selectedKind()).toBe('pfctl');
+    // nlc was never probed once pfctl said yes
+    expect((nlc.isAvailable as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('falls back to NLC when pfctl is unavailable', async () => {
+    const pfctl = makeBackend('pfctl', false);
+    const nlc = makeBackend('nlc', true);
+    const auto = new AutoBlocker({ candidates: [pfctl, nlc] });
+    await auto.isAvailable();
+    expect(auto.selectedKind()).toBe('nlc');
+  });
+
+  it('reports unavailable and throws on apply when every candidate is unavailable', async () => {
+    const pfctl = makeBackend('pfctl', false);
+    const nlc = makeBackend('nlc', false);
+    const auto = new AutoBlocker({ candidates: [pfctl, nlc] });
+    await expect(auto.isAvailable()).resolves.toBe(false);
+    await expect(auto.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerUnavailableError);
+  });
+
+  it('caches the selected backend across calls', async () => {
+    const pfctl = makeBackend('pfctl', true);
+    const nlc = makeBackend('nlc', true);
+    const auto = new AutoBlocker({ candidates: [pfctl, nlc] });
+    await auto.isAvailable();
+    await auto.status();
+    await auto.apply(DEVICE_ID);
+    expect((pfctl.isAvailable as jest.Mock).mock.calls.length).toBe(1);
+    expect(pfctl.apply).toHaveBeenCalledWith(DEVICE_ID);
+  });
+
+  it('reset() clears the cached selection so the next call re-probes', async () => {
+    const pfctl = makeBackend('pfctl', true);
+    const auto = new AutoBlocker({ candidates: [pfctl] });
+    await auto.isAvailable();
+    expect((pfctl.isAvailable as jest.Mock).mock.calls.length).toBe(1);
+    auto.reset();
+    await auto.isAvailable();
+    expect((pfctl.isAvailable as jest.Mock).mock.calls.length).toBe(2);
+  });
+
+  it('revert is a no-op when no backend was ever selected (no apply yet)', async () => {
+    const pfctl = makeBackend('pfctl', true);
+    const auto = new AutoBlocker({ candidates: [pfctl] });
+    await expect(auto.revert(DEVICE_ID)).resolves.toBeUndefined();
+    expect(pfctl.revert).not.toHaveBeenCalled();
+  });
+
+  it('revert delegates to the selected backend after apply', async () => {
+    const pfctl = makeBackend('pfctl', true);
+    const auto = new AutoBlocker({ candidates: [pfctl] });
+    await auto.apply(DEVICE_ID);
+    await auto.revert(DEVICE_ID);
+    expect(pfctl.revert).toHaveBeenCalledWith(DEVICE_ID);
+  });
+
+  it('status returns inactive before any selection', async () => {
+    const pfctl = makeBackend('pfctl', true);
+    const auto = new AutoBlocker({ candidates: [pfctl] });
+    await expect(auto.status()).resolves.toEqual({
+      active: false,
+      activeSince: null,
+      detail: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/simulator/network-blockers/` — a small abstraction that future PRs drop real host-level network blocking into without touching the `device_network_set` / `device_network_get` tool scaffold from #656.
- Ships three concrete backends (`PfctlBlocker`, `NlcBlocker`, `AutoBlocker`) as **stubs** that raise `NetworkBlockerNotImplementedError` on `apply` / `revert`. The intent is to surface the missing backend in CI rather than silently no-op.
- **Pure TypeScript**, no real system calls — all exec goes through an injectable `HostExec` interface that tests replace with `jest.fn()` mocks.
- 27 new unit tests, all green. No behavior change for existing tools.

## Why this PR is independently valuable

1. It freezes the interface the `device_network_set` tool will consume, so PR 3 and PR 4 can be reviewed as pure backend implementations without any abstraction bikeshedding.
2. `AutoBlocker`'s selection order (pfctl first → NLC fallback) is locked in and tested here, so PR 3 / PR 4 authors inherit the policy rather than rediscovering it.
3. The `HostExec` seam proves the design is unit-testable end-to-end, which is critical because real pfctl / NLC calls require sudo / extra hardware and cannot be exercised in ordinary CI.

## File map

| Path | Role |
|---|---|
| `src/simulator/network-blockers/types.ts` | `NetworkBlocker` interface, `NetworkBlockerStatus`, `HostExec`, and the two typed error classes. |
| `src/simulator/network-blockers/pfctl.ts` | `PfctlBlocker` stub. `isAvailable()` probes `sudo -n pfctl -sr`. Reserves anchor name `opensafari-simdevnet`. `apply`/`revert` throw `NotImplemented` pending PR 3. |
| `src/simulator/network-blockers/nlc.ts` | `NlcBlocker` stub. `isAvailable()` probes for the Network Link Conditioner .prefPane. `apply`/`revert` throw `NotImplemented` pending PR 4. |
| `src/simulator/network-blockers/auto.ts` | `AutoBlocker` — lazy, cached candidate selection; `reset()` for tests. |
| `src/simulator/network-blockers/host-exec.ts` | `RealHostExec` production adapter around `child_process.execFile`. |
| `src/simulator/network-blockers/index.ts` | Public surface. Consumers should import from this module only. |
| `tests/unit/network-blockers.test.ts` | 27 cases covering kind reporting, availability probing, idempotence, error types, status transitions, and `AutoBlocker` selection / caching / reset / revert-before-apply. |

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit` — clean.
- [x] `npx jest tests/unit/network-blockers.test.ts` — 27 passed, 27 total.
- [x] `npx jest tests/unit/` — 1944 passed / 10 failed, all failures pre-existing in `tests/unit/ax-bridge-help.test.ts` (native Swift binary executed under `node`; reproduces on `main` and PR 1's branch). No regressions introduced by this PR.
- [ ] CI green on this PR.

## Stacking

Base is `feat/640-device-network-pr1-scaffold` (PR #656) to keep the review diff limited to PR 2's delta. After #656 merges, re-target to `develop`.

## Follow-up PRs (tracked in #640)

- **PR 3** — real `pfctl` mechanism + crash-safe cleanup + sudoers docs.
- **PR 4** — Network Link Conditioner fallback.
- **PR 5** — docs + Omofictions#31 S27 integration example.
- **PR 6** *(optional)* — reusable Flutter fixture app.

Closes: part of #640 (abstraction layer). Full close on PR 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)