### PR TITLE
fix(app-tree): retry on DEVICE_CONTENT_ROOT_EMPTY after alert dismissal (#639 Problem 4a)

### DIFF
--- a/src/tools/app-tree.ts
+++ b/src/tools/app-tree.ts
@@ -5,6 +5,49 @@ import {
   createContextMismatchError,
   ensureTargetAppContext,
 } from './native-app-context';
+import { AccessibilityBridgeError } from '../native/accessibility-bridge';
+import { DEVICE_CONTENT_ROOT_EMPTY } from '../native/ax-bridge-content-root';
+
+const APP_TREE_RETRY_COUNT = 3;
+const APP_TREE_RETRY_BACKOFF_MS = [250, 500, 1000] as const;
+
+/**
+ * Calls `bridge.dumpTree(options)` and retries with backoff on
+ * `DEVICE_CONTENT_ROOT_EMPTY`. The empty-root condition is observed
+ * transiently after a system alert is dismissed (issue #639 Problem 4a) —
+ * iOS takes a beat to repopulate the AX root for the foreground app, and
+ * before that beat the bridge sees zero app-semantics nodes and reports
+ * the structured empty-root error. Re-querying after a short backoff
+ * almost always succeeds; only persistent empty-root after `maxRetries`
+ * surfaces as an error.
+ *
+ * Other bridge errors are re-thrown immediately without retry.
+ *
+ * Exported so unit tests can assert the retry contract without driving
+ * a live simulator.
+ */
+export async function dumpTreeWithRetry(
+  bridge: { dumpTree: (opts: { deviceId?: string; maxDepth?: number }) => Promise<unknown> },
+  options: { deviceId?: string; maxDepth?: number },
+  maxRetries = APP_TREE_RETRY_COUNT,
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise<void>((r) => setTimeout(r, ms)),
+): Promise<unknown> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await bridge.dumpTree(options);
+    } catch (err) {
+      lastError = err;
+      const isEmptyRoot =
+        err instanceof AccessibilityBridgeError &&
+        err.code === DEVICE_CONTENT_ROOT_EMPTY;
+      if (!isEmptyRoot || attempt >= maxRetries) throw err;
+      await sleep(APP_TREE_RETRY_BACKOFF_MS[attempt] ?? 1000);
+    }
+  }
+  throw lastError;
+}
 
 export function registerAppTreeTool(server: MCPServer): void {
   server.registerTool(
@@ -54,7 +97,13 @@ export function registerAppTreeTool(server: MCPServer): void {
           }
         } else {
           await ensureSemanticsActive(deviceId, { bundleId });
-          tree = await bridge.dumpTree({ deviceId, maxDepth });
+          // Wrap in retry-with-backoff to absorb the transient empty-root
+          // window iOS leaves immediately after a system alert is dismissed
+          // (#639 Problem 4a). Persistent empty-root still surfaces as an
+          // error after the configured retries.
+          tree = (await dumpTreeWithRetry(bridge, { deviceId, maxDepth })) as Awaited<
+            ReturnType<typeof bridge.dumpTree>
+          >;
           meta = {
             requestedBundleId: undefined,
             deviceId: deviceId ?? '',

--- a/tests/unit/app-tree-retry.test.ts
+++ b/tests/unit/app-tree-retry.test.ts
@@ -1,0 +1,73 @@
+import { dumpTreeWithRetry } from '../../src/tools/app-tree';
+import { AccessibilityBridgeError } from '../../src/native/accessibility-bridge';
+import { DEVICE_CONTENT_ROOT_EMPTY } from '../../src/native/ax-bridge-content-root';
+
+describe('dumpTreeWithRetry (issue #639 Problem 4a — AX recovery after alert)', () => {
+  test('returns immediately on success without retrying', async () => {
+    const dumpTree = jest.fn().mockResolvedValue({ root: { id: 'ok' } });
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const result = await dumpTreeWithRetry({ dumpTree }, { deviceId: 'dev' }, 3, sleep);
+    expect(result).toEqual({ root: { id: 'ok' } });
+    expect(dumpTree).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test('retries on DEVICE_CONTENT_ROOT_EMPTY then succeeds', async () => {
+    const emptyError = new AccessibilityBridgeError(
+      'no app semantics in tree',
+      DEVICE_CONTENT_ROOT_EMPTY,
+    );
+    const dumpTree = jest
+      .fn()
+      .mockRejectedValueOnce(emptyError)
+      .mockRejectedValueOnce(emptyError)
+      .mockResolvedValue({ root: { id: 'ok-after-retry' } });
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const result = await dumpTreeWithRetry({ dumpTree }, { deviceId: 'dev' }, 3, sleep);
+    expect(result).toEqual({ root: { id: 'ok-after-retry' } });
+    expect(dumpTree).toHaveBeenCalledTimes(3);
+    // Two backoffs should have fired (250 ms then 500 ms per the schedule).
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep.mock.calls[0]?.[0]).toBe(250);
+    expect(sleep.mock.calls[1]?.[0]).toBe(500);
+  });
+
+  test('surfaces DEVICE_CONTENT_ROOT_EMPTY after exhausting retries', async () => {
+    const emptyError = new AccessibilityBridgeError(
+      'no app semantics in tree',
+      DEVICE_CONTENT_ROOT_EMPTY,
+    );
+    const dumpTree = jest.fn().mockRejectedValue(emptyError);
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    await expect(
+      dumpTreeWithRetry({ dumpTree }, { deviceId: 'dev' }, 2, sleep),
+    ).rejects.toBe(emptyError);
+    // 1 initial + 2 retries = 3 total invocations.
+    expect(dumpTree).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  test('does NOT retry on non-empty-root errors (re-throws immediately)', async () => {
+    const otherError = new AccessibilityBridgeError(
+      'bridge crashed',
+      'BRIDGE_CRASHED',
+    );
+    const dumpTree = jest.fn().mockRejectedValue(otherError);
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    await expect(
+      dumpTreeWithRetry({ dumpTree }, { deviceId: 'dev' }, 3, sleep),
+    ).rejects.toBe(otherError);
+    expect(dumpTree).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test('does NOT retry on plain Error (only AccessibilityBridgeError with empty-root code)', async () => {
+    const plainError = new Error('something else');
+    const dumpTree = jest.fn().mockRejectedValue(plainError);
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    await expect(
+      dumpTreeWithRetry({ dumpTree }, { deviceId: 'dev' }, 3, sleep),
+    ).rejects.toBe(plainError);
+    expect(dumpTree).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds an automatic retry loop with backoff when `app_tree` hits `DEVICE_CONTENT_ROOT_EMPTY` — the transient AX state iOS leaves immediately after a system alert is dismissed. Closes the most-impactful slice of #639 Problem 4.

## Why
Issue #639 Problem 4a: callers running `app_handle_alert` followed by `app_tree` get a hard `DEVICE_CONTENT_ROOT_EMPTY` for a few seconds while iOS repopulates the foreground app's AX root. The previous behaviour required either defensive caller-side sleeps or a full simulator relaunch — both make Flutter signup/auth lanes brittle.

## Changes
- `src/tools/app-tree.ts`
  - New exported `dumpTreeWithRetry(bridge, options, maxRetries, sleep)` — retries `bridge.dumpTree()` with backoff `[250, 500, 1000]` ms when the underlying error is `AccessibilityBridgeError` with code `DEVICE_CONTENT_ROOT_EMPTY`. Other errors are re-thrown immediately.
  - The no-bundleId path (the path that drives raw AX dumps right after permission alerts) now uses the retry wrapper. The bundleId / target-app-context path is left unchanged because `ensureTargetAppContext` already has its own retry/heuristics.
- `tests/unit/app-tree-retry.test.ts`
  - 5 new tests: success-no-retry, retry-then-success, exhaust-then-throw, immediate re-throw on non-empty-root bridge errors, immediate re-throw on plain errors. Backoff schedule asserted.

## Tests
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx jest tests/unit/app-tree-retry.test.ts` — 5/5 pass.

## Acceptance (from #639 Problem 4)
- [x] **4a** — `app_tree` retries automatically on `DEVICE_CONTENT_ROOT_EMPTY` (3 retries, backoff `[250, 500, 1000]` ms).
- [ ] **4a** — `app_handle_alert` reports `axRecovered: boolean`. Deferred — the `app_tree` retry alone resolves the user-facing symptom; structuring the recovery signal inside `app_handle_alert` belongs with the next slice.
- [ ] **4b** — `dismissAllVisible` loop for stacked alerts (Apple Intelligence + push permission). Deferred to follow-up.
- [ ] **4c** — Korean push-permission button classification regression fixture. Deferred to follow-up. The label corpus already contains `허용` / `허용 안 함`; the failure observed on iPhone 17 Pro / iOS 26.4 needs a captured AX dump to fixture against, which is out of scope for this PR.

## Backward compatibility
Purely additive. Default retry count and backoff are conservative; the worst case adds ~1.75 s of latency only when the underlying call would otherwise have hard-failed. Successful calls take the existing fast path.

Refs #639 (Problem 4a). Follow-up PR will cover 4b/4c.