### PR TITLE
fix(pasteboard): verify paste applied and surface PASTE_NOT_APPLIED (#639 Problem 3)

### DIFF
--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -19,7 +19,7 @@ import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import type { AXNode, AXQuery } from '../native';
 import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 import { tryPress } from './app-tap-element';
-import { typeViaPasteboard } from './pasteboard-input';
+import { typeViaPasteboard, type PasteNotAppliedError } from './pasteboard-input';
 
 const execFileAsync = promisify(execFile);
 
@@ -242,10 +242,37 @@ export function registerAppTypeElementTool(server: MCPServer): void {
           const autoAcceptPastePermission =
             (params.autoAcceptPastePermission as boolean | undefined) ?? true;
 
-          const pasteResult = await typeViaPasteboard(deviceId, textToType, {
-            restorePasteboard,
-            autoAcceptPastePermission,
-          });
+          let pasteResult;
+          try {
+            pasteResult = await typeViaPasteboard(deviceId, textToType, {
+              restorePasteboard,
+              autoAcceptPastePermission,
+              expected: textToType,
+              focusedElementPath: match.path,
+            });
+          } catch (err) {
+            if (err instanceof Error && (err as unknown as PasteNotAppliedError).code === 'PASTE_NOT_APPLIED') {
+              const e = err as unknown as PasteNotAppliedError;
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: JSON.stringify({
+                      error: 'PASTE_NOT_APPLIED',
+                      code: e.code,
+                      expected: e.expected,
+                      actual: e.actual,
+                      permissionDialogObserved: e.permissionDialogObserved,
+                      element: elementDescriptor,
+                      deviceId,
+                    }),
+                  },
+                ],
+                isError: true,
+              };
+            }
+            throw err;
+          }
 
           return {
             content: [

--- a/src/tools/pasteboard-input.ts
+++ b/src/tools/pasteboard-input.ts
@@ -79,6 +79,44 @@ export type PermissionDialogOutcome =
   | 'auto_accepted'
   | 'not_accepted';
 
+export interface PasteNotAppliedError {
+  code: 'PASTE_NOT_APPLIED';
+  expected: string;
+  actual: string | undefined;
+  permissionDialogObserved: boolean;
+}
+
+/**
+ * Compares the post-paste AX value against the expected payload and throws a
+ * structured `PASTE_NOT_APPLIED` error when the paste did not land. Pure
+ * function so the readback contract can be unit-tested without mocking the
+ * accessibility bridge or the simulator pasteboard.
+ *
+ * The "applied" predicate accepts either an exact suffix match or a substring
+ * match because some text fields prepend placeholder text to the value, and
+ * IME composition state can leave the cursor mid-string.
+ *
+ * `actual === undefined` (bridge readback failed) is treated as inconclusive
+ * and does NOT throw — we cannot distinguish "paste failed" from "bridge
+ * unavailable" in that case.
+ */
+export function assertPasteApplied(
+  actual: string | undefined,
+  expected: string,
+  permissionDialogObserved: boolean,
+): void {
+  if (actual === undefined || actual === null) return;
+  const applied = actual.endsWith(expected) || actual.includes(expected);
+  if (applied) return;
+  const err: PasteNotAppliedError = {
+    code: 'PASTE_NOT_APPLIED',
+    expected,
+    actual,
+    permissionDialogObserved,
+  };
+  throw Object.assign(new Error('PASTE_NOT_APPLIED'), err);
+}
+
 export interface PasteboardTypeResult {
   backend: 'pasteboard';
   length: number;
@@ -101,6 +139,18 @@ export interface PasteboardTypeOptions {
   permissionDialogPollMs?: number;
   /** Injected backend (for tests). Default: auto-resolve via `tryCreateSimulatorKitHIDBackend`. */
   backend?: SimulatorKitHIDInputBackend;
+  /**
+   * The text that was placed on the pasteboard. When provided, `typeViaPasteboard`
+   * reads back the focused element's AX value after `pasteSettleMs` and returns a
+   * structured `PasteNotAppliedError` if the field does not contain the expected
+   * text. Omit to skip verification (legacy behaviour).
+   */
+  expected?: string;
+  /**
+   * AX path of the focused element. Required for readback verification; ignored
+   * when `expected` is not set.
+   */
+  focusedElementPath?: string;
 }
 
 /**
@@ -143,6 +193,7 @@ export async function typeViaPasteboard(
 
   let permissionDialog: PermissionDialogOutcome = 'not_shown';
   let permissionDialogMatchedLabel: string | undefined;
+  let permissionDialogObserved = false;
   if (autoAcceptPermission) {
     const match = await pollForPermissionDialog(
       deviceId,
@@ -150,6 +201,7 @@ export async function typeViaPasteboard(
       permissionDialogPollMs,
     );
     if (match) {
+      permissionDialogObserved = true;
       const pressed = await tryPressPermissionButton(deviceId, match.path);
       permissionDialog = pressed ? 'auto_accepted' : 'not_accepted';
       permissionDialogMatchedLabel = match.label;
@@ -164,6 +216,22 @@ export async function typeViaPasteboard(
     } catch {
       pasteboardRestored = false;
     }
+  }
+
+  // Readback verification: if the caller supplied the expected payload and an
+  // element path, re-read the AX value and confirm the paste landed.
+  const { expected, focusedElementPath } = options;
+  if (expected !== undefined && focusedElementPath) {
+    const bridge = getAccessibilityBridge();
+    let actual: string | undefined;
+    try {
+      const node = await bridge.inspect(focusedElementPath, deviceId);
+      actual = node.value;
+    } catch {
+      // Bridge error — treat as unknown; do not surface PASTE_NOT_APPLIED
+      // because we cannot distinguish "paste failed" from "bridge unavailable".
+    }
+    assertPasteApplied(actual, expected, permissionDialogObserved);
   }
 
   return {

--- a/tests/unit/pasteboard-input.test.ts
+++ b/tests/unit/pasteboard-input.test.ts
@@ -1,0 +1,58 @@
+import {
+  assertPasteApplied,
+  type PasteNotAppliedError,
+} from '../../src/tools/pasteboard-input';
+
+describe('assertPasteApplied (issue #639 Problem 3 — readback contract)', () => {
+  test('returns silently when actual === expected', () => {
+    expect(() =>
+      assertPasteApplied('qa@example.com', 'qa@example.com', false),
+    ).not.toThrow();
+  });
+
+  test('returns silently when actual ends with expected (placeholder + paste)', () => {
+    expect(() =>
+      assertPasteApplied('Email: qa@example.com', 'qa@example.com', true),
+    ).not.toThrow();
+  });
+
+  test('returns silently when actual contains expected (cursor mid-string)', () => {
+    expect(() =>
+      assertPasteApplied('foo qa@example.com bar', 'qa@example.com', false),
+    ).not.toThrow();
+  });
+
+  test('returns silently when actual is undefined (bridge readback failed)', () => {
+    // We cannot distinguish "paste failed" from "bridge unavailable" — must not
+    // surface PASTE_NOT_APPLIED in that case.
+    expect(() =>
+      assertPasteApplied(undefined, 'qa@example.com', false),
+    ).not.toThrow();
+  });
+
+  test('throws PASTE_NOT_APPLIED with empty actual after Cmd+V', () => {
+    let caught: PasteNotAppliedError | undefined;
+    try {
+      assertPasteApplied('', 'qa@example.com', false);
+    } catch (err) {
+      caught = err as PasteNotAppliedError;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.code).toBe('PASTE_NOT_APPLIED');
+    expect(caught?.expected).toBe('qa@example.com');
+    expect(caught?.actual).toBe('');
+    expect(caught?.permissionDialogObserved).toBe(false);
+  });
+
+  test('throws PASTE_NOT_APPLIED with divergent actual; preserves permissionDialogObserved=true', () => {
+    let caught: PasteNotAppliedError | undefined;
+    try {
+      assertPasteApplied('different value', 'qa@example.com', true);
+    } catch (err) {
+      caught = err as PasteNotAppliedError;
+    }
+    expect(caught?.code).toBe('PASTE_NOT_APPLIED');
+    expect(caught?.actual).toBe('different value');
+    expect(caught?.permissionDialogObserved).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Verifies that `Cmd+V` paste actually landed in the focused field, and surfaces a structured `PASTE_NOT_APPLIED` error when it did not. Closes part 3 of #639.

## Why
Issue #639 Problem 3: the pasteboard helper previously treated an absent paste-permission dialog as success, so when iOS silently rejected the paste, callers got `permissionDialog: 'not_shown'` and a 200 result while the field was empty. This made paste useless as an escape hatch for the IME-reinterpretation problem (Problem 1).

## Changes
- `src/tools/pasteboard-input.ts`
  - New `typeViaPasteboard` options: `expected` and `focusedElementPath`. When both are set, the focused element's AX value is read after `pasteSettleMs` and compared to the expected payload.
  - New exported `assertPasteApplied(actual, expected, permissionDialogObserved)` — pure helper that throws a structured `{ code: "PASTE_NOT_APPLIED", expected, actual, permissionDialogObserved }` on mismatch. Bridge readback failure (`actual === undefined`) is inconclusive and does **not** throw.
- `src/tools/app-type-element.ts`
  - Pasteboard backend now plumbs the expected payload and focused element path into the verifier and surfaces the structured error via the existing tool error envelope (`isError: true`).
- `tests/unit/pasteboard-input.test.ts`
  - 6 new tests covering exact, suffix, substring, undefined, empty-actual, and divergent-actual readback cases.

## Tests
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx jest tests/unit/pasteboard-input.test.ts` — 6/6 pass.
- Full `tests/unit` suite: only `ax-bridge-help.test.ts` fails (pre-existing on `develop` — Swift binary not built locally; unrelated to this change).

## Acceptance (from #639 Problem 3)
- [x] After `pasteSettleMs`, the focused element value is compared to the expected payload.
- [x] On readback failure, returns structured `{ code: "PASTE_NOT_APPLIED", expected, actual, permissionDialogObserved }`.
- [x] Bridge errors are not surfaced as `PASTE_NOT_APPLIED` (inconclusive).
- [x] `expected` is plumbed into the verifier from the existing `app-type-element` pasteboard backend caller.
- [ ] Permission-button label corpus expansion: existing corpus (en/ko/ja/zh-Hans accept + dismiss) was reviewed and judged adequate. Deferred — only add labels with concrete evidence to avoid corpus pollution.

## Backward compatibility
Purely additive. When `expected` and `focusedElementPath` are not provided, behaviour is unchanged. Existing successful paths keep working.

Refs #639 (Problem 3).