### PR TITLE
fix(app-handle-alert): emit NBSP variants of multi-word labels in AppleScript fallback (#642)

### DIFF
--- a/src/tools/app-handle-alert.ts
+++ b/src/tools/app-handle-alert.ts
@@ -81,6 +81,11 @@ interface HandleAlertResponse {
  * Build an AppleScript that clicks a Simulator alert button, trying every
  * label in the en/ko/ja/zh-Hans corpus for the requested action before
  * giving up.
+ *
+ * For any multi-word label, also try a variant that replaces each ASCII
+ * space with U+00A0 (NBSP). iOS 26.4's SpringBoard embeds NBSP between
+ * syllables of localized labels (e.g. `허용 안 함`) so that
+ * System Events' button-by-name match requires the NBSP form.
  */
 export function buildAlertScript(action: AlertAction): string {
   const labels = [
@@ -88,12 +93,20 @@ export function buildAlertScript(action: AlertAction): string {
     ...(action === 'accept' ? ['Allow', 'OK', 'Allow While Using App'] : ["Don't Allow", 'Cancel']),
   ];
   const seen = new Set<string>();
-  const unique = labels.filter((l) => {
+  const unique: string[] = [];
+  for (const l of labels) {
     const k = l.trim();
-    if (seen.has(k) || k.length === 0) return false;
+    if (k.length === 0 || seen.has(k)) continue;
     seen.add(k);
-    return true;
-  });
+    unique.push(k);
+    if (k.includes(' ')) {
+      const nbspVariant = k.replace(/ /g, ' ');
+      if (!seen.has(nbspVariant)) {
+        seen.add(nbspVariant);
+        unique.push(nbspVariant);
+      }
+    }
+  }
   const tries = unique.map((l) =>
     `      try\n        click button "${escapeAppleScript(l)}" of sheet 1 of window 1\n        return\n      end try`,
   );

--- a/tests/unit/app-handle-alert.test.ts
+++ b/tests/unit/app-handle-alert.test.ts
@@ -193,4 +193,29 @@ describe('app_handle_alert tool', () => {
     // "Don't Allow" apostrophe is not a quote; must appear verbatim
     expect(script).toContain("Don't Allow");
   });
+
+  test('buildAlertScript emits both ASCII-space and NBSP-space variants for multi-word labels (issue #642)', () => {
+    const NBSP = ' ';
+    const dismissScript = buildAlertScript('dismiss');
+    // Korean dismiss label with ASCII spaces
+    expect(dismissScript).toContain('click button "허용 안 함"');
+    // Same label with U+00A0 between every syllable
+    expect(dismissScript).toContain(`click button "허용${NBSP}안${NBSP}함"`);
+
+    const acceptScript = buildAlertScript('accept');
+    // English multi-word accept label
+    expect(acceptScript).toContain('click button "Allow While Using App"');
+    expect(acceptScript).toContain(
+      `click button "Allow${NBSP}While${NBSP}Using${NBSP}App"`,
+    );
+  });
+
+  test('buildAlertScript does not emit a redundant NBSP variant for single-word labels', () => {
+    const script = buildAlertScript('accept');
+    const NBSP = ' ';
+    // "OK" is one token; no NBSP variant should be emitted
+    const okCount = (script.match(/click button "OK"/g) ?? []).length;
+    expect(okCount).toBeGreaterThanOrEqual(1);
+    expect(script).not.toContain(`click button "OK${NBSP}`);
+  });
 });


### PR DESCRIPTION
## Summary

Extends `buildAlertScript` so that, for every multi-word corpus label, the generated AppleScript also tries a `U+00A0`-separated variant (`click button "허용 안 함"`). This is the belt-and-suspenders for the AX-scan normalization landed in #670: if the AX bridge is unreachable and AppleScript is the only available tier, System Events' exact-name match for a button now finds the NBSP-separated iOS 26.4 Korean label.

- Labels without whitespace are emitted exactly once (no redundant NBSP variant for `"OK"`).
- Existing dedup semantics preserved — a corpus label that already contains NBSP is not duplicated.

Slice 3 of #642. **Stacked on top of #670** — base is `fix/642-normalize-label`, please merge #670 first.

## Test plan

- [x] `npx jest tests/unit/app-handle-alert.test.ts tests/unit/app-system-tools.test.ts tests/unit/alert-detection.test.ts tests/unit/app-handle-alert-labels.test.ts` — 91/91 pass.
- [x] New assertions cover:
  - `click button "허용 안 함"` (ASCII) **and** `click button "허용 안 함"` (NBSP) are both present in the dismiss script.
  - `click button "Allow While Using App"` and its NBSP variant are both present in the accept script.
  - `"OK"` is emitted but not followed by an `OK${NBSP}` variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)