### PR TITLE
feat(app-type-element): attach TEXT_INPUT_LAYOUT_MISMATCH on non-Latin layout (#639 Problem 1)

### DIFF
--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -9,6 +9,29 @@
  * once focused).
  *
  * Works with any app including Flutter — no WebKit/DOM required.
+ *
+ * ## Keyboard-layout limitation (issue #639 Problem 1)
+ *
+ * When `backend: "auto"` (default), text is sent via raw HID keycodes
+ * that assume a US-ABC (QWERTY) software keyboard. If the simulator's
+ * active input source is non-Latin (Korean 2-Set, Japanese Kana, Chinese
+ * Pinyin, …) those keycodes are silently re-composed by the iOS IME into
+ * the corresponding script — producing garbage in the text field.
+ *
+ * There is currently no documented way to switch the simulator's input
+ * source programmatically from the host. Until a native switcher lands,
+ * use `backend: "pasteboard"` which round-trips via the simulator
+ * clipboard (Cmd+V) and is fully keyboard-layout-independent.
+ *
+ * When post-typing readback (`verifyAfterTyping: true`, or the legacy
+ * `verify: true` default) detects divergence AND the detected keyboard
+ * layout is non-Latin, the tool returns `isError: true` with:
+ *
+ *   { code: "TEXT_INPUT_LAYOUT_MISMATCH", expected, actual,
+ *     suggestedBackend: "pasteboard", detectedLayout }
+ *
+ * For Latin layouts where characters are dropped (different failure
+ * mode), see error code `TEXT_INPUT_DROPPED` (PR A / issue #639).
  */
 
 import { execFile } from 'child_process';
@@ -20,6 +43,7 @@ import type { AXNode, AXQuery } from '../native';
 import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 import { tryPress } from './app-tap-element';
 import { typeViaPasteboard } from './pasteboard-input';
+import { mismatchHint } from './keyboard-layout';
 
 const execFileAsync = promisify(execFile);
 
@@ -50,6 +74,13 @@ interface VerifyResult {
     | 'skipped-non-simhid'
     | 'readback-failed';
   verify_reason?: string;
+  /**
+   * Raw AX-value observed at readback. Populated only when the readback
+   * actually succeeded (`verify_method === 'ax-value-readback'`); used by the
+   * caller to attach structured error payloads (e.g. TEXT_INPUT_LAYOUT_MISMATCH
+   * — issue #639 Problem 1) without re-querying the AX bridge.
+   */
+  observed?: string;
 }
 
 export function registerAppTypeElementTool(server: MCPServer): void {
@@ -321,6 +352,19 @@ export function registerAppTypeElementTool(server: MCPServer): void {
         // surface `isError: true` so MCP clients / agents don't treat the
         // call as a trustworthy "typed" step and proceed to submit garbage.
         const mismatched = verify.verified === false;
+
+        // When verification observed a mismatch AND the simulator's keyboard
+        // layout is non-Latin, attach a structured TEXT_INPUT_LAYOUT_MISMATCH
+        // payload so callers can programmatically pick the recommended
+        // remediation (issue #639 Problem 1). Latin-layout mismatches use a
+        // different code (TEXT_INPUT_DROPPED — see PR A) and are intentionally
+        // skipped here.
+        if (mismatched && verify.observed !== undefined) {
+          const hint = mismatchHint(textToType, verify.observed, keyboardLayoutDetected);
+          if (hint) {
+            responseBody.error = hint;
+          }
+        }
         const result: {
           content: Array<{ type: 'text'; text: string }>;
           isError?: boolean;
@@ -400,7 +444,7 @@ async function verifyTypedText(
     };
   }
   if (observed.endsWith(expected) || observed.includes(expected)) {
-    return { verified: true, verify_method: 'ax-value-readback' };
+    return { verified: true, verify_method: 'ax-value-readback', observed };
   }
   return {
     verified: false,
@@ -408,6 +452,7 @@ async function verifyTypedText(
     verify_reason:
       `observed "${truncate(observed)}" does not contain requested "${truncate(expected)}" — ` +
       'likely caused by a non-Latin simulator keyboard transliterating the HID input (issue #39)',
+    observed,
   };
 }
 

--- a/src/tools/keyboard-layout.ts
+++ b/src/tools/keyboard-layout.ts
@@ -71,17 +71,47 @@ export function isLatinSoftwareLayout(key: string): boolean {
 }
 
 /**
+ * Max characters echoed for `expected` / `actual` in the hint payload.
+ * These fields exist only to prove that HID typing transliterated the input —
+ * a short prefix does that without shipping the full user value (emails,
+ * tokens, passwords) through MCP error payloads / logs. Matches the
+ * `VERIFY_ECHO_LEN` cap `app_type_element` uses in `verify_reason`.
+ */
+const HINT_ECHO_LEN = 24;
+
+function truncateForHint(s: string): string {
+  if (s.length <= HINT_ECHO_LEN) return s;
+  return `${s.slice(0, HINT_ECHO_LEN)}…`;
+}
+
+/**
  * Structured hint returned by `mismatchHint()` when a non-Latin keyboard
  * layout is detected and HID-typed text diverges from the expected value.
  * Surface this as `isError: true` with this object as the error payload so
  * callers can programmatically choose the recommended remediation.
+ *
+ * `expected` / `actual` are truncated echoes (prefix + `…`) of the caller's
+ * input and the AX readback — truncation is done by `mismatchHint` itself so
+ * the hint never carries full user text through MCP logs / telemetry, and
+ * `truncated: true` flags that the caller must not treat them as authoritative
+ * text. The raw readback is only ever exposed via the tool's separate
+ * `verify_reason` (which has matching truncation).
  */
 export interface LayoutMismatchHint {
   code: 'TEXT_INPUT_LAYOUT_MISMATCH';
   expected: string;
   actual: string;
+  truncated: boolean;
   suggestedBackend: 'pasteboard';
   detectedLayout?: string;
+  /**
+   * `detectedLayout` is the first `AppleKeyboards` entry with a `sw=` token,
+   * which is heuristic — iOS 26.4 exposes no deterministic "active layout"
+   * signal from the host (see module header). Callers should treat the
+   * hint as "probably a layout transliteration problem" rather than a
+   * verified active-layout claim.
+   */
+  layoutSource?: 'apple_keyboards_first_entry';
 }
 
 /**
@@ -93,10 +123,16 @@ export interface LayoutMismatchHint {
  * surface this error for Latin layouts, since divergence there indicates a
  * different failure mode (e.g. `TEXT_INPUT_DROPPED` from PR A).
  *
+ * The returned `expected` / `actual` fields are truncated prefix echoes
+ * (see `HINT_ECHO_LEN`). Full values are never included — callers that need
+ * longer echoes should read the tool's `verify_reason`, which applies the
+ * same cap.
+ *
  * @param expected  The text the caller intended to type.
  * @param actual    The text observed in the AX readback.
  * @param detectedLayout  Raw `AppleKeyboards` entry (from `detectKeyboardLayout`).
- *                        May be `null` when the probe failed.
+ *                        May be `null` when the probe failed. Heuristic —
+ *                        not guaranteed to be the currently active layout.
  */
 export function mismatchHint(
   expected: string,
@@ -108,12 +144,16 @@ export function mismatchHint(
   // error code (TEXT_INPUT_DROPPED) applies to the Latin mismatch case.
   if (!detectedLayout) return null;
   if (isLatinSoftwareLayout(detectedLayout)) return null;
+  const truncated =
+    expected.length > HINT_ECHO_LEN || actual.length > HINT_ECHO_LEN;
   const hint: LayoutMismatchHint = {
     code: 'TEXT_INPUT_LAYOUT_MISMATCH',
-    expected,
-    actual,
+    expected: truncateForHint(expected),
+    actual: truncateForHint(actual),
+    truncated,
     suggestedBackend: 'pasteboard',
+    detectedLayout,
+    layoutSource: 'apple_keyboards_first_entry',
   };
-  hint.detectedLayout = detectedLayout;
   return hint;
 }

--- a/src/tools/keyboard-layout.ts
+++ b/src/tools/keyboard-layout.ts
@@ -21,6 +21,12 @@
  * Per issue #39 addendum §2 the load-bearing assertion is that the `sw=`
  * (software layout) token equals `QWERTY`. Every other part of the key —
  * locale prefix, `hw=` token, whitespace — is ignored.
+ *
+ * Limitation (issue #639 Problem 1):
+ *   There is currently no documented way to programmatically switch the
+ *   simulator's active input source from the host. When a non-Latin layout
+ *   is detected and text diverges after HID typing, use
+ *   `backend: "pasteboard"` to bypass the software keyboard entirely.
  */
 
 /**
@@ -62,4 +68,52 @@ export function isLatinSoftwareLayout(key: string): boolean {
   const token = extractSoftwareLayout(key);
   if (!token) return false;
   return token.toLowerCase() === 'qwerty';
+}
+
+/**
+ * Structured hint returned by `mismatchHint()` when a non-Latin keyboard
+ * layout is detected and HID-typed text diverges from the expected value.
+ * Surface this as `isError: true` with this object as the error payload so
+ * callers can programmatically choose the recommended remediation.
+ */
+export interface LayoutMismatchHint {
+  code: 'TEXT_INPUT_LAYOUT_MISMATCH';
+  expected: string;
+  actual: string;
+  suggestedBackend: 'pasteboard';
+  detectedLayout?: string;
+}
+
+/**
+ * Build a `TEXT_INPUT_LAYOUT_MISMATCH` hint for use by `app_type_element`
+ * when post-typing readback diverges AND the detected keyboard layout is
+ * non-Latin (issue #639 Problem 1).
+ *
+ * Returns `null` when the layout is Latin (or unknown) — callers must NOT
+ * surface this error for Latin layouts, since divergence there indicates a
+ * different failure mode (e.g. `TEXT_INPUT_DROPPED` from PR A).
+ *
+ * @param expected  The text the caller intended to type.
+ * @param actual    The text observed in the AX readback.
+ * @param detectedLayout  Raw `AppleKeyboards` entry (from `detectKeyboardLayout`).
+ *                        May be `null` when the probe failed.
+ */
+export function mismatchHint(
+  expected: string,
+  actual: string,
+  detectedLayout: string | null,
+): LayoutMismatchHint | null {
+  // Only fire for confirmed non-Latin layouts. When the layout is unknown
+  // (detectedLayout === null) or is Latin-safe, return null — a different
+  // error code (TEXT_INPUT_DROPPED) applies to the Latin mismatch case.
+  if (!detectedLayout) return null;
+  if (isLatinSoftwareLayout(detectedLayout)) return null;
+  const hint: LayoutMismatchHint = {
+    code: 'TEXT_INPUT_LAYOUT_MISMATCH',
+    expected,
+    actual,
+    suggestedBackend: 'pasteboard',
+  };
+  hint.detectedLayout = detectedLayout;
+  return hint;
 }

--- a/tests/unit/app-type-element.test.ts
+++ b/tests/unit/app-type-element.test.ts
@@ -7,6 +7,15 @@
  * session manager) so these stay pure unit tests.
  */
 
+// CI hardening: macos-latest GitHub runners under full-suite load
+// occasionally miss Jest's default 5 s per-test deadline on the first
+// cases here (ts-jest cold-compile + accessibility-bridge mock wire-up
+// together push the first `await handler(...)` past 5 s). Locally these
+// tests resolve in <100 ms. Bump the per-test cap so a slow CI machine
+// no longer flags "Exceeded timeout of 5000 ms" as a PR-introduced
+// regression; real hangs still fail fast well under the new cap.
+jest.setTimeout(20000);
+
 jest.mock('../../src/mcp-server', () => {
   const actual = jest.requireActual('../../src/mcp-server');
   return { ...actual, getWebKitClient: jest.fn().mockReturnValue(null) };

--- a/tests/unit/keyboard-layout-mismatch.test.ts
+++ b/tests/unit/keyboard-layout-mismatch.test.ts
@@ -23,10 +23,13 @@ describe('mismatchHint (issue #639 Problem 1 — fail-loud on non-Latin layout)'
     );
     expect(hint).not.toBeNull();
     expect(hint?.code).toBe('TEXT_INPUT_LAYOUT_MISMATCH');
+    // Short inputs (≤ 24 chars) are echoed verbatim — no truncation sentinel.
     expect(hint?.expected).toBe('qa.signup@example.com');
     expect(hint?.actual).toBe('ㄴ뎁ㅁ.냐후ㅕㅔ@ㄷㅌ므ㅔㅣㄷ.채ㅡ');
+    expect(hint?.truncated).toBe(false);
     expect(hint?.suggestedBackend).toBe('pasteboard');
     expect(hint?.detectedLayout).toBe(koEntry);
+    expect(hint?.layoutSource).toBe('apple_keyboards_first_entry');
   });
 
   test('returns a hint for a Japanese Kana layout (non-Latin)', () => {
@@ -34,6 +37,27 @@ describe('mismatchHint (issue #639 Problem 1 — fail-loud on non-Latin layout)'
     const hint = mismatchHint('hello', 'こんにちは', jpEntry);
     expect(hint?.code).toBe('TEXT_INPUT_LAYOUT_MISMATCH');
     expect(hint?.suggestedBackend).toBe('pasteboard');
+    expect(hint?.layoutSource).toBe('apple_keyboards_first_entry');
+  });
+
+  test('truncates long expected/actual values so hint payload never leaks full user text', () => {
+    const koEntry = 'ko_KR@sw=Korean;hw=Automatic';
+    const longExpected = 'pfx-0123456789012345678901-SECRET_TAIL_THAT_MUST_NOT_LEAK';
+    const longActual = 'ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ-TAIL';
+    const hint = mismatchHint(longExpected, longActual, koEntry);
+    expect(hint).not.toBeNull();
+    // Both sides are capped at 24 code units and suffixed with `…`.
+    expect(hint?.expected.length).toBeLessThanOrEqual(25);
+    expect(hint?.actual.length).toBeLessThanOrEqual(25);
+    expect(hint?.expected.endsWith('…')).toBe(true);
+    expect(hint?.actual.endsWith('…')).toBe(true);
+    expect(hint?.truncated).toBe(true);
+    // Full originals must NOT be reachable through the hint payload — the
+    // tail beyond the echo window is dropped.
+    expect(hint?.expected).not.toBe(longExpected);
+    expect(hint?.actual).not.toBe(longActual);
+    expect(JSON.stringify(hint)).not.toContain('SECRET_TAIL_THAT_MUST_NOT_LEAK');
+    expect(JSON.stringify(hint)).not.toContain('-TAIL');
   });
 
   test('hint payload is JSON-serialisable (transports cleanly through MCP)', () => {
@@ -42,5 +66,7 @@ describe('mismatchHint (issue #639 Problem 1 — fail-loud on non-Latin layout)'
     const parsed = JSON.parse(JSON.stringify(hint));
     expect(parsed.code).toBe('TEXT_INPUT_LAYOUT_MISMATCH');
     expect(parsed.suggestedBackend).toBe('pasteboard');
+    expect(parsed.layoutSource).toBe('apple_keyboards_first_entry');
+    expect(parsed.truncated).toBe(false);
   });
 });

--- a/tests/unit/keyboard-layout-mismatch.test.ts
+++ b/tests/unit/keyboard-layout-mismatch.test.ts
@@ -1,0 +1,46 @@
+import { mismatchHint, isLatinSoftwareLayout } from '../../src/tools/keyboard-layout';
+
+describe('mismatchHint (issue #639 Problem 1 — fail-loud on non-Latin layout)', () => {
+  test('returns null when detectedLayout is null (probe failed)', () => {
+    expect(mismatchHint('qa@example.com', 'whatever', null)).toBeNull();
+  });
+
+  test('returns null for a Latin (QWERTY) software layout', () => {
+    const usEntry = 'en_US@hw=Automatic;sw=QWERTY';
+    expect(isLatinSoftwareLayout(usEntry)).toBe(true);
+    expect(mismatchHint('qa@example.com', 'qa@exmple.com', usEntry)).toBeNull();
+  });
+
+  test('returns a structured TEXT_INPUT_LAYOUT_MISMATCH for a Korean 2-Set layout', () => {
+    // Real-world AppleKeyboards entry shape; sw=Korean is the load-bearing
+    // signal that the simulator's active software layout is non-Latin.
+    const koEntry = 'ko_KR@sw=Korean;hw=Automatic';
+    expect(isLatinSoftwareLayout(koEntry)).toBe(false);
+    const hint = mismatchHint(
+      'qa.signup@example.com',
+      'ㄴ뎁ㅁ.냐후ㅕㅔ@ㄷㅌ므ㅔㅣㄷ.채ㅡ',
+      koEntry,
+    );
+    expect(hint).not.toBeNull();
+    expect(hint?.code).toBe('TEXT_INPUT_LAYOUT_MISMATCH');
+    expect(hint?.expected).toBe('qa.signup@example.com');
+    expect(hint?.actual).toBe('ㄴ뎁ㅁ.냐후ㅕㅔ@ㄷㅌ므ㅔㅣㄷ.채ㅡ');
+    expect(hint?.suggestedBackend).toBe('pasteboard');
+    expect(hint?.detectedLayout).toBe(koEntry);
+  });
+
+  test('returns a hint for a Japanese Kana layout (non-Latin)', () => {
+    const jpEntry = 'ja_JP@sw=Kana;hw=Automatic';
+    const hint = mismatchHint('hello', 'こんにちは', jpEntry);
+    expect(hint?.code).toBe('TEXT_INPUT_LAYOUT_MISMATCH');
+    expect(hint?.suggestedBackend).toBe('pasteboard');
+  });
+
+  test('hint payload is JSON-serialisable (transports cleanly through MCP)', () => {
+    const hint = mismatchHint('qa', 'ㅂㅁ', 'ko_KR@sw=Korean;hw=Automatic');
+    expect(() => JSON.parse(JSON.stringify(hint))).not.toThrow();
+    const parsed = JSON.parse(JSON.stringify(hint));
+    expect(parsed.code).toBe('TEXT_INPUT_LAYOUT_MISMATCH');
+    expect(parsed.suggestedBackend).toBe('pasteboard');
+  });
+});


### PR DESCRIPTION
## Summary
Attaches a structured `TEXT_INPUT_LAYOUT_MISMATCH` error payload to the existing readback-mismatch response when the simulator's active keyboard layout is confirmed non-Latin. Lets MCP clients / agents programmatically pick the recommended remediation (`backend: "pasteboard"`) instead of inferring intent from a free-form `verify_reason` string.

## Why
Issue #639 Problem 1: with a Korean 2-Set host IME, `app_type_element` sending the ASCII string `qa.signup@example.com` lands as `ㄴ뎁ㅁ.냐후ㅕㅔ@ㄷㅌ므ㅔㅣㄷ.채ㅡ` in the destination field. Even a Swift `CGEvent.keyboardSetUnicodeString` helper produces the same jamo output, which means the failure is on the simulator side (active IM extension or default keyboard layout). There is currently no documented OpenSafari knob to force the simulator's input source to ASCII/US.

Until a native input-source switcher lands, this PR makes the failure **machine-readable** so callers can route around it without parsing prose.

## Changes
- `src/tools/keyboard-layout.ts`
  - New `mismatchHint(expected, actual, detectedLayout)` pure helper. Returns `null` for Latin (QWERTY) layouts and for failed detection. Returns `{ code: "TEXT_INPUT_LAYOUT_MISMATCH", expected, actual, suggestedBackend: "pasteboard", detectedLayout }` for confirmed non-Latin layouts.
  - Module-header limitation note + workaround pointer.
- `src/tools/app-type-element.ts`
  - Module-header doc explaining the limitation and the `backend: "pasteboard"` workaround.
  - `VerifyResult` now carries the raw `observed` AX value alongside the existing `verified` / `verify_method` / `verify_reason` fields, so the caller does not have to re-query the bridge.
  - When the existing mismatch path fires (`verify.verified === false`) AND `mismatchHint(…)` returns a non-null hint (i.e. layout is confirmed non-Latin), the response body now also includes `responseBody.error = hint` in addition to the existing `isError: true` flag.
- `tests/unit/keyboard-layout-mismatch.test.ts`
  - 5 tests: null/Latin no-op, Korean and Japanese hint shape, and JSON-serialisability through MCP.

## Coordination with PR A (#639 Problem 2)
PR A introduces `perKeyDelayMs` for segmented OTP fields — the failure mode there is **dropped characters on a Latin layout**, which gets a different code (`TEXT_INPUT_DROPPED`). The two error codes are mutually exclusive by layout detection in this PR — `mismatchHint()` deliberately returns `null` for Latin layouts so the dropped-character case does not collide. PR A and this PR can land in either order.

## Tests
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx jest tests/unit/keyboard-layout-mismatch.test.ts` — 5/5 pass.
- `npx jest tests/unit/app-type-element.test.ts` — 20/20 still pass (no regressions from the `VerifyResult.observed` field addition).

## Acceptance (from #639 Problem 1)
- [x] Structured `TEXT_INPUT_LAYOUT_MISMATCH` payload surfaced when readback diverges AND layout is non-Latin.
- [x] `suggestedBackend: "pasteboard"` field in the payload.
- [x] `detectedLayout` field carries the raw `AppleKeyboards` entry for triage.
- [x] Tool docstring lists the limitation and the `backend: "pasteboard"` workaround.
- [x] Backward-compatible: existing `verified`/`verify_reason`/`isError` surface is unchanged.
- [ ] Native simulator input-source switcher (Swift/IOKit `TIS`). **Out of scope** — tracked as a follow-up if the fail-loud path proves insufficient in practice.

Refs #639 (Problem 1).