### PR TITLE
feat(app-handle-alert): annotate non-ASCII whitespace in visibleButtons diagnostics (#642)

### DIFF
--- a/src/tools/alert-detection.ts
+++ b/src/tools/alert-detection.ts
@@ -278,8 +278,32 @@ export function findAlertCandidates(
 }
 
 /**
+ * Detect Unicode whitespace codepoints or NFC-decomposed characters that
+ * would otherwise be indistinguishable from ASCII whitespace in a plain
+ * `string[]` diagnostic field. Mirrors the set handled by `normalizeLabel`
+ * so the annotation is consistent with matching.
+ */
+const DIAGNOSTIC_FANCY_WHITESPACE = /[\u00A0\u202F\u2007\u2060\u2028\u2029]/;
+
+function annotateWhitespace(trimmed: string): string {
+  if (trimmed.length === 0) return trimmed;
+  const nfc = trimmed.normalize('NFC');
+  const hasFancy = DIAGNOSTIC_FANCY_WHITESPACE.test(trimmed);
+  if (!hasFancy && nfc === trimmed) {
+    return trimmed;
+  }
+  const normalized = normalizeLabel(trimmed);
+  return `${trimmed} (norm: ${normalized})`;
+}
+
+/**
  * DFS-collect label strings for all visible+enabled AXButton nodes.
- * Used by PR #3 for diagnostics.
+ * Used for diagnostics surfaced in the `visibleButtons` response field.
+ *
+ * When an original label contains non-ASCII whitespace (NBSP, Narrow NBSP,
+ * Figure Space, Word Joiner, line/paragraph separators) or NFC-divergent
+ * characters, the returned string is annotated as `"<original> (norm: <normalized>)"`.
+ * Pure-ASCII labels are returned unchanged. Return type remains `string[]`.
  */
 export function collectVisibleButtonLabels(tree: AXNode): string[] {
   const labels: string[] = [];
@@ -291,7 +315,7 @@ export function collectVisibleButtonLabels(tree: AXNode): string[] {
       node.label &&
       node.label.trim().length > 0
     ) {
-      labels.push(node.label.trim());
+      labels.push(annotateWhitespace(node.label.trim()));
     }
     for (const child of node.children ?? []) {
       walk(child);
@@ -303,7 +327,7 @@ export function collectVisibleButtonLabels(tree: AXNode): string[] {
 
 /**
  * DFS-collect label strings for all visible+enabled AXStaticText nodes.
- * Used by PR #3 for diagnostics.
+ * Applies the same whitespace annotation as `collectVisibleButtonLabels`.
  */
 export function collectVisibleStaticTexts(tree: AXNode): string[] {
   const texts: string[] = [];
@@ -314,7 +338,7 @@ export function collectVisibleStaticTexts(tree: AXNode): string[] {
       node.label &&
       node.label.trim().length > 0
     ) {
-      texts.push(node.label.trim());
+      texts.push(annotateWhitespace(node.label.trim()));
     }
     for (const child of node.children ?? []) {
       walk(child);

--- a/src/tools/app-handle-alert.ts
+++ b/src/tools/app-handle-alert.ts
@@ -134,13 +134,29 @@ function inferSurface(tree: AXNode): Surface {
   return 'simulator_chrome';
 }
 
+/**
+ * `collectVisibleButtonLabels` annotates non-ASCII whitespace as
+ * `"<original> (norm: <normalized>)"` for diagnostics (slice 2 of #642).
+ * `suggestLabels` operates against the raw label corpus and must strip
+ * that display-only annotation before matching — otherwise the corpus
+ * membership test always misses and we emit synthetic "add me" entries
+ * like `"허용 안 함 (norm: 허용 안 함)"`, which are not real button labels
+ * and would never match at runtime.
+ */
+const DIAGNOSTIC_ANNOTATION_SUFFIX = / \(norm: [^)]*\)$/;
+
+function stripDiagnosticAnnotation(label: string): string {
+  return label.replace(DIAGNOSTIC_ANNOTATION_SUFFIX, '');
+}
+
 function suggestLabels(visibleButtons: string[], action: AlertAction): string[] {
   const corpus = new Set(flattenLabels(action).map((s) => s.trim().toLowerCase()));
   const out: string[] = [];
   for (const label of visibleButtons) {
-    const key = label.trim().toLowerCase();
-    if (key.length === 0) continue;
-    if (!corpus.has(key)) out.push(label.trim());
+    const raw = stripDiagnosticAnnotation(label).trim();
+    if (raw.length === 0) continue;
+    const key = raw.toLowerCase();
+    if (!corpus.has(key)) out.push(raw);
   }
   return Array.from(new Set(out));
 }

--- a/tests/unit/alert-detection.test.ts
+++ b/tests/unit/alert-detection.test.ts
@@ -142,6 +142,25 @@ describe('collectVisibleStaticTexts', () => {
   });
 });
 
+describe('collectVisibleButtonLabels — NBSP annotation (issue #642)', () => {
+  test('notifications-ko-nbsp: NBSP label is annotated, ASCII label is not', () => {
+    const tree = loadFixture('notifications-ko-nbsp.json');
+    const labels = collectVisibleButtonLabels(tree);
+    const NBSP = ' ';
+    expect(labels).toContain(`허용${NBSP}안${NBSP}함 (norm: 허용 안 함)`);
+    expect(labels).toContain('허용');
+    expect(labels).toHaveLength(2);
+  });
+
+  test('maps-ko-location: pure-ASCII-space labels are returned unchanged', () => {
+    const tree = loadFixture('maps-ko-location.json');
+    const labels = collectVisibleButtonLabels(tree);
+    for (const label of labels) {
+      expect(label).not.toContain('(norm:');
+    }
+  });
+});
+
 describe('empty tree edge cases', () => {
   const emptyTree: AXNode = {
     role: 'AXApplication',

--- a/tests/unit/app-handle-alert.test.ts
+++ b/tests/unit/app-handle-alert.test.ts
@@ -161,6 +161,21 @@ describe('app_handle_alert tool', () => {
     expect(body.suggestedLabelsToAdd).toContain('Novel Action');
   });
 
+  test('diagnostics: suggestLabels strips NBSP annotation + matches corpus without polluting suggestions', () => {
+    // Simulates `collectVisibleButtonLabels` output where the NBSP-bearing
+    // label has been annotated as `"<original> (norm: <normalized>)"` for
+    // the `visibleButtons` diagnostic. The corpus stores the ASCII form, so
+    // `suggestLabels` must (a) strip the annotation before matching (so the
+    // corpus membership test still succeeds), and (b) emit only real button
+    // text — never the synthetic `"X (norm: Y)"` string — into
+    // `suggestedLabelsToAdd`.
+    const NBSP = ' ';
+    const annotated = `허용${NBSP}안${NBSP}함 (norm: 허용 안 함)`;
+    const result = _internal.suggestLabels([annotated], 'dismiss');
+    expect(result).not.toContain(annotated);
+    expect(result.some((l) => l.includes('(norm:'))).toBe(false);
+  });
+
   test('surface: SpringBoard-only → simulator_chrome', async () => {
     const tree: AXNode = {
       role: 'AXApplication',


### PR DESCRIPTION
## Summary

Surfaces embedded NBSP / Narrow NBSP / Figure Space / Word Joiner / NFC-decomposed characters in `visibleButtons` and `visibleStaticTexts`, which previously looked identical to their ASCII-spaced corpus counterparts in diagnostic output.

- When a label contains one of the codepoints handled by `normalizeLabel` (or is NFC-decomposed), `collectVisibleButtonLabels` / `collectVisibleStaticTexts` return `"<original> (norm: <normalized>)"`.
- Pure-ASCII labels are returned unchanged. Return type remains `string[]` for compatibility.

Slice 2 of #642. **Stacked on top of #670** — set base to `fix/642-normalize-label` so only PR 2 commits are shown here; please merge #670 first.

## Why

Before this change, the `no_candidate_button` response carried
```
"visibleButtons": ["허용 안 함", "허용"]
```
whether or not the runtime `허용 안 함` used `U+0020` or `U+00A0`. Debug sessions could not tell by eye whether normalization mismatch was the cause. Now NBSP-bearing labels render as
```
"허용 안 함 (norm: 허용 안 함)"
```
which makes the mismatch immediately visible while keeping the field a simple `string[]`.

## Test plan

- [x] `npx jest tests/unit/alert-detection.test.ts tests/unit/app-handle-alert-labels.test.ts tests/unit/app-handle-alert.test.ts` — 62/62 pass.
- [x] New assertion covers the annotated NBSP label and confirms ASCII labels are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)