### PR TITLE
feat(device-network): implement pfctl host-wide blocker (#640 PR 3/6)

### DIFF
--- a/src/simulator/network-blockers/index.ts
+++ b/src/simulator/network-blockers/index.ts
@@ -9,15 +9,24 @@ export { AutoBlocker } from './auto';
 export type { AutoBlockerOptions } from './auto';
 export { NlcBlocker } from './nlc';
 export type { NlcBlockerOptions } from './nlc';
-export { PfctlBlocker, PFCTL_ANCHOR_NAME } from './pfctl';
+export {
+  PFCTL_ANCHOR_NAME,
+  PFCTL_BLOCK_RULES,
+  PfctlBlocker,
+  PfctlCommandError,
+  PfctlPfDisabledError,
+} from './pfctl';
 export type { PfctlBlockerOptions } from './pfctl';
 export { RealHostExec } from './host-exec';
+export { RealTempFileWriter } from './temp-file';
+export type { RealTempFileWriterOptions } from './temp-file';
 export type {
   HostExec,
   HostExecOptions,
   NetworkBlocker,
   NetworkBlockerKind,
   NetworkBlockerStatus,
+  TempFileWriter,
 } from './types';
 export {
   NetworkBlockerNotImplementedError,

--- a/src/simulator/network-blockers/pfctl.ts
+++ b/src/simulator/network-blockers/pfctl.ts
@@ -1,22 +1,69 @@
 /**
- * PfctlBlocker — stub that will install/remove a dedicated `pf` anchor to
- * block simulator-bound traffic at the host level. Issue #640, PR 2 only
- * wires the interface and an in-memory state machine; the real anchor
- * rules land in PR 3.
+ * PfctlBlocker — installs a dedicated `pf` anchor that drops all
+ * non-loopback outbound traffic, so iOS Simulator apps (which share
+ * the host's network stack) see deterministic `SocketException` /
+ * `NSURLErrorNotConnectedToInternet` failures.
+ *
+ * Issue #640, PR 3 wires the real `pfctl` calls on top of the PR 2
+ * interface. Crash-safe cleanup / startup reconciliation is PR 4;
+ * the NLC fallback is PR 5.
+ *
+ * Prerequisites (documented in PR 5 / `docs/tools/device-network.md`):
+ *   - `/etc/pf.conf` references the anchor:
+ *       anchor "opensafari-simdevnet"
+ *   - `/etc/sudoers.d/opensafari` grants passwordless pfctl:
+ *       <user> ALL=(root) NOPASSWD: /sbin/pfctl
+ *   - pf is enabled on the host (`sudo pfctl -E`).
+ *
+ * Without these, `apply()` surfaces a structured error rather than
+ * silently loading rules that never fire.
  */
 
 import {
   HostExec,
   NetworkBlocker,
-  NetworkBlockerNotImplementedError,
   NetworkBlockerStatus,
   NetworkBlockerUnavailableError,
+  TempFileWriter,
 } from './types';
 
 export const PFCTL_ANCHOR_NAME = 'opensafari-simdevnet';
 
+/**
+ * pf rules loaded into the anchor. Blocks all non-loopback outbound
+ * traffic so URLSession / dart:io HttpClient calls from the simulator
+ * fail immediately. Loopback is preserved so localhost IPC (webkit
+ * proxy, MCP stdio) keeps working while the block is active.
+ */
+export const PFCTL_BLOCK_RULES = [
+  '# opensafari #640: simulator-bound network block',
+  'block drop out on ! lo0 all',
+  '',
+].join('\n');
+
+export class PfctlPfDisabledError extends Error {
+  constructor() {
+    super(
+      'pf is not enabled on this host; run "sudo pfctl -E" or follow the one-time setup in docs/tools/device-network.md to enable pf and install the opensafari-simdevnet anchor',
+    );
+    this.name = 'PfctlPfDisabledError';
+  }
+}
+
+export class PfctlCommandError extends Error {
+  constructor(
+    public readonly op: 'apply' | 'revert' | 'probe',
+    public readonly stderr: string,
+    public readonly exitCode: number | null,
+  ) {
+    super(`pfctl ${op} failed (exit ${exitCode ?? '?'}): ${stderr.trim() || '(no stderr)'}`);
+    this.name = 'PfctlCommandError';
+  }
+}
+
 export interface PfctlBlockerOptions {
   exec: HostExec;
+  tempFile: TempFileWriter;
   /**
    * When true, `isAvailable()` resolves true without probing (used by tests).
    * In production, availability is decided by whether `sudo -n pfctl -sr`
@@ -25,20 +72,30 @@ export interface PfctlBlockerOptions {
   assumeAvailable?: boolean;
   /** Override anchor name for tests. */
   anchorName?: string;
+  /** Override the rule body for tests. */
+  rules?: string;
+  /** Time provider for deterministic tests. */
+  now?: () => Date;
 }
 
 export class PfctlBlocker implements NetworkBlocker {
   readonly kind = 'pfctl' as const;
   private readonly exec: HostExec;
+  private readonly tempFile: TempFileWriter;
   private readonly assumeAvailable: boolean;
   private readonly anchor: string;
+  private readonly rules: string;
+  private readonly nowFn: () => Date;
   private active = false;
   private activeSince: string | null = null;
 
   constructor(opts: PfctlBlockerOptions) {
     this.exec = opts.exec;
+    this.tempFile = opts.tempFile;
     this.assumeAvailable = opts.assumeAvailable === true;
     this.anchor = opts.anchorName ?? PFCTL_ANCHOR_NAME;
+    this.rules = opts.rules ?? PFCTL_BLOCK_RULES;
+    this.nowFn = opts.now ?? (() => new Date());
   }
 
   async isAvailable(): Promise<boolean> {
@@ -57,19 +114,44 @@ export class PfctlBlocker implements NetworkBlocker {
     if (!(await this.isAvailable())) {
       throw new NetworkBlockerUnavailableError(
         'pfctl',
-        'sudo pfctl requires a passwordless sudoers rule; see docs/tools/device-network.md (pending PR 5)',
+        'sudo pfctl requires a passwordless sudoers rule; see docs/tools/device-network.md',
       );
     }
     if (this.active) return; // idempotent
-    // Real anchor install lands in PR 3.
-    // For PR 2 we deliberately raise NotImplemented so CI surfaces the
-    // missing backend rather than silently "blocking" traffic.
-    throw new NetworkBlockerNotImplementedError('pfctl', 'apply');
+
+    await this.assertPfEnabled();
+
+    const rulesPath = await this.tempFile.write(this.rules);
+    try {
+      try {
+        await this.exec.run(
+          '/usr/bin/sudo',
+          ['-n', '/sbin/pfctl', '-a', this.anchor, '-f', rulesPath],
+          { timeoutMs: 5000 },
+        );
+      } catch (err) {
+        throw this.wrapExecError('apply', err);
+      }
+      this.active = true;
+      this.activeSince = this.nowFn().toISOString();
+    } finally {
+      await this.tempFile.remove(rulesPath).catch(() => undefined);
+    }
   }
 
   async revert(_deviceId: string): Promise<void> {
     if (!this.active) return; // idempotent
-    throw new NetworkBlockerNotImplementedError('pfctl', 'revert');
+    try {
+      await this.exec.run(
+        '/usr/bin/sudo',
+        ['-n', '/sbin/pfctl', '-a', this.anchor, '-F', 'all'],
+        { timeoutMs: 5000 },
+      );
+    } catch (err) {
+      throw this.wrapExecError('revert', err);
+    }
+    this.active = false;
+    this.activeSince = null;
   }
 
   async status(): Promise<NetworkBlockerStatus> {
@@ -78,6 +160,28 @@ export class PfctlBlocker implements NetworkBlocker {
       activeSince: this.activeSince,
       detail: this.active ? `pf anchor ${this.anchor}` : null,
     };
+  }
+
+  private async assertPfEnabled(): Promise<void> {
+    let stdout: string;
+    try {
+      stdout = await this.exec.run('/usr/bin/sudo', ['-n', '/sbin/pfctl', '-s', 'info'], {
+        timeoutMs: 2000,
+      });
+    } catch (err) {
+      throw this.wrapExecError('probe', err);
+    }
+    // macOS `pfctl -s info` prints e.g. "Status: Enabled for 12 days ..." or "Status: Disabled".
+    if (!/Status:\s*Enabled/i.test(stdout)) {
+      throw new PfctlPfDisabledError();
+    }
+  }
+
+  private wrapExecError(op: 'apply' | 'revert' | 'probe', err: unknown): PfctlCommandError {
+    const e = err as { stderr?: string; code?: number; message?: string };
+    const stderr = e.stderr ?? e.message ?? '';
+    const code = typeof e.code === 'number' ? e.code : null;
+    return new PfctlCommandError(op, stderr, code);
   }
 
   /** Test-only helper to inject state without going through apply(). */

--- a/src/simulator/network-blockers/temp-file.ts
+++ b/src/simulator/network-blockers/temp-file.ts
@@ -1,0 +1,50 @@
+/**
+ * Production {@link TempFileWriter} backed by `fs.promises`.
+ *
+ * Kept isolated from the blocker modules so unit tests can import the
+ * blockers without pulling in any Node filesystem code, and so the tool
+ * layer can inject a test writer that returns deterministic paths.
+ */
+
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { TempFileWriter } from './types';
+
+export interface RealTempFileWriterOptions {
+  /** Directory name prefix for `fs.mkdtemp`. */
+  prefix?: string;
+  /** Override the base tmp directory (tests). */
+  baseDir?: string;
+}
+
+export class RealTempFileWriter implements TempFileWriter {
+  private readonly prefix: string;
+  private readonly baseDir: string;
+
+  constructor(opts: RealTempFileWriterOptions = {}) {
+    this.prefix = opts.prefix ?? 'opensafari-pfctl-';
+    this.baseDir = opts.baseDir ?? os.tmpdir();
+  }
+
+  async write(contents: string): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(this.baseDir, this.prefix));
+    const file = path.join(dir, 'rules.conf');
+    await fs.writeFile(file, contents, { mode: 0o644 });
+    return file;
+  }
+
+  async remove(filePath: string): Promise<void> {
+    try {
+      await fs.unlink(filePath);
+    } catch {
+      // already gone — acceptable
+    }
+    try {
+      await fs.rmdir(path.dirname(filePath));
+    } catch {
+      // non-empty or already gone — acceptable
+    }
+  }
+}

--- a/src/simulator/network-blockers/types.ts
+++ b/src/simulator/network-blockers/types.ts
@@ -6,9 +6,9 @@
  * tools consume blockers through this interface only — they do not know
  * which mechanism is in use, so selection logic lives in `AutoBlocker`.
  *
- * This file is PR 2 (#640) and is intentionally side-effect-free:
- * concrete blockers accept an injectable {@link HostExec} so unit tests
- * can drive them with mocks. Real system calls land in PRs 3 / 4.
+ * Concrete blockers accept injectable {@link HostExec} and {@link TempFileWriter}
+ * surfaces so unit tests can drive them with mocks. PR 2 (#640) added the
+ * abstraction; PR 3 wires the real pfctl backend; PR 5 wires NLC.
  */
 
 export type NetworkBlockerKind = 'pfctl' | 'nlc';
@@ -70,6 +70,30 @@ export interface HostExecOptions {
   env?: Record<string, string>;
   /** If true, non-zero exit is returned as {stdout, code, stderr} instead of throwing. */
   allowNonZero?: boolean;
+}
+
+/**
+ * Injectable temp-file surface used by blockers that must materialise
+ * on-disk rules for system tools that read files (e.g. `pfctl -f <path>`).
+ *
+ * Production code wires this to a `fs.mkdtemp`-based writer under
+ * `os.tmpdir()`. Tests pass a mock that returns a fixed path so they
+ * can assert on the rule contents without touching the filesystem.
+ */
+export interface TempFileWriter {
+  /**
+   * Write the given contents to a fresh temp file and return its absolute
+   * path. The writer owns the parent directory; callers must call
+   * `remove()` (best-effort) after the file is consumed.
+   */
+  write(contents: string): Promise<string>;
+
+  /**
+   * Best-effort cleanup: remove the file and its parent directory if
+   * empty. Must never throw — stale temp files are a lower-priority
+   * concern than apply/revert correctness.
+   */
+  remove(path: string): Promise<void>;
 }
 
 export class NetworkBlockerUnavailableError extends Error {

--- a/src/tools/device-network.ts
+++ b/src/tools/device-network.ts
@@ -1,6 +1,14 @@
 import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { getSessionManager } from '../session-manager';
+import {
+  AutoBlocker,
+  NetworkBlocker,
+  NlcBlocker,
+  PfctlBlocker,
+  RealHostExec,
+  RealTempFileWriter,
+} from '../simulator/network-blockers';
 
 export type DeviceNetworkMode = 'online' | 'offline' | 'airplane';
 export type DeviceNetworkMechanism = 'pfctl' | 'nlc' | 'auto';
@@ -20,8 +28,77 @@ const DEFAULT_STATE: DeviceNetworkStateEntry = {
 
 const stateByDevice = new Map<string, DeviceNetworkStateEntry>();
 
+/**
+ * Blocker bundle used by the tool layer. The pf/NLC backends are
+ * host-wide — they affect the whole machine's network stack — so we
+ * keep a single shared instance and reference-count offline devices.
+ *
+ * The `auto` member is an {@link AutoBlocker} composed from the two
+ * concrete backends; when the caller passes `mechanism: "auto"` we
+ * route through it so selection (pfctl → nlc fallback) is cached.
+ */
+export interface HostBlockerBundle {
+  pfctl: NetworkBlocker;
+  nlc: NetworkBlocker;
+  auto: NetworkBlocker;
+}
+
+let hostBlocker: HostBlockerBundle | null = null;
+/** Reference-tracking: which blocker (if any) currently owns the active host rule. */
+let activeHostBlocker: NetworkBlocker | null = null;
+
+function buildDefaultHostBlocker(): HostBlockerBundle {
+  const exec = new RealHostExec();
+  const tempFile = new RealTempFileWriter();
+  const pfctl = new PfctlBlocker({ exec, tempFile });
+  const nlc = new NlcBlocker({ exec });
+  const auto = new AutoBlocker({ candidates: [pfctl, nlc] });
+  return { pfctl, nlc, auto };
+}
+
+function getHostBlocker(): HostBlockerBundle {
+  if (!hostBlocker) {
+    hostBlocker = buildDefaultHostBlocker();
+  }
+  return hostBlocker;
+}
+
+function selectBlocker(
+  bundle: HostBlockerBundle,
+  mechanism: DeviceNetworkMechanism,
+): NetworkBlocker {
+  switch (mechanism) {
+    case 'pfctl':
+      return bundle.pfctl;
+    case 'nlc':
+      return bundle.nlc;
+    case 'auto':
+      return bundle.auto;
+  }
+}
+
+function resolvedMechanismFor(b: NetworkBlocker): DeviceNetworkResolvedMechanism {
+  return b.kind === 'pfctl' || b.kind === 'nlc' ? b.kind : null;
+}
+
+function countOfflineDevices(): number {
+  let n = 0;
+  for (const s of stateByDevice.values()) {
+    if (s.mode !== 'online') n += 1;
+  }
+  return n;
+}
+
+/** Test hook: inject a mock blocker bundle. Passing null restores the default. */
+export function __setHostBlockerForTests(bundle: HostBlockerBundle | null): void {
+  hostBlocker = bundle;
+  activeHostBlocker = null;
+}
+
 export function __resetDeviceNetworkStateForTests(): void {
   stateByDevice.clear();
+  hostBlocker = null;
+  activeHostBlocker = null;
 }
 
 export function getDeviceNetworkState(deviceId: string): DeviceNetworkStateEntry {
@@ -48,12 +125,23 @@ function jsonResponse(body: unknown, isError = false) {
   };
 }
 
+function blockerErrorBody(deviceId: string, mode: DeviceNetworkMode, err: unknown) {
+  const e = err as { name?: string; message?: string };
+  return {
+    ok: false,
+    error: e.name ?? 'blocker_failed',
+    message: e.message ?? String(err),
+    deviceId,
+    requestedMode: mode,
+  };
+}
+
 export function registerDeviceNetworkSetTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'device_network_set',
       description:
-        'Toggle the iOS Simulator host-level network state so native apps (Flutter, UIKit) see real SocketException / NSURLErrorNotConnectedToInternet. Unlike network_offline (which is WebKit-only), this is intended to affect URLSession and dart:io HttpClient traffic. Scaffold only in this build — requesting offline/airplane returns NotImplemented until the pfctl/NLC backend lands.',
+        'Toggle the iOS Simulator host-level network state so native apps (Flutter, UIKit) see real SocketException / NSURLErrorNotConnectedToInternet. Unlike network_offline (WebKit-only), this targets URLSession and dart:io HttpClient traffic via pfctl or Network Link Conditioner. Requires a one-time setup (passwordless sudoers + /etc/pf.conf anchor) — see docs/tools/device-network.md.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -95,15 +183,30 @@ export function registerDeviceNetworkSetTool(server: MCPServer): void {
         return jsonResponse({ ok: false, error: 'no_booted_device' }, true);
       }
 
+      const bundle = getHostBlocker();
       const current = getDeviceNetworkState(deviceId);
 
       if (mode === 'online') {
+        const wasOffline = current.mode !== 'online';
         const next: DeviceNetworkStateEntry = {
           mode: 'online',
           mechanism: null,
           activeSince: null,
         };
         setDeviceNetworkState(deviceId, next);
+
+        // If this was the last offline device, revert the host-wide rule.
+        if (wasOffline && countOfflineDevices() === 0 && activeHostBlocker) {
+          try {
+            await activeHostBlocker.revert(deviceId);
+          } catch (err) {
+            // Roll state back so a subsequent retry can re-attempt revert.
+            setDeviceNetworkState(deviceId, current);
+            return jsonResponse(blockerErrorBody(deviceId, mode, err), true);
+          }
+          activeHostBlocker = null;
+        }
+
         return jsonResponse({
           ok: true,
           deviceId,
@@ -114,22 +217,54 @@ export function registerDeviceNetworkSetTool(server: MCPServer): void {
           note:
             current.mode === 'online'
               ? 'already online; no mechanism was active'
-              : 'restored to online (scaffold: no real rule was installed)',
+              : 'restored to online',
         });
       }
 
-      return jsonResponse(
-        {
-          ok: false,
-          error: 'not_implemented',
-          deviceId,
-          requestedMode: mode,
-          requestedMechanism: mechanismArg,
-          message:
-            'device_network_set scaffold is registered, but no blocking backend is wired yet. Tracking in issue #640 — PR 2 adds the mechanism abstraction, PR 3 wires pfctl, PR 4 wires NLC.',
-        },
-        true,
-      );
+      // offline / airplane
+      const requested = selectBlocker(bundle, mechanismArg);
+
+      // Enforce single-mechanism invariant: if a different blocker is already
+      // active, reject rather than silently stacking rules on the host.
+      if (activeHostBlocker && activeHostBlocker !== requested) {
+        return jsonResponse(
+          {
+            ok: false,
+            error: 'mechanism_conflict',
+            message:
+              'another mechanism is already active on this host; set all devices back to "online" before switching mechanisms',
+            activeMechanism: activeHostBlocker.kind,
+            requestedMechanism: requested.kind,
+            deviceId,
+          },
+          true,
+        );
+      }
+
+      try {
+        await requested.apply(deviceId);
+      } catch (err) {
+        return jsonResponse(blockerErrorBody(deviceId, mode, err), true);
+      }
+
+      activeHostBlocker = requested;
+      const resolved = resolvedMechanismFor(requested);
+      const appliedAt = new Date().toISOString();
+      const next: DeviceNetworkStateEntry = {
+        mode,
+        mechanism: resolved,
+        activeSince: appliedAt,
+      };
+      setDeviceNetworkState(deviceId, next);
+
+      return jsonResponse({
+        ok: true,
+        deviceId,
+        mode,
+        mechanism: resolved,
+        appliedAt,
+        previousMode: current.mode,
+      });
     },
   );
 }
@@ -139,7 +274,7 @@ export function registerDeviceNetworkGetTool(server: MCPServer): void {
     {
       name: 'device_network_get',
       description:
-        'Read the current simulated network state set by device_network_set. Returns {mode, mechanism, activeSince}. Scaffold build — always reports "online" until a backend is wired.',
+        'Read the current simulated network state set by device_network_set. Returns {mode, mechanism, activeSince}.',
       inputSchema: {
         type: 'object' as const,
         properties: {

--- a/tests/unit/device-network.test.ts
+++ b/tests/unit/device-network.test.ts
@@ -1,8 +1,9 @@
 /**
- * Unit tests for device_network_set / device_network_get (issue #640, PR 1 scaffold).
+ * Unit tests for device_network_set / device_network_get (issue #640).
  *
- * The scaffold intentionally returns `not_implemented` for offline/airplane so that
- * CI surfaces the missing backend; online + get must still behave correctly.
+ * PR 3 wires the tool layer to a real pfctl blocker via the bundle DI seam.
+ * All host side-effects are stubbed: tests inject a mock blocker bundle so
+ * the handler calls `apply`/`revert` on predictable mocks.
  */
 
 jest.mock('../../src/simulator', () => ({
@@ -18,14 +19,20 @@ jest.mock('../../src/session-manager', () => ({
 }));
 
 import { MCPServer } from '../../src/mcp-server';
+import { NetworkBlocker, NetworkBlockerStatus } from '../../src/simulator/network-blockers';
 import {
-  registerDeviceNetworkSetTool,
-  registerDeviceNetworkGetTool,
-  registerDeviceNetworkTools,
+  HostBlockerBundle,
   __resetDeviceNetworkStateForTests,
+  __setHostBlockerForTests,
+  registerDeviceNetworkGetTool,
+  registerDeviceNetworkSetTool,
+  registerDeviceNetworkTools,
 } from '../../src/tools/device-network';
 
-type ToolHandler = (s: string, p: Record<string, unknown>) => Promise<{
+type ToolHandler = (
+  s: string,
+  p: Record<string, unknown>,
+) => Promise<{
   content: Array<{ type: string; text: string }>;
   isError?: boolean;
 }>;
@@ -40,8 +47,45 @@ function extractHandler(server: { registerTool: jest.Mock }, name: string): Tool
   return call[1] as ToolHandler;
 }
 
+interface MockBlocker extends NetworkBlocker {
+  isAvailable: jest.Mock<Promise<boolean>, []>;
+  apply: jest.Mock<Promise<void>, [string]>;
+  revert: jest.Mock<Promise<void>, [string]>;
+  status: jest.Mock<Promise<NetworkBlockerStatus>, []>;
+}
+
+function makeMockBlocker(kind: 'pfctl' | 'nlc'): MockBlocker {
+  return {
+    kind,
+    isAvailable: jest.fn<Promise<boolean>, []>().mockResolvedValue(true),
+    apply: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
+    revert: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
+    status: jest
+      .fn<Promise<NetworkBlockerStatus>, []>()
+      .mockResolvedValue({ active: false, activeSince: null, detail: null }),
+  };
+}
+
+function makeMockBundle(): {
+  bundle: HostBlockerBundle;
+  pfctl: MockBlocker;
+  nlc: MockBlocker;
+  auto: MockBlocker;
+} {
+  const pfctl = makeMockBlocker('pfctl');
+  const nlc = makeMockBlocker('nlc');
+  // auto delegates to pfctl for test determinism; its kind is 'pfctl' so
+  // `resolvedMechanismFor` surfaces 'pfctl' for auto-routed callers too.
+  const auto = makeMockBlocker('pfctl');
+  return { bundle: { pfctl, nlc, auto }, pfctl, nlc, auto };
+}
+
 beforeEach(() => {
   __resetDeviceNetworkStateForTests();
+});
+
+afterEach(() => {
+  __setHostBlockerForTests(null);
 });
 
 describe('device_network registration', () => {
@@ -72,15 +116,15 @@ describe('device_network registration', () => {
   });
 });
 
-describe('device_network_set handler (scaffold)', () => {
+describe('device_network_set handler — validation', () => {
   let setHandler: ToolHandler;
-  let getHandler: ToolHandler;
 
   beforeEach(() => {
     const server = makeServer();
+    const { bundle } = makeMockBundle();
+    __setHostBlockerForTests(bundle);
     registerDeviceNetworkTools(server as unknown as MCPServer);
     setHandler = extractHandler(server, 'device_network_set');
-    getHandler = extractHandler(server, 'device_network_get');
   });
 
   it('rejects invalid mode', async () => {
@@ -97,38 +141,35 @@ describe('device_network_set handler (scaffold)', () => {
     const body = JSON.parse(result.content[0].text);
     expect(body.error).toBe('invalid_mechanism');
   });
+});
 
-  it('returns not_implemented for offline (scaffold build)', async () => {
-    const result = await setHandler('s', { mode: 'offline' });
-    expect(result.isError).toBe(true);
-    const body = JSON.parse(result.content[0].text);
-    expect(body.error).toBe('not_implemented');
-    expect(body.requestedMode).toBe('offline');
-    expect(body.requestedMechanism).toBe('auto');
-    expect(body.message).toMatch(/#640/);
+describe('device_network_set handler — online path', () => {
+  let setHandler: ToolHandler;
+  let getHandler: ToolHandler;
+  let pfctl: MockBlocker;
+
+  beforeEach(() => {
+    const server = makeServer();
+    const { bundle, pfctl: p } = makeMockBundle();
+    pfctl = p;
+    __setHostBlockerForTests(bundle);
+    registerDeviceNetworkTools(server as unknown as MCPServer);
+    setHandler = extractHandler(server, 'device_network_set');
+    getHandler = extractHandler(server, 'device_network_get');
   });
 
-  it('returns not_implemented for airplane (scaffold build)', async () => {
-    const result = await setHandler('s', { mode: 'airplane', mechanism: 'pfctl' });
-    expect(result.isError).toBe(true);
-    const body = JSON.parse(result.content[0].text);
-    expect(body.error).toBe('not_implemented');
-    expect(body.requestedMode).toBe('airplane');
-    expect(body.requestedMechanism).toBe('pfctl');
-  });
-
-  it('accepts online as an idempotent no-op and records state', async () => {
+  it('online when already online is an idempotent no-op (no blocker calls)', async () => {
     const first = await setHandler('s', { mode: 'online' });
     expect(first.isError).toBeUndefined();
     const firstBody = JSON.parse(first.content[0].text);
     expect(firstBody.ok).toBe(true);
     expect(firstBody.mode).toBe('online');
-    expect(firstBody.mechanism).toBeNull();
     expect(firstBody.previousMode).toBe('online');
+    expect(firstBody.note).toMatch(/already online/);
+    expect(pfctl.revert).not.toHaveBeenCalled();
 
     const second = await setHandler('s', { mode: 'online' });
     const secondBody = JSON.parse(second.content[0].text);
-    expect(secondBody.ok).toBe(true);
     expect(secondBody.note).toMatch(/already online/);
   });
 
@@ -152,12 +193,137 @@ describe('device_network_set handler (scaffold)', () => {
     expect(body.mechanism).toBeNull();
     expect(body.activeSince).toBeNull();
   });
+});
 
-  it('device_network_get reports state set by device_network_set(online)', async () => {
-    await setHandler('s', { mode: 'online', udid: 'device-a' });
-    const result = await getHandler('s', { udid: 'device-a' });
+describe('device_network_set handler — offline path (pfctl wired)', () => {
+  let setHandler: ToolHandler;
+  let getHandler: ToolHandler;
+  let pfctl: MockBlocker;
+  let nlc: MockBlocker;
+  let auto: MockBlocker;
+
+  beforeEach(() => {
+    const server = makeServer();
+    const bundle = makeMockBundle();
+    pfctl = bundle.pfctl;
+    nlc = bundle.nlc;
+    auto = bundle.auto;
+    __setHostBlockerForTests(bundle.bundle);
+    registerDeviceNetworkTools(server as unknown as MCPServer);
+    setHandler = extractHandler(server, 'device_network_set');
+    getHandler = extractHandler(server, 'device_network_get');
+  });
+
+  it('offline calls AutoBlocker.apply and records state with resolved mechanism', async () => {
+    const result = await setHandler('s', { mode: 'offline', udid: 'device-a' });
+    expect(result.isError).toBeUndefined();
     const body = JSON.parse(result.content[0].text);
-    expect(body.mode).toBe('online');
-    expect(body.deviceId).toBe('device-a');
+    expect(body.ok).toBe(true);
+    expect(body.mode).toBe('offline');
+    expect(body.mechanism).toBe('pfctl');
+    expect(body.appliedAt).toEqual(expect.any(String));
+    expect(auto.apply).toHaveBeenCalledWith('device-a');
+    expect(pfctl.apply).not.toHaveBeenCalled();
+    expect(nlc.apply).not.toHaveBeenCalled();
+
+    const getResult = await getHandler('s', { udid: 'device-a' });
+    const getBody = JSON.parse(getResult.content[0].text);
+    expect(getBody.mode).toBe('offline');
+    expect(getBody.mechanism).toBe('pfctl');
+  });
+
+  it('airplane routes through the same apply code path as offline', async () => {
+    const result = await setHandler('s', { mode: 'airplane', udid: 'device-b' });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content[0].text);
+    expect(body.mode).toBe('airplane');
+    expect(body.mechanism).toBe('pfctl');
+    expect(auto.apply).toHaveBeenCalledWith('device-b');
+  });
+
+  it('mechanism: "pfctl" routes directly to the pfctl backend', async () => {
+    const result = await setHandler('s', {
+      mode: 'offline',
+      mechanism: 'pfctl',
+      udid: 'device-c',
+    });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content[0].text);
+    expect(body.mechanism).toBe('pfctl');
+    expect(pfctl.apply).toHaveBeenCalledWith('device-c');
+    expect(auto.apply).not.toHaveBeenCalled();
+  });
+
+  it('propagates blocker apply() failure as an isError response', async () => {
+    const err = new Error('sudo pfctl failed');
+    err.name = 'PfctlCommandError';
+    auto.apply.mockRejectedValueOnce(err);
+
+    const result = await setHandler('s', { mode: 'offline', udid: 'device-d' });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toBe('PfctlCommandError');
+    expect(body.message).toMatch(/sudo pfctl failed/);
+
+    // state must NOT be recorded when apply fails
+    const getResult = await getHandler('s', { udid: 'device-d' });
+    const getBody = JSON.parse(getResult.content[0].text);
+    expect(getBody.mode).toBe('online');
+  });
+
+  it('rejects a mechanism switch when another backend is already active (mechanism_conflict)', async () => {
+    await setHandler('s', { mode: 'offline', mechanism: 'pfctl', udid: 'device-a' });
+    const conflict = await setHandler('s', { mode: 'offline', mechanism: 'nlc', udid: 'device-b' });
+    expect(conflict.isError).toBe(true);
+    const body = JSON.parse(conflict.content[0].text);
+    expect(body.error).toBe('mechanism_conflict');
+    expect(body.activeMechanism).toBe('pfctl');
+    expect(body.requestedMechanism).toBe('nlc');
+    expect(nlc.apply).not.toHaveBeenCalled();
+  });
+});
+
+describe('device_network_set handler — reference-counting revert', () => {
+  let setHandler: ToolHandler;
+  let auto: MockBlocker;
+
+  beforeEach(() => {
+    const server = makeServer();
+    const bundle = makeMockBundle();
+    auto = bundle.auto;
+    __setHostBlockerForTests(bundle.bundle);
+    registerDeviceNetworkTools(server as unknown as MCPServer);
+    setHandler = extractHandler(server, 'device_network_set');
+  });
+
+  it('does not revert when one of several offline devices returns online', async () => {
+    await setHandler('s', { mode: 'offline', udid: 'device-a' });
+    await setHandler('s', { mode: 'offline', udid: 'device-b' });
+    expect(auto.apply).toHaveBeenCalledTimes(2);
+
+    await setHandler('s', { mode: 'online', udid: 'device-a' });
+    expect(auto.revert).not.toHaveBeenCalled();
+  });
+
+  it('reverts when the last offline device returns online', async () => {
+    await setHandler('s', { mode: 'offline', udid: 'device-a' });
+    await setHandler('s', { mode: 'offline', udid: 'device-b' });
+    await setHandler('s', { mode: 'online', udid: 'device-a' });
+    await setHandler('s', { mode: 'online', udid: 'device-b' });
+    expect(auto.revert).toHaveBeenCalledTimes(1);
+    expect(auto.revert).toHaveBeenCalledWith('device-b');
+  });
+
+  it('rolls back state and surfaces error when revert fails', async () => {
+    await setHandler('s', { mode: 'offline', udid: 'device-a' });
+
+    const err = new Error('pfctl revert failed');
+    err.name = 'PfctlCommandError';
+    auto.revert.mockRejectedValueOnce(err);
+
+    const result = await setHandler('s', { mode: 'online', udid: 'device-a' });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toBe('PfctlCommandError');
   });
 });

--- a/tests/unit/network-blockers.test.ts
+++ b/tests/unit/network-blockers.test.ts
@@ -1,6 +1,8 @@
 /**
  * Unit tests for the simulator network-blocker abstraction layer
- * (issue #640, PR 2). No real system calls — all exec is mocked.
+ * (issue #640). No real system calls — all exec and temp-file I/O is
+ * mocked. PR 3 wires pfctl to real pfctl commands; NLC is still
+ * scaffold and raises NotImplemented until PR 5.
  */
 
 import {
@@ -11,96 +13,248 @@ import {
   NetworkBlockerUnavailableError,
   NlcBlocker,
   PFCTL_ANCHOR_NAME,
+  PFCTL_BLOCK_RULES,
   PfctlBlocker,
+  PfctlCommandError,
+  PfctlPfDisabledError,
+  TempFileWriter,
 } from '../../src/simulator/network-blockers';
 
 function makeMockExec(): jest.Mocked<HostExec> {
   return { run: jest.fn().mockResolvedValue('') };
 }
 
+function makeMockTempFile(
+  fixedPath = '/tmp/opensafari-pfctl-mock/rules.conf',
+): jest.Mocked<TempFileWriter> {
+  return {
+    write: jest.fn<Promise<string>, [string]>().mockResolvedValue(fixedPath),
+    remove: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
+  };
+}
+
 const DEVICE_ID = 'test-device-udid';
+const PF_INFO_ENABLED = 'Status: Enabled for 12 days 03:45:12                Debug: Urgent\n';
+const PF_INFO_DISABLED = 'Status: Disabled\n';
 
 describe('PfctlBlocker', () => {
   it('reports kind "pfctl"', () => {
-    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true });
+    const b = new PfctlBlocker({
+      exec: makeMockExec(),
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+    });
     expect(b.kind).toBe('pfctl');
   });
 
-  it('isAvailable returns true when sudo pfctl -sr succeeds', async () => {
-    const exec = makeMockExec();
-    exec.run.mockResolvedValueOnce('scrub in all');
-    const b = new PfctlBlocker({ exec });
-    await expect(b.isAvailable()).resolves.toBe(true);
-    expect(exec.run).toHaveBeenCalledWith(
-      '/usr/bin/sudo',
-      ['-n', '/sbin/pfctl', '-sr'],
-      expect.objectContaining({ timeoutMs: 2000 }),
-    );
-  });
+  describe('isAvailable', () => {
+    it('returns true when sudo pfctl -sr succeeds', async () => {
+      const exec = makeMockExec();
+      exec.run.mockResolvedValueOnce('scrub in all');
+      const b = new PfctlBlocker({ exec, tempFile: makeMockTempFile() });
+      await expect(b.isAvailable()).resolves.toBe(true);
+      expect(exec.run).toHaveBeenCalledWith(
+        '/usr/bin/sudo',
+        ['-n', '/sbin/pfctl', '-sr'],
+        expect.objectContaining({ timeoutMs: 2000 }),
+      );
+    });
 
-  it('isAvailable returns false when sudo pfctl fails', async () => {
-    const exec = makeMockExec();
-    exec.run.mockRejectedValueOnce(new Error('sudo: a password is required'));
-    const b = new PfctlBlocker({ exec });
-    await expect(b.isAvailable()).resolves.toBe(false);
-  });
+    it('returns false when sudo pfctl fails', async () => {
+      const exec = makeMockExec();
+      exec.run.mockRejectedValueOnce(new Error('sudo: a password is required'));
+      const b = new PfctlBlocker({ exec, tempFile: makeMockTempFile() });
+      await expect(b.isAvailable()).resolves.toBe(false);
+    });
 
-  it('assumeAvailable bypasses probing', async () => {
-    const exec = makeMockExec();
-    const b = new PfctlBlocker({ exec, assumeAvailable: true });
-    await expect(b.isAvailable()).resolves.toBe(true);
-    expect(exec.run).not.toHaveBeenCalled();
-  });
-
-  it('apply throws NetworkBlockerUnavailableError when mechanism is unavailable', async () => {
-    const exec = makeMockExec();
-    exec.run.mockRejectedValueOnce(new Error('sudo required'));
-    const b = new PfctlBlocker({ exec });
-    await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerUnavailableError);
-  });
-
-  it('apply throws NotImplemented in scaffold PR 2 even when available', async () => {
-    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true });
-    await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerNotImplementedError);
-  });
-
-  it('apply is idempotent when already active (no throw, no exec call)', async () => {
-    const exec = makeMockExec();
-    const b = new PfctlBlocker({ exec, assumeAvailable: true });
-    b.__setActiveForTests(true);
-    await expect(b.apply(DEVICE_ID)).resolves.toBeUndefined();
-    expect(exec.run).not.toHaveBeenCalled();
-  });
-
-  it('revert is a no-op when nothing is active', async () => {
-    const exec = makeMockExec();
-    const b = new PfctlBlocker({ exec, assumeAvailable: true });
-    await expect(b.revert(DEVICE_ID)).resolves.toBeUndefined();
-    expect(exec.run).not.toHaveBeenCalled();
-  });
-
-  it('revert throws NotImplemented when active (scaffold)', async () => {
-    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true });
-    b.__setActiveForTests(true);
-    await expect(b.revert(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerNotImplementedError);
-  });
-
-  it('status reports active+detail when active, inactive otherwise', async () => {
-    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true });
-    await expect(b.status()).resolves.toEqual({ active: false, activeSince: null, detail: null });
-    b.__setActiveForTests(true, '2026-04-23T00:00:00.000Z');
-    await expect(b.status()).resolves.toEqual({
-      active: true,
-      activeSince: '2026-04-23T00:00:00.000Z',
-      detail: `pf anchor ${PFCTL_ANCHOR_NAME}`,
+    it('assumeAvailable bypasses probing', async () => {
+      const exec = makeMockExec();
+      const b = new PfctlBlocker({ exec, tempFile: makeMockTempFile(), assumeAvailable: true });
+      await expect(b.isAvailable()).resolves.toBe(true);
+      expect(exec.run).not.toHaveBeenCalled();
     });
   });
 
-  it('anchorName option overrides the default anchor', async () => {
-    const b = new PfctlBlocker({ exec: makeMockExec(), assumeAvailable: true, anchorName: 'custom' });
-    b.__setActiveForTests(true);
-    const s = await b.status();
-    expect(s.detail).toBe('pf anchor custom');
+  describe('apply (PR 3 real backend)', () => {
+    it('throws NetworkBlockerUnavailableError when mechanism is unavailable', async () => {
+      const exec = makeMockExec();
+      exec.run.mockRejectedValueOnce(new Error('sudo required'));
+      const b = new PfctlBlocker({ exec, tempFile: makeMockTempFile() });
+      await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerUnavailableError);
+    });
+
+    it('throws PfctlPfDisabledError when pf is disabled', async () => {
+      const exec = makeMockExec();
+      exec.run.mockResolvedValueOnce(PF_INFO_DISABLED); // assertPfEnabled
+      const b = new PfctlBlocker({
+        exec,
+        tempFile: makeMockTempFile(),
+        assumeAvailable: true,
+      });
+      await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(PfctlPfDisabledError);
+    });
+
+    it('writes rules to a temp file and loads them into the anchor', async () => {
+      const exec = makeMockExec();
+      exec.run
+        .mockResolvedValueOnce(PF_INFO_ENABLED) // assertPfEnabled
+        .mockResolvedValueOnce(''); // pfctl -a ... -f ...
+      const tempFile = makeMockTempFile('/tmp/opensafari-pfctl-xyz/rules.conf');
+      const now = () => new Date('2026-04-23T18:00:00.000Z');
+      const b = new PfctlBlocker({ exec, tempFile, assumeAvailable: true, now });
+
+      await b.apply(DEVICE_ID);
+
+      expect(tempFile.write).toHaveBeenCalledWith(PFCTL_BLOCK_RULES);
+      expect(exec.run).toHaveBeenCalledTimes(2);
+      expect(exec.run).toHaveBeenNthCalledWith(
+        1,
+        '/usr/bin/sudo',
+        ['-n', '/sbin/pfctl', '-s', 'info'],
+        expect.objectContaining({ timeoutMs: 2000 }),
+      );
+      expect(exec.run).toHaveBeenNthCalledWith(
+        2,
+        '/usr/bin/sudo',
+        ['-n', '/sbin/pfctl', '-a', PFCTL_ANCHOR_NAME, '-f', '/tmp/opensafari-pfctl-xyz/rules.conf'],
+        expect.objectContaining({ timeoutMs: 5000 }),
+      );
+      expect(tempFile.remove).toHaveBeenCalledWith('/tmp/opensafari-pfctl-xyz/rules.conf');
+
+      const s = await b.status();
+      expect(s.active).toBe(true);
+      expect(s.activeSince).toBe('2026-04-23T18:00:00.000Z');
+      expect(s.detail).toBe(`pf anchor ${PFCTL_ANCHOR_NAME}`);
+    });
+
+    it('honors custom anchor name and rules body', async () => {
+      const exec = makeMockExec();
+      exec.run.mockResolvedValueOnce(PF_INFO_ENABLED).mockResolvedValueOnce('');
+      const tempFile = makeMockTempFile();
+      const b = new PfctlBlocker({
+        exec,
+        tempFile,
+        assumeAvailable: true,
+        anchorName: 'custom-anchor',
+        rules: 'block drop out all',
+      });
+      await b.apply(DEVICE_ID);
+      expect(tempFile.write).toHaveBeenCalledWith('block drop out all');
+      expect(exec.run).toHaveBeenNthCalledWith(
+        2,
+        '/usr/bin/sudo',
+        ['-n', '/sbin/pfctl', '-a', 'custom-anchor', '-f', expect.any(String)],
+        expect.anything(),
+      );
+    });
+
+    it('is idempotent when already active (no exec, no temp file)', async () => {
+      const exec = makeMockExec();
+      const tempFile = makeMockTempFile();
+      const b = new PfctlBlocker({ exec, tempFile, assumeAvailable: true });
+      b.__setActiveForTests(true);
+      await expect(b.apply(DEVICE_ID)).resolves.toBeUndefined();
+      expect(exec.run).not.toHaveBeenCalled();
+      expect(tempFile.write).not.toHaveBeenCalled();
+    });
+
+    it('wraps pfctl exec failures in PfctlCommandError and still cleans the temp file', async () => {
+      const exec = makeMockExec();
+      const pfctlErr = Object.assign(new Error('pfctl: No such file'), {
+        stderr: 'pfctl: No such file',
+        code: 1,
+      });
+      exec.run.mockResolvedValueOnce(PF_INFO_ENABLED).mockRejectedValueOnce(pfctlErr);
+      const tempFile = makeMockTempFile();
+      const b = new PfctlBlocker({ exec, tempFile, assumeAvailable: true });
+
+      await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(PfctlCommandError);
+      expect(tempFile.remove).toHaveBeenCalled(); // cleanup on error
+      const s = await b.status();
+      expect(s.active).toBe(false); // state rollback
+    });
+  });
+
+  describe('revert (PR 3 real backend)', () => {
+    it('is a no-op when nothing is active', async () => {
+      const exec = makeMockExec();
+      const b = new PfctlBlocker({ exec, tempFile: makeMockTempFile(), assumeAvailable: true });
+      await expect(b.revert(DEVICE_ID)).resolves.toBeUndefined();
+      expect(exec.run).not.toHaveBeenCalled();
+    });
+
+    it('flushes the anchor when active', async () => {
+      const exec = makeMockExec();
+      exec.run.mockResolvedValueOnce('');
+      const b = new PfctlBlocker({
+        exec,
+        tempFile: makeMockTempFile(),
+        assumeAvailable: true,
+        anchorName: 'test-anchor',
+      });
+      b.__setActiveForTests(true);
+      await b.revert(DEVICE_ID);
+      expect(exec.run).toHaveBeenCalledWith(
+        '/usr/bin/sudo',
+        ['-n', '/sbin/pfctl', '-a', 'test-anchor', '-F', 'all'],
+        expect.objectContaining({ timeoutMs: 5000 }),
+      );
+      const s = await b.status();
+      expect(s.active).toBe(false);
+      expect(s.activeSince).toBeNull();
+    });
+
+    it('wraps pfctl revert failures in PfctlCommandError and leaves state active', async () => {
+      const exec = makeMockExec();
+      exec.run.mockRejectedValueOnce(
+        Object.assign(new Error('pfctl: permission denied'), {
+          stderr: 'pfctl: permission denied',
+          code: 2,
+        }),
+      );
+      const b = new PfctlBlocker({ exec, tempFile: makeMockTempFile(), assumeAvailable: true });
+      b.__setActiveForTests(true);
+      await expect(b.revert(DEVICE_ID)).rejects.toBeInstanceOf(PfctlCommandError);
+      const s = await b.status();
+      expect(s.active).toBe(true); // did not clear; caller can retry
+    });
+  });
+
+  describe('status', () => {
+    it('reports inactive by default', async () => {
+      const b = new PfctlBlocker({
+        exec: makeMockExec(),
+        tempFile: makeMockTempFile(),
+        assumeAvailable: true,
+      });
+      await expect(b.status()).resolves.toEqual({ active: false, activeSince: null, detail: null });
+    });
+
+    it('reports active+detail after __setActiveForTests', async () => {
+      const b = new PfctlBlocker({
+        exec: makeMockExec(),
+        tempFile: makeMockTempFile(),
+        assumeAvailable: true,
+      });
+      b.__setActiveForTests(true, '2026-04-23T00:00:00.000Z');
+      await expect(b.status()).resolves.toEqual({
+        active: true,
+        activeSince: '2026-04-23T00:00:00.000Z',
+        detail: `pf anchor ${PFCTL_ANCHOR_NAME}`,
+      });
+    });
+
+    it('anchorName option overrides the default anchor in detail', async () => {
+      const b = new PfctlBlocker({
+        exec: makeMockExec(),
+        tempFile: makeMockTempFile(),
+        assumeAvailable: true,
+        anchorName: 'custom',
+      });
+      b.__setActiveForTests(true);
+      const s = await b.status();
+      expect(s.detail).toBe('pf anchor custom');
+    });
   });
 });
 
@@ -141,7 +295,7 @@ describe('NlcBlocker', () => {
     await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerUnavailableError);
   });
 
-  it('apply throws NotImplemented when NLC is available (scaffold)', async () => {
+  it('apply throws NotImplemented when NLC is available (scaffold; impl lands in PR 5)', async () => {
     const b = new NlcBlocker({ exec: makeMockExec(), assumeAvailable: true });
     await expect(b.apply(DEVICE_ID)).rejects.toBeInstanceOf(NetworkBlockerNotImplementedError);
   });
@@ -176,8 +330,7 @@ describe('AutoBlocker selection order', () => {
     const auto = new AutoBlocker({ candidates: [pfctl, nlc] });
     await auto.isAvailable();
     expect(auto.selectedKind()).toBe('pfctl');
-    // nlc was never probed once pfctl said yes
-    expect((nlc.isAvailable as jest.Mock)).not.toHaveBeenCalled();
+    expect(nlc.isAvailable as jest.Mock).not.toHaveBeenCalled();
   });
 
   it('falls back to NLC when pfctl is unavailable', async () => {


### PR DESCRIPTION
## Summary

Wires `PfctlBlocker.apply` / `revert` onto real `pfctl` commands (PR 3 of the 6-PR sequence tracked by #640). After this PR the `auto` / `pfctl` mechanisms actually block iOS Simulator native traffic; the NLC path still raises `NetworkBlockerNotImplementedError` until PR 5.

> **Stacked on [#663](https://github.com/shaun0927/opensafari/pull/663).** Review that PR first; this one targets `feat/640-device-network-pr2-mechanism` directly and will rebase when #663 merges.

## What changes

### Blocker core
- New `TempFileWriter` injectable (`types.ts`) + `RealTempFileWriter` backed by `fs.mkdtemp` under `os.tmpdir()`.
- `PfctlBlocker.apply(deviceId)`:
  1. Probes availability (`sudo -n pfctl -sr`, unchanged from PR 2).
  2. Probes pf itself is enabled via `sudo -n pfctl -s info`; raises new `PfctlPfDisabledError` otherwise so silent rule-loads that never fire are impossible.
  3. Writes `PFCTL_BLOCK_RULES` (block drop out on ! lo0 all) to a temp file via the injected writer.
  4. Loads them into the dedicated anchor `opensafari-simdevnet` via `sudo -n pfctl -a <anchor> -f <file>`.
  5. Records `activeSince` (injectable clock) and removes the temp file in a `finally` block — cleanup runs even on error.
- `PfctlBlocker.revert(deviceId)` flushes the anchor (`sudo -n pfctl -a <anchor> -F all`).
- Non-zero `pfctl` exits are wrapped in a structured `PfctlCommandError(op, stderr, exitCode)` so the tool layer can propagate clean error bodies.

### Tool layer
- `src/tools/device-network.ts` constructs a shared `HostBlockerBundle` (`pfctl`, `nlc`, `auto`) via `RealHostExec` + `RealTempFileWriter`.
- Offline / airplane now actually call `apply()`; online now calls `revert()`.
- **Reference counting:** the host-wide rule only reverts when the last offline simulator returns to online, so two devices that both go offline share a single rule and a single revert.
- **Mechanism conflict guard:** if a caller requests a different mechanism while another is already active on the host, the handler returns `{ok:false, error:"mechanism_conflict"}` rather than silently stacking rules.
- New test hook `__setHostBlockerForTests(bundle)` lets unit tests swap in a mocked bundle without touching `fs`/`child_process`.

### Errors exported
- `PfctlCommandError` — carries `op` (`apply`/`revert`/`probe`), `stderr`, `exitCode`.
- `PfctlPfDisabledError` — surfaces the concrete missing setup step.
- Both are re-exported from `src/simulator/network-blockers/index.ts`.

## Out of scope (deferred to later PRs)

- **PR 4** — crash-safe cleanup (signal handlers, startup reconciliation that flushes a leftover anchor from a crashed previous run).
- **PR 5** — NLC fallback backend and `docs/tools/device-network.md` documenting the one-time host setup (`/etc/pf.conf` anchor reference + `/etc/sudoers.d/opensafari`).
- **PR 6** — live acceptance test verifying a native `HttpClient` request raises `SocketException` within 5 s of `device_network_set({mode:"offline"})`.

## Verification

| Check | Result |
|---|---|
| `npm test -- tests/unit/network-blockers.test.ts tests/unit/device-network.test.ts` | 49/49 green |
| Full `npm test` | 1959/1969 green; the 10 failures are pre-existing `tests/unit/ax-bridge-help.test.ts` cases that require `npm run build` first (binary absent in the bare test run) — verified identical on the base branch `feat/640-device-network-pr2-mechanism` |
| `npx tsc --noEmit` | 0 errors |
| `npm run lint` | 0 errors (warnings are pre-existing `any` usages) |

No live pfctl verification in this PR — that's PR 6's job on a real simulator host.

## Test plan

- [ ] Reviewer confirms unit tests cover: availability probe, pf-disabled probe, temp-file write+cleanup, anchor install, idempotent apply, error wrapping, revert, revert error rollback, reference counting across two devices, mechanism conflict guard.
- [ ] Manual verification on a configured host:
  - [ ] `device_network_set({mode:"offline"})` returns `{ok:true, mechanism:"pfctl", appliedAt}` and a `curl` from the host fails.
  - [ ] `device_network_set({mode:"online"})` restores network.
  - [ ] Issuing `offline` on two simulators and then `online` on one leaves the rule in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)