### PR TITLE
feat(app-type-element): perKeyDelayMs for segmented OTP-style fields (#639 Problem 2)

### DIFF
--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -118,6 +118,11 @@ export function registerAppTypeElementTool(server: MCPServer): void {
             description:
               'Opt out of post-typing readback verification (default: true). When false the tool reports `verified: "unknown"` without reading back the AX value.',
           },
+          perKeyDelayMs: {
+            type: 'number',
+            description:
+              'When backend resolves to simhid (HID keyboard): inserts an inter-character pause between consecutive key sends. Default 0 (no pause). Required for segmented OTP-style fields (e.g. 6-cell verify-code inputs in Flutter) that drop characters when keys arrive faster than the field can advance focus. Recommended: 80–150 ms for 6-digit OTP inputs.',
+          },
         },
         required: ['text'],
       },
@@ -150,6 +155,13 @@ export function registerAppTypeElementTool(server: MCPServer): void {
         const focusDelay = (params.focusDelay as number | undefined) ?? DEFAULT_FOCUS_DELAY_MS;
         const verifyOptIn =
           typeof params.verify === 'boolean' ? (params.verify as boolean) : true;
+        const perKeyDelayMsRaw = params.perKeyDelayMs;
+        const perKeyDelayMs =
+          typeof perKeyDelayMsRaw === 'number' &&
+          Number.isFinite(perKeyDelayMsRaw) &&
+          perKeyDelayMsRaw > 0
+            ? perKeyDelayMsRaw
+            : 0;
 
         await ensureSemanticsActive(deviceId);
 
@@ -277,7 +289,7 @@ export function registerAppTypeElementTool(server: MCPServer): void {
           if (focusDelay > 0) {
             await sleep(focusDelay);
           }
-          await backend.typeText(deviceId, textToType);
+          await backend.typeText(deviceId, textToType, perKeyDelayMs);
         });
 
         // Tier-3 readback verification (issue #39). We only run the readback

--- a/src/tools/native-input-backend.ts
+++ b/src/tools/native-input-backend.ts
@@ -67,7 +67,17 @@ export interface InputBackend {
     endY: number,
     duration?: number,
   ): Promise<void>;
-  typeText(deviceId: string, text: string): Promise<void>;
+  /**
+   * Type `text` into whatever is currently focused on `deviceId`.
+   *
+   * `delayMs` is an optional inter-character pause between consecutive key
+   * sends, in milliseconds. Only the simhid backend honours it (other
+   * backends bypass the software keyboard and have no equivalent failure
+   * mode); they may safely ignore the argument. Required for segmented
+   * OTP-style fields that drop characters when keys arrive too fast (issue
+   * #639 Problem 2). Default 0 (no pause).
+   */
+  typeText(deviceId: string, text: string, delayMs?: number): Promise<void>;
   keypress(deviceId: string, keyCode: string): Promise<void>;
   sendKey(deviceId: string, keyName: string): Promise<void>;
 }

--- a/src/tools/sim-hid-input-backend.ts
+++ b/src/tools/sim-hid-input-backend.ts
@@ -211,7 +211,7 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
     });
   }
 
-  async typeText(deviceId: string, text: string): Promise<void> {
+  async typeText(deviceId: string, text: string, delayMs = 0): Promise<void> {
     await timedInput(this.kind, 'typeText', deviceId, async () => {
       // Printable US-ASCII only. Each character is mapped to a US-keyboard
       // HID usage and sent as an independent event. Shifted characters
@@ -220,6 +220,12 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
       // the key press. Tab, newline, DEL, and non-ASCII characters have no
       // mapping and are rejected; higher layers should compose those via
       // WebKit/Flutter/simctl backends instead.
+      //
+      // When delayMs > 0 an inter-character pause is inserted between
+      // consecutive key sends. This is required for segmented OTP-style
+      // inputs (e.g. 6-cell verify-code fields in Flutter) that drop
+      // characters when keys arrive in rapid succession (issue #639).
+      let first = true;
       for (const ch of text) {
         const key = asciiToHidKey(ch);
         if (key === null) {
@@ -231,6 +237,10 @@ export class SimulatorKitHIDInputBackend implements InputBackend {
             'BAD_ARGS',
           );
         }
+        if (!first && delayMs > 0) {
+          await sleep(delayMs);
+        }
+        first = false;
         if (key.shift) {
           await this.run([
             deviceId,
@@ -454,4 +464,8 @@ export async function tryCreateSimulatorKitHIDBackend(): Promise<
       'Run npm run build or set OPENSAFARI_ALLOW_SWIFT_INTERPRETER=1 for dev mode.',
     'HID_BRIDGE_MISSING',
   );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/unit/app-type-element.test.ts
+++ b/tests/unit/app-type-element.test.ts
@@ -7,6 +7,11 @@
  * session manager) so these stay pure unit tests.
  */
 
+// CI runners occasionally exceed Jest's 5000 ms default for the heavier
+// composite flow tests in this file. Bump the file-scoped timeout so the
+// slow-runner flakes stop masking real regressions.
+jest.setTimeout(30000);
+
 jest.mock('../../src/mcp-server', () => {
   const actual = jest.requireActual('../../src/mcp-server');
   return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };

--- a/tests/unit/app-type-element.test.ts
+++ b/tests/unit/app-type-element.test.ts
@@ -175,7 +175,7 @@ describe('app_type_element', () => {
     // Tap to focus
     expect(mockTap).toHaveBeenCalledWith('test-device-id', 195, 120);
     // Then type
-    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'user@example.com');
+    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'user@example.com', 0);
     // Tap must come before typeText
     const tapOrder = mockTap.mock.invocationCallOrder[0];
     const typeOrder = mockTypeText.mock.invocationCallOrder[0];
@@ -196,7 +196,7 @@ describe('app_type_element', () => {
 
     expect(body.status).toBe('typed');
     expect(body.coordinates).toEqual({ x: 110, y: 222 });
-    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'alice');
+    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'alice', 0);
   });
 
   it('uses index to disambiguate multiple fields', async () => {
@@ -215,7 +215,7 @@ describe('app_type_element', () => {
     });
 
     expect(mockTap).toHaveBeenCalledWith('test-device-id', 50, 220);
-    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'hello');
+    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'hello', 0);
   });
 
   it('returns error when text is missing or empty', async () => {
@@ -376,7 +376,7 @@ describe('app_type_element — Tier 1.5 AX press focus', () => {
     expect(mockPress).toHaveBeenCalledWith('0/3', 'test-device-id');
     // Coordinate tap MUST NOT fire when AX press focused the element.
     expect(mockTap).not.toHaveBeenCalled();
-    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'user@example.com');
+    expect(mockTypeText).toHaveBeenCalledWith('test-device-id', 'user@example.com', 0);
   });
 
   it('falls back to coordinate tap when the text field is not AX-pressable', async () => {

--- a/tests/unit/sim-hid-input-backend.test.ts
+++ b/tests/unit/sim-hid-input-backend.test.ts
@@ -183,6 +183,35 @@ describe('SimulatorKitHIDInputBackend', () => {
     );
   });
 
+  test('typeText with delayMs > 0 inserts pauses between characters (#639 Problem 2)', async () => {
+    execFileMock.mockResolvedValue({
+      stdout: '{"ok":true,"kind":"key","udid":"x","elapsed_ms":1}',
+      stderr: '',
+    });
+    // 4 characters with 30 ms between each → 3 gaps → at least ~75 ms wall
+    // clock (allow some slack for setTimeout drift). Without delay, this
+    // completes in well under 75 ms because execFile is mocked synchronously.
+    const start = Date.now();
+    await backend.typeText(DEVICE, 'abcd', 30);
+    const elapsed = Date.now() - start;
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+    expect(elapsed).toBeGreaterThanOrEqual(75);
+  });
+
+  test('typeText with delayMs === 0 keeps existing fast-path (no pause)', async () => {
+    execFileMock.mockResolvedValue({
+      stdout: '{"ok":true,"kind":"key","udid":"x","elapsed_ms":1}',
+      stderr: '',
+    });
+    const start = Date.now();
+    await backend.typeText(DEVICE, 'abcd', 0);
+    const elapsed = Date.now() - start;
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+    // No deliberate pause — should complete promptly. Allow generous headroom
+    // for CI noise but assert it's well below the delayed-path threshold.
+    expect(elapsed).toBeLessThan(60);
+  });
+
   // ── Printable-ASCII symbol coverage (issue #483 follow-up) ────────────────
   // The original PoC only mapped A-Z, a-z, 0-9, and space, so the tool could
   // not type an email address (no '@', '.', or '-'). typeText now covers every


### PR DESCRIPTION
## Summary
Adds `perKeyDelayMs` to `app_type_element` so segmented OTP-style fields (e.g. 6-cell verify-code inputs in Flutter) no longer silently drop characters.

## Why
Issue #639 Problem 2: the simhid backend sends keys back-to-back via the Swift HID bridge, and segmented inputs that programmatically advance focus between cells per keystroke cannot keep up — characters land in random cells, often leaving the field partially filled with no error surfaced.

## Changes
- `src/tools/native-input-backend.ts`: `InputBackend.typeText` interface now accepts an optional `delayMs?: number`. Other backends bypass the software keyboard and may safely ignore it.
- `src/tools/sim-hid-input-backend.ts`: `SimulatorKitHIDInputBackend.typeText` awaits `delayMs` ms between consecutive key sends when `delayMs > 0`. Existing fast path (`delayMs === 0`) is unchanged.
- `src/tools/app-type-element.ts`: new `perKeyDelayMs` input (number, default `0`). Plumbed through to the backend call. Recommended **80–150 ms** for 6-cell OTP-style inputs.

## Tests
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `tests/unit/sim-hid-input-backend.test.ts` — 39/39 pass (37 existing + 2 new):
  - `typeText` with `delayMs: 30` over 4 chars → wall-clock ≥ 75 ms (3 gaps).
  - `typeText` with `delayMs: 0` → fast path, < 60 ms.

## Acceptance (from #639 Problem 2)
- [x] `app_type_element` accepts optional `perKeyDelayMs`, default `0`.
- [x] HID backend respects `delayMs` between characters when > 0.
- [x] Backward-compatible defaults; existing callers unaffected.
- [ ] `verifyAfterTyping` + `TEXT_INPUT_DROPPED` structured error: deferred. The existing `verify: true` (default) post-typing readback already catches divergence and surfaces it via the `verified` / `verify_reason` fields. Adding `droppedIndices` computation belongs with the layout-mismatch work in the parallel PR D so the two error codes (`TEXT_INPUT_DROPPED` vs `TEXT_INPUT_LAYOUT_MISMATCH`) ship together with consistent shapes.

## Backward compatibility
Purely additive. Default `perKeyDelayMs: 0` preserves existing behaviour exactly.

Refs #639 (Problem 2).