### PR TITLE
fix(app-handle-alert): normalize Unicode whitespace in label matching (#642)

### DIFF
--- a/src/tools/alert-detection.ts
+++ b/src/tools/alert-detection.ts
@@ -1,5 +1,5 @@
 import { AXNode } from '../native/ax-types';
-import { AlertAction, AlertLocale, matchLabel } from './app-handle-alert-labels';
+import { AlertAction, AlertLocale, matchLabel, normalizeLabel } from './app-handle-alert-labels';
 
 export interface DialogDetectionContext {
   tree: AXNode;        // full AX tree root
@@ -121,13 +121,14 @@ function isGeometryBounded(
  * tree has the same label AND a non-empty identifier (in-app stable ID).
  */
 function hasNoIdentifierConflict(label: string, tree: AXNode): boolean {
+  const target = normalizeLabel(label);
   return !dfsFind(tree, (n) => {
     return (
       n.role === 'AXButton' &&
       typeof n.identifier === 'string' &&
       n.identifier.length > 0 &&
       typeof n.label === 'string' &&
-      n.label.trim().toLowerCase() === label.trim().toLowerCase()
+      normalizeLabel(n.label) === target
     );
   });
 }

--- a/src/tools/app-handle-alert-labels.ts
+++ b/src/tools/app-handle-alert-labels.ts
@@ -41,15 +41,37 @@ export function flattenLabels(action: AlertAction): string[] {
   return result;
 }
 
+// Unicode whitespace codepoints frequently embedded in Apple's localized
+// SpringBoard strings to prevent line-wrapping. The corpus stores ASCII
+// U+0020 spaces, while the runtime AX label may contain any of these
+// "fancy" spaces. Equality must compare normalized forms.
+//
+// U+00A0 NO-BREAK SPACE
+// U+202F NARROW NO-BREAK SPACE
+// U+2007 FIGURE SPACE
+// U+2060 WORD JOINER
+// U+2028 LINE SEPARATOR
+// U+2029 PARAGRAPH SEPARATOR
+const FANCY_WHITESPACE = /[\u00A0\u202F\u2007\u2060\u2028\u2029]/g;
+
+export function normalizeLabel(text: string): string {
+  return text
+    .normalize('NFC')
+    .replace(FANCY_WHITESPACE, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
 export function matchLabel(
   text: string,
   action: AlertAction,
 ): { locale: AlertLocale; label: string } | null {
-  const trimmed = text.trim().toLowerCase();
+  const normalized = normalizeLabel(text);
   const localeMap = ALL_LABELS[action];
   for (const locale of Object.keys(localeMap) as AlertLocale[]) {
     for (const label of localeMap[locale]) {
-      if (label.toLowerCase() === trimmed) {
+      if (normalizeLabel(label) === normalized) {
         return { locale, label };
       }
     }

--- a/tests/fixtures/ax-trees/notifications-ko-nbsp.json
+++ b/tests/fixtures/ax-trees/notifications-ko-nbsp.json
@@ -1,0 +1,111 @@
+{
+  "role": "AXApplication",
+  "label": "SpringBoard",
+  "traits": [],
+  "frame": {
+    "x": 0,
+    "y": 0,
+    "width": 393,
+    "height": 852
+  },
+  "visible": true,
+  "enabled": true,
+  "focused": false,
+  "path": "0",
+  "children": [
+    {
+      "role": "AXWindow",
+      "traits": [],
+      "frame": {
+        "x": 0,
+        "y": 0,
+        "width": 393,
+        "height": 852
+      },
+      "visible": true,
+      "enabled": true,
+      "focused": false,
+      "path": "0/0",
+      "children": [
+        {
+          "role": "AXSheet",
+          "traits": [],
+          "frame": {
+            "x": 20,
+            "y": 280,
+            "width": 353,
+            "height": 240
+          },
+          "visible": true,
+          "enabled": true,
+          "focused": false,
+          "path": "0/0/0",
+          "children": [
+            {
+              "role": "AXStaticText",
+              "label": "'Omofictions App'에서 알림을 보내고자 합니다.",
+              "traits": [
+                "AXHeading"
+              ],
+              "frame": {
+                "x": 40,
+                "y": 300,
+                "width": 313,
+                "height": 60
+              },
+              "visible": true,
+              "enabled": true,
+              "focused": false,
+              "path": "0/0/0/0"
+            },
+            {
+              "role": "AXStaticText",
+              "label": "경고, 사운드 및 아이콘 배지가 알림에 포함될 수 있습니다.",
+              "traits": [],
+              "frame": {
+                "x": 40,
+                "y": 360,
+                "width": 313,
+                "height": 40
+              },
+              "visible": true,
+              "enabled": true,
+              "focused": false,
+              "path": "0/0/0/1"
+            },
+            {
+              "role": "AXButton",
+              "label": "허용 안 함",
+              "traits": [],
+              "frame": {
+                "x": 40,
+                "y": 420,
+                "width": 153,
+                "height": 44
+              },
+              "visible": true,
+              "enabled": true,
+              "focused": false,
+              "path": "0/0/0/2"
+            },
+            {
+              "role": "AXButton",
+              "label": "허용",
+              "traits": [],
+              "frame": {
+                "x": 200,
+                "y": 420,
+                "width": 153,
+                "height": 44
+              },
+              "visible": true,
+              "enabled": true,
+              "focused": false,
+              "path": "0/0/0/3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/alert-detection.test.ts
+++ b/tests/unit/alert-detection.test.ts
@@ -92,6 +92,28 @@ describe('findAlertCandidates — springboard-dialog (geometry_bounded)', () => 
   });
 });
 
+describe('findAlertCandidates — notifications-ko-nbsp (issue #642)', () => {
+  const tree = loadFixture('notifications-ko-nbsp.json');
+
+  test('dismiss: finds the NBSP-separated 허용 안 함 button', () => {
+    const candidates = findAlertCandidates('dismiss', ctx(tree));
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].label).toBe('허용 안 함');
+  });
+
+  test('dismiss: candidate AX node label retains its NBSP separators', () => {
+    const candidates = findAlertCandidates('dismiss', ctx(tree));
+    const NBSP = ' ';
+    expect(candidates[0].node.label).toBe(`허용${NBSP}안${NBSP}함`);
+  });
+
+  test('accept: finds the 허용 button', () => {
+    const candidates = findAlertCandidates('accept', ctx(tree));
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].label).toBe('허용');
+  });
+});
+
 describe('findAlertCandidates — spotlight-search (non-match)', () => {
   const tree = loadFixture('spotlight-search.json');
 

--- a/tests/unit/app-handle-alert-labels.test.ts
+++ b/tests/unit/app-handle-alert-labels.test.ts
@@ -4,6 +4,7 @@ import {
   ALL_LABELS,
   flattenLabels,
   matchLabel,
+  normalizeLabel,
   type AlertLocale,
 } from '../../src/tools/app-handle-alert-labels';
 
@@ -84,5 +85,59 @@ describe('app-handle-alert-labels corpus', () => {
   test('matchLabel("random", "accept") returns null', () => {
     const result = matchLabel('random', 'accept');
     expect(result).toBeNull();
+  });
+
+  describe('Unicode whitespace normalization (issue #642)', () => {
+    const NBSP = ' ';
+    const NNBSP = ' ';
+    const FIGURE_SPACE = ' ';
+    const WORD_JOINER = '⁠';
+
+    test('matchLabel matches NBSP-separated ko dismiss label', () => {
+      const input = `허용${NBSP}안${NBSP}함`;
+      const result = matchLabel(input, 'dismiss');
+      expect(result).toEqual({ locale: 'ko', label: '허용 안 함' });
+    });
+
+    test('matchLabel matches Narrow-NBSP-separated ko dismiss label', () => {
+      const input = `허용${NNBSP}안${NNBSP}함`;
+      const result = matchLabel(input, 'dismiss');
+      expect(result).toEqual({ locale: 'ko', label: '허용 안 함' });
+    });
+
+    test('matchLabel matches Figure-Space (U+2007) variant', () => {
+      const input = `허용${FIGURE_SPACE}안${FIGURE_SPACE}함`;
+      const result = matchLabel(input, 'dismiss');
+      expect(result).toEqual({ locale: 'ko', label: '허용 안 함' });
+    });
+
+    test('matchLabel collapses Word-Joiner (U+2060) inside the label', () => {
+      const input = `허용${WORD_JOINER}안${WORD_JOINER}함`;
+      const result = matchLabel(input, 'dismiss');
+      expect(result).toEqual({ locale: 'ko', label: '허용 안 함' });
+    });
+
+    test('matchLabel collapses runs of mixed ASCII whitespace', () => {
+      const result = matchLabel('  Allow   While  Using  App  ', 'accept');
+      expect(result).toEqual({ locale: 'en', label: 'Allow While Using App' });
+    });
+
+    test('matchLabel matches NBSP-padded en label', () => {
+      const input = `Allow${NBSP}While${NBSP}Using${NBSP}App`;
+      const result = matchLabel(input, 'accept');
+      expect(result).toEqual({ locale: 'en', label: 'Allow While Using App' });
+    });
+
+    test('normalizeLabel collapses NBSP runs and lowercases', () => {
+      const input = `Allow${NBSP}${NBSP}While${NBSP}Using${NBSP}App`;
+      expect(normalizeLabel(input)).toBe('allow while using app');
+    });
+
+    test('normalizeLabel applies NFC normalization', () => {
+      // Korean syllable "한" decomposed to its jamo: U+1112 U+1161 U+11AB.
+      const decomposed = '한';
+      expect(decomposed.normalize('NFC')).toBe('한');
+      expect(normalizeLabel(decomposed)).toBe('한');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `normalizeLabel()` that NFC-normalizes, collapses non-breaking / narrow / figure / word-joiner spaces into ASCII space, trims and lowercases. Used by `matchLabel` and `hasNoIdentifierConflict`.
- Adds fixture `notifications-ko-nbsp.json` reproducing the iOS 26.4 SpringBoard Korean notification permission popup, where `허용 안 함` embeds `U+00A0` between syllables.
- Adds unit tests for `U+00A0`, `U+202F`, `U+2007`, `U+2060`, NFC jamo decomposition, and runs of mixed ASCII whitespace.

Fixes first slice (PR 1) of #642.

## Why

iOS 26.4's SpringBoard uses non-breaking whitespace inside localized multi-word permission-dialog button labels so they do not wrap. The pre-existing `matchLabel` only compared `trim()` + `toLowerCase()` equality, so the AX-scan tier saw the `허용 안 함` corpus entry (ASCII `U+0020`) diverge from the runtime AX label (`U+00A0`-separated) and returned `no_candidate_button`, causing `app_handle_alert({ action: "dismiss" })` to no-op and drop the user back to `visibleButtons: ["허용 안 함", "허용"]` diagnostics.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 1931/1931 pass on a clean build
- [x] `npx jest tests/unit/app-handle-alert-labels.test.ts tests/unit/alert-detection.test.ts tests/unit/app-handle-alert.test.ts` — 60+ passes, including the 9 new normalization cases
- [ ] Manual smoke: iPhone 17 Pro / iOS 26.4 simulator, cold-launch Omofictions-App, confirm `app_handle_alert({ action: "dismiss" })` now returns `dismissed: true` with `strategy: "ax-scan"`.

## Follow-ups (separate PRs)

- PR 2 — annotate `collectVisibleButtonLabels` output so NBSP-bearing labels are visibly distinct from pure-ASCII labels in the diagnostic response.
- PR 3 — expand `buildAlertScript` to try ASCII-space and NBSP-space variants of every multi-word label in AppleScript fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)