### PR TITLE
feat(device-network): crash-safe cleanup + startup reconciliation (#640 PR 4/6)

### DIFF
--- a/src/simulator/network-blockers/cleanup.ts
+++ b/src/simulator/network-blockers/cleanup.ts
@@ -1,0 +1,135 @@
+/**
+ * Crash-safe process cleanup registry (issue #640, PR 4).
+ *
+ * Blockers that mutate host state (pf anchors, NLC profiles) must make a
+ * best-effort attempt to revert during process shutdown so SIGINT/SIGTERM
+ * and normal exit don't leave stale rules that break the host network.
+ *
+ * This module owns a single lazily-installed set of process signal
+ * handlers. Blockers register async cleanup functions via
+ * {@link cleanupRegistry}.`add()`; the registry drains them on:
+ *   - SIGINT / SIGTERM (exit with 130 / 143 respectively)
+ *   - `beforeExit` (normal event-loop drain)
+ *
+ * We do not attempt to intercept `uncaughtException`: letting Node's
+ * default handler print the trace is more useful for debugging, and
+ * `beforeExit` will still fire on the way out.
+ *
+ * SIGKILL is uncatchable by design — for that case the startup
+ * reconciliation path in {@link PfctlBlocker.reconcileStaleAnchor} is
+ * the authoritative cleanup mechanism on the next server start.
+ *
+ * Test guidance: call `cleanupRegistry.disableForTests()` once at
+ * module load (e.g. in a setup file) so unit tests don't install real
+ * process handlers. Tests that need to drive the registry directly
+ * use `NodeCleanupRegistry` from this module.
+ */
+
+export type CleanupFn = () => Promise<void>;
+
+export interface CleanupRegistry {
+  /**
+   * Register an async cleanup function. Returns an `unregister` function
+   * that callers MUST call when their resource is released in the normal
+   * path (revert succeeded) — otherwise the handler re-runs on shutdown
+   * and tries to revert state that is already gone.
+   */
+  add(fn: CleanupFn): () => void;
+
+  /** Number of currently registered handlers (diagnostics / tests). */
+  size(): number;
+
+  /**
+   * Test-only: clear all registered handlers without firing them.
+   * Use in `beforeEach` to isolate tests.
+   */
+  clearForTests(): void;
+
+  /**
+   * Test-only: suppress process handler installation. MUST be called
+   * before any `add()` to have effect. Prevents unit tests from
+   * registering real signal handlers on the Node process.
+   */
+  disableForTests(): void;
+
+  /**
+   * Test-only: drain handlers in-band (no process.exit). Returns the
+   * number of handlers fired so tests can assert on invocation counts.
+   */
+  fireForTests(): Promise<number>;
+}
+
+export class NodeCleanupRegistry implements CleanupRegistry {
+  private handlers: Set<CleanupFn> = new Set();
+  private installed = false;
+  private disabled: boolean;
+
+  constructor() {
+    // Under Jest (`JEST_WORKER_ID` is set per worker) we must not install
+    // real process signal handlers — they leak across tests and fire on
+    // the Jest runner's own SIGINT/SIGTERM. Tests that want to exercise
+    // the fire path construct their own `NodeCleanupRegistry`.
+    this.disabled = process.env.JEST_WORKER_ID !== undefined;
+  }
+
+  add(fn: CleanupFn): () => void {
+    this.handlers.add(fn);
+    this.ensureInstalled();
+    return () => {
+      this.handlers.delete(fn);
+    };
+  }
+
+  size(): number {
+    return this.handlers.size;
+  }
+
+  clearForTests(): void {
+    this.handlers.clear();
+  }
+
+  disableForTests(): void {
+    this.disabled = true;
+  }
+
+  async fireForTests(): Promise<number> {
+    const snapshot = Array.from(this.handlers);
+    this.handlers.clear();
+    await Promise.allSettled(snapshot.map((h) => h()));
+    return snapshot.length;
+  }
+
+  private ensureInstalled(): void {
+    if (this.installed || this.disabled) return;
+    this.installed = true;
+
+    const drain = async (): Promise<void> => {
+      const snapshot = Array.from(this.handlers);
+      // Clear first so a subsequent signal doesn't re-fire the same handlers.
+      this.handlers.clear();
+      await Promise.allSettled(
+        snapshot.map((h) =>
+          h().catch((err) => {
+            // eslint-disable-next-line no-console
+            console.error('[opensafari] cleanup handler failed:', err);
+          }),
+        ),
+      );
+    };
+
+    const exitWith = (code: number): void => {
+      drain()
+        .catch(() => undefined)
+        .finally(() => process.exit(code));
+    };
+
+    process.once('SIGINT', () => exitWith(130));
+    process.once('SIGTERM', () => exitWith(143));
+    process.once('beforeExit', () => {
+      void drain();
+    });
+  }
+}
+
+/** Shared cleanup registry for the whole server. */
+export const cleanupRegistry: CleanupRegistry = new NodeCleanupRegistry();

--- a/src/simulator/network-blockers/index.ts
+++ b/src/simulator/network-blockers/index.ts
@@ -7,6 +7,8 @@
 
 export { AutoBlocker } from './auto';
 export type { AutoBlockerOptions } from './auto';
+export { cleanupRegistry, NodeCleanupRegistry } from './cleanup';
+export type { CleanupFn, CleanupRegistry } from './cleanup';
 export { NlcBlocker } from './nlc';
 export type { NlcBlockerOptions } from './nlc';
 export {
@@ -16,7 +18,7 @@ export {
   PfctlCommandError,
   PfctlPfDisabledError,
 } from './pfctl';
-export type { PfctlBlockerOptions } from './pfctl';
+export type { PfctlBlockerOptions, PfctlReconcileResult } from './pfctl';
 export { RealHostExec } from './host-exec';
 export { RealTempFileWriter } from './temp-file';
 export type { RealTempFileWriterOptions } from './temp-file';

--- a/src/simulator/network-blockers/pfctl.ts
+++ b/src/simulator/network-blockers/pfctl.ts
@@ -4,9 +4,10 @@
  * the host's network stack) see deterministic `SocketException` /
  * `NSURLErrorNotConnectedToInternet` failures.
  *
- * Issue #640, PR 3 wires the real `pfctl` calls on top of the PR 2
- * interface. Crash-safe cleanup / startup reconciliation is PR 4;
- * the NLC fallback is PR 5.
+ * Issue #640 PR sequence:
+ *   - PR 3: real `pfctl` apply/revert on top of the PR 2 interface.
+ *   - PR 4 (this PR): crash-safe cleanup + startup reconciliation.
+ *   - PR 5: NLC fallback + host setup docs.
  *
  * Prerequisites (documented in PR 5 / `docs/tools/device-network.md`):
  *   - `/etc/pf.conf` references the anchor:
@@ -14,11 +15,9 @@
  *   - `/etc/sudoers.d/opensafari` grants passwordless pfctl:
  *       <user> ALL=(root) NOPASSWD: /sbin/pfctl
  *   - pf is enabled on the host (`sudo pfctl -E`).
- *
- * Without these, `apply()` surfaces a structured error rather than
- * silently loading rules that never fire.
  */
 
+import { CleanupRegistry, cleanupRegistry as defaultRegistry } from './cleanup';
 import {
   HostExec,
   NetworkBlocker,
@@ -52,13 +51,23 @@ export class PfctlPfDisabledError extends Error {
 
 export class PfctlCommandError extends Error {
   constructor(
-    public readonly op: 'apply' | 'revert' | 'probe',
+    public readonly op: 'apply' | 'revert' | 'probe' | 'reconcile',
     public readonly stderr: string,
     public readonly exitCode: number | null,
   ) {
     super(`pfctl ${op} failed (exit ${exitCode ?? '?'}): ${stderr.trim() || '(no stderr)'}`);
     this.name = 'PfctlCommandError';
   }
+}
+
+/** Result surfaced by {@link PfctlBlocker.reconcileStaleAnchor}. */
+export interface PfctlReconcileResult {
+  /** Whether reconciliation found leftover rules and flushed them. */
+  reconciled: boolean;
+  /** Number of non-empty rule lines observed in the anchor. */
+  rulesFound: number;
+  /** Non-fatal reason reconciliation did nothing (e.g. probe skipped). */
+  skippedReason?: 'unavailable' | 'probe_failed' | 'anchor_empty';
 }
 
 export interface PfctlBlockerOptions {
@@ -76,6 +85,12 @@ export interface PfctlBlockerOptions {
   rules?: string;
   /** Time provider for deterministic tests. */
   now?: () => Date;
+  /**
+   * Injectable cleanup registry. Default is the shared process-wide
+   * singleton; tests pass a scoped registry so unit tests don't touch
+   * real process signals.
+   */
+  cleanup?: CleanupRegistry;
 }
 
 export class PfctlBlocker implements NetworkBlocker {
@@ -86,8 +101,10 @@ export class PfctlBlocker implements NetworkBlocker {
   private readonly anchor: string;
   private readonly rules: string;
   private readonly nowFn: () => Date;
+  private readonly cleanup: CleanupRegistry;
   private active = false;
   private activeSince: string | null = null;
+  private unregisterCleanup: (() => void) | null = null;
 
   constructor(opts: PfctlBlockerOptions) {
     this.exec = opts.exec;
@@ -96,6 +113,7 @@ export class PfctlBlocker implements NetworkBlocker {
     this.anchor = opts.anchorName ?? PFCTL_ANCHOR_NAME;
     this.rules = opts.rules ?? PFCTL_BLOCK_RULES;
     this.nowFn = opts.now ?? (() => new Date());
+    this.cleanup = opts.cleanup ?? defaultRegistry;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -134,6 +152,7 @@ export class PfctlBlocker implements NetworkBlocker {
       }
       this.active = true;
       this.activeSince = this.nowFn().toISOString();
+      this.registerCleanupHandler();
     } finally {
       await this.tempFile.remove(rulesPath).catch(() => undefined);
     }
@@ -152,6 +171,7 @@ export class PfctlBlocker implements NetworkBlocker {
     }
     this.active = false;
     this.activeSince = null;
+    this.unregisterCleanupHandler();
   }
 
   async status(): Promise<NetworkBlockerStatus> {
@@ -160,6 +180,49 @@ export class PfctlBlocker implements NetworkBlocker {
       activeSince: this.activeSince,
       detail: this.active ? `pf anchor ${this.anchor}` : null,
     };
+  }
+
+  /**
+   * Probe our anchor for leftover rules and flush them. Intended to be
+   * called exactly once at server start so a prior run that died before
+   * reverting (SIGKILL, OOM, host crash) doesn't leave the user's
+   * network broken.
+   *
+   * Best-effort: any probe/flush failure is swallowed and returned as
+   * a `skippedReason` rather than thrown — reconciliation should never
+   * block server startup.
+   */
+  async reconcileStaleAnchor(): Promise<PfctlReconcileResult> {
+    if (!(await this.isAvailable())) {
+      return { reconciled: false, rulesFound: 0, skippedReason: 'unavailable' };
+    }
+
+    let stdout: string;
+    try {
+      stdout = await this.exec.run(
+        '/usr/bin/sudo',
+        ['-n', '/sbin/pfctl', '-a', this.anchor, '-sr'],
+        { timeoutMs: 2000, allowNonZero: true },
+      );
+    } catch {
+      return { reconciled: false, rulesFound: 0, skippedReason: 'probe_failed' };
+    }
+
+    const rulesFound = countRuleLines(stdout);
+    if (rulesFound === 0) {
+      return { reconciled: false, rulesFound: 0, skippedReason: 'anchor_empty' };
+    }
+
+    try {
+      await this.exec.run(
+        '/usr/bin/sudo',
+        ['-n', '/sbin/pfctl', '-a', this.anchor, '-F', 'all'],
+        { timeoutMs: 5000 },
+      );
+    } catch (err) {
+      throw this.wrapExecError('reconcile', err);
+    }
+    return { reconciled: true, rulesFound };
   }
 
   private async assertPfEnabled(): Promise<void> {
@@ -177,7 +240,35 @@ export class PfctlBlocker implements NetworkBlocker {
     }
   }
 
-  private wrapExecError(op: 'apply' | 'revert' | 'probe', err: unknown): PfctlCommandError {
+  private registerCleanupHandler(): void {
+    if (this.unregisterCleanup) return;
+    this.unregisterCleanup = this.cleanup.add(async () => {
+      // Best-effort flush during shutdown. Errors are swallowed by the
+      // registry itself; the next server start will reconcile anything
+      // we missed.
+      try {
+        await this.exec.run(
+          '/usr/bin/sudo',
+          ['-n', '/sbin/pfctl', '-a', this.anchor, '-F', 'all'],
+          { timeoutMs: 5000 },
+        );
+      } catch {
+        // Swallow — startup reconciliation is the authoritative path.
+      }
+    });
+  }
+
+  private unregisterCleanupHandler(): void {
+    if (this.unregisterCleanup) {
+      this.unregisterCleanup();
+      this.unregisterCleanup = null;
+    }
+  }
+
+  private wrapExecError(
+    op: 'apply' | 'revert' | 'probe' | 'reconcile',
+    err: unknown,
+  ): PfctlCommandError {
     const e = err as { stderr?: string; code?: number; message?: string };
     const stderr = e.stderr ?? e.message ?? '';
     const code = typeof e.code === 'number' ? e.code : null;
@@ -189,4 +280,26 @@ export class PfctlBlocker implements NetworkBlocker {
     this.active = active;
     this.activeSince = active ? sinceIso ?? new Date().toISOString() : null;
   }
+
+  /** Test-only: observe whether a cleanup handler is currently registered. */
+  __hasCleanupHandlerForTests(): boolean {
+    return this.unregisterCleanup !== null;
+  }
+}
+
+/**
+ * Count non-empty, non-comment rule lines in `pfctl -sr` output.
+ * Comments start with `#`; blank lines are ignored. This keeps the
+ * `skippedReason: 'anchor_empty'` branch deterministic across pfctl
+ * output shapes (some versions emit a trailing comment on empty anchors).
+ */
+function countRuleLines(stdout: string): number {
+  if (!stdout) return 0;
+  let n = 0;
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    n += 1;
+  }
+  return n;
 }

--- a/src/tools/device-network.ts
+++ b/src/tools/device-network.ts
@@ -6,6 +6,7 @@ import {
   NetworkBlocker,
   NlcBlocker,
   PfctlBlocker,
+  PfctlReconcileResult,
   RealHostExec,
   RealTempFileWriter,
 } from '../simulator/network-blockers';
@@ -46,6 +47,11 @@ export interface HostBlockerBundle {
 let hostBlocker: HostBlockerBundle | null = null;
 /** Reference-tracking: which blocker (if any) currently owns the active host rule. */
 let activeHostBlocker: NetworkBlocker | null = null;
+/**
+ * Set once after the first successful reconciliation attempt so we don't
+ * re-probe on every tool call. See {@link reconcileHostBlockers}.
+ */
+let reconciledOnce = false;
 
 function buildDefaultHostBlocker(): HostBlockerBundle {
   const exec = new RealHostExec();
@@ -99,6 +105,46 @@ export function __resetDeviceNetworkStateForTests(): void {
   stateByDevice.clear();
   hostBlocker = null;
   activeHostBlocker = null;
+  reconciledOnce = false;
+}
+
+/**
+ * Probe each supported mechanism for leftover state from a previous
+ * server run that died before reverting, and flush it. Best-effort:
+ * probe failures are logged to stderr and swallowed — reconciliation
+ * must never block the server from starting.
+ *
+ * Called lazily on the first `device_network_set` invocation so tests
+ * that never touch this tool don't pay the cost. The one-time gate is
+ * {@link reconciledOnce}.
+ *
+ * Returns the reconcile result so callers (tests, diagnostics) can
+ * inspect whether any stale rules were flushed.
+ */
+export async function reconcileHostBlockers(
+  bundle: HostBlockerBundle,
+): Promise<{ pfctl: PfctlReconcileResult | null }> {
+  let pfctl: PfctlReconcileResult | null = null;
+  if (bundle.pfctl instanceof PfctlBlocker) {
+    try {
+      pfctl = await bundle.pfctl.reconcileStaleAnchor();
+      if (pfctl.reconciled) {
+        console.error(
+          `[device-network] flushed ${pfctl.rulesFound} stale rules from previous run`,
+        );
+      }
+    } catch (err) {
+      console.error('[device-network] pfctl reconciliation failed:', err);
+    }
+  }
+  // NLC reconciliation lands in PR 5.
+  return { pfctl };
+}
+
+async function ensureReconciled(bundle: HostBlockerBundle): Promise<void> {
+  if (reconciledOnce) return;
+  reconciledOnce = true;
+  await reconcileHostBlockers(bundle);
 }
 
 export function getDeviceNetworkState(deviceId: string): DeviceNetworkStateEntry {
@@ -184,6 +230,10 @@ export function registerDeviceNetworkSetTool(server: MCPServer): void {
       }
 
       const bundle = getHostBlocker();
+      // Run startup reconciliation once per process — flushes a stale
+      // anchor from a previous server that died before reverting. Safe
+      // to call on every handler invocation because of the one-shot gate.
+      await ensureReconciled(bundle);
       const current = getDeviceNetworkState(deviceId);
 
       if (mode === 'online') {

--- a/tests/unit/cleanup-registry.test.ts
+++ b/tests/unit/cleanup-registry.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for NodeCleanupRegistry (issue #640, PR 4).
+ *
+ * Validates:
+ *   - add() returns an unregister function that actually unregisters
+ *   - fireForTests() drains handlers and returns the count
+ *   - handlers survive failures of peer handlers (Promise.allSettled)
+ *   - disableForTests suppresses real process handler installation
+ *
+ * We never install real signal handlers here — `process.env.JEST_WORKER_ID`
+ * is set by Jest, which the default `NodeCleanupRegistry` constructor
+ * interprets as "tests — do not touch process signals".
+ */
+
+import { NodeCleanupRegistry } from '../../src/simulator/network-blockers';
+
+describe('NodeCleanupRegistry', () => {
+  it('add() registers a handler and returns an unregister function', async () => {
+    const r = new NodeCleanupRegistry();
+    const fn = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    const unregister = r.add(fn);
+    expect(r.size()).toBe(1);
+    unregister();
+    expect(r.size()).toBe(0);
+  });
+
+  it('fireForTests() drains and clears handlers, returning the count', async () => {
+    const r = new NodeCleanupRegistry();
+    const a = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    const b = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    r.add(a);
+    r.add(b);
+    const fired = await r.fireForTests();
+    expect(fired).toBe(2);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(r.size()).toBe(0);
+  });
+
+  it('fireForTests() isolates handlers from each other (allSettled)', async () => {
+    const r = new NodeCleanupRegistry();
+    const failing = jest.fn<Promise<void>, []>().mockRejectedValue(new Error('boom'));
+    const succeeding = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    r.add(failing);
+    r.add(succeeding);
+    await expect(r.fireForTests()).resolves.toBe(2);
+    expect(failing).toHaveBeenCalled();
+    expect(succeeding).toHaveBeenCalled();
+  });
+
+  it('unregister only removes the specific handler', async () => {
+    const r = new NodeCleanupRegistry();
+    const a = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    const b = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    r.add(a);
+    const unregisterB = r.add(b);
+    unregisterB();
+    expect(r.size()).toBe(1);
+    await r.fireForTests();
+    expect(a).toHaveBeenCalled();
+    expect(b).not.toHaveBeenCalled();
+  });
+
+  it('clearForTests() drops handlers without firing them', async () => {
+    const r = new NodeCleanupRegistry();
+    const a = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+    r.add(a);
+    r.clearForTests();
+    expect(r.size()).toBe(0);
+    await r.fireForTests();
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it('disableForTests() prevents real handler installation (idempotent, safe)', () => {
+    const r = new NodeCleanupRegistry();
+    r.disableForTests();
+    // Even with JEST_WORKER_ID unset this would be a no-op; the key
+    // guarantee is that add() doesn't throw or mutate process handlers.
+    const unreg = r.add(async () => undefined);
+    expect(r.size()).toBe(1);
+    unreg();
+  });
+});

--- a/tests/unit/device-network.test.ts
+++ b/tests/unit/device-network.test.ts
@@ -19,11 +19,21 @@ jest.mock('../../src/session-manager', () => ({
 }));
 
 import { MCPServer } from '../../src/mcp-server';
-import { NetworkBlocker, NetworkBlockerStatus } from '../../src/simulator/network-blockers';
+import {
+  AutoBlocker,
+  HostExec,
+  NetworkBlocker,
+  NetworkBlockerStatus,
+  NlcBlocker,
+  NodeCleanupRegistry,
+  PfctlBlocker,
+  TempFileWriter,
+} from '../../src/simulator/network-blockers';
 import {
   HostBlockerBundle,
   __resetDeviceNetworkStateForTests,
   __setHostBlockerForTests,
+  reconcileHostBlockers,
   registerDeviceNetworkGetTool,
   registerDeviceNetworkSetTool,
   registerDeviceNetworkTools,
@@ -325,5 +335,77 @@ describe('device_network_set handler — reference-counting revert', () => {
     expect(result.isError).toBe(true);
     const body = JSON.parse(result.content[0].text);
     expect(body.error).toBe('PfctlCommandError');
+  });
+});
+
+describe('device_network_set — startup reconciliation (PR 4)', () => {
+  function makeBundleWithRealPfctl(): {
+    bundle: HostBlockerBundle;
+    pfctlExec: jest.Mocked<HostExec>;
+    pfctl: PfctlBlocker;
+  } {
+    const pfctlExec: jest.Mocked<HostExec> = { run: jest.fn().mockResolvedValue('') };
+    const tempFile: TempFileWriter = {
+      write: jest.fn().mockResolvedValue('/tmp/opensafari-pfctl-x/rules.conf'),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+    const cleanup = new NodeCleanupRegistry();
+    cleanup.disableForTests();
+    const pfctl = new PfctlBlocker({
+      exec: pfctlExec,
+      tempFile,
+      assumeAvailable: true,
+      cleanup,
+    });
+    const nlc = new NlcBlocker({ exec: pfctlExec, assumeAvailable: false });
+    const auto = new AutoBlocker({ candidates: [pfctl, nlc] });
+    return { bundle: { pfctl, nlc, auto }, pfctlExec, pfctl };
+  }
+
+  it('runs reconciliation exactly once across multiple tool calls', async () => {
+    const { bundle, pfctlExec } = makeBundleWithRealPfctl();
+    __setHostBlockerForTests(bundle);
+
+    const server = makeServer();
+    registerDeviceNetworkTools(server as unknown as MCPServer);
+    const setHandler = extractHandler(server, 'device_network_set');
+
+    // First call: reconciliation runs. The empty anchor probe returns '',
+    // so no flush is attempted — just a single `pfctl -a <anchor> -sr`
+    // sniffing call.
+    pfctlExec.run.mockResolvedValueOnce(''); // reconcile probe
+    pfctlExec.run.mockResolvedValueOnce(''); // online set: no blocker call
+    await setHandler('s', { mode: 'online', udid: 'device-a' });
+    const firstCallCount = pfctlExec.run.mock.calls.length;
+    expect(firstCallCount).toBeGreaterThanOrEqual(1);
+
+    // Second call: reconciliation must NOT run again.
+    await setHandler('s', { mode: 'online', udid: 'device-a' });
+    expect(pfctlExec.run.mock.calls.length).toBe(firstCallCount);
+  });
+
+  it('reconcileHostBlockers flushes a stale anchor found on startup', async () => {
+    const { bundle, pfctlExec } = makeBundleWithRealPfctl();
+    pfctlExec.run
+      .mockResolvedValueOnce('block drop out on ! lo0 all\n') // probe
+      .mockResolvedValueOnce(''); // flush
+    const result = await reconcileHostBlockers(bundle);
+    expect(result.pfctl).toMatchObject({ reconciled: true, rulesFound: 1 });
+    expect(pfctlExec.run).toHaveBeenCalledWith(
+      '/usr/bin/sudo',
+      expect.arrayContaining(['-F', 'all']),
+      expect.anything(),
+    );
+  });
+
+  it('reconcileHostBlockers swallows pfctl errors rather than blocking startup', async () => {
+    const { bundle, pfctlExec } = makeBundleWithRealPfctl();
+    pfctlExec.run
+      .mockResolvedValueOnce('block drop out on ! lo0 all\n')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('pfctl: not root'), { stderr: 'err', code: 1 }),
+      );
+    // Should resolve (swallowed), not throw, even though the flush failed.
+    await expect(reconcileHostBlockers(bundle)).resolves.toBeDefined();
   });
 });

--- a/tests/unit/network-blockers.test.ts
+++ b/tests/unit/network-blockers.test.ts
@@ -12,6 +12,7 @@ import {
   NetworkBlockerNotImplementedError,
   NetworkBlockerUnavailableError,
   NlcBlocker,
+  NodeCleanupRegistry,
   PFCTL_ANCHOR_NAME,
   PFCTL_BLOCK_RULES,
   PfctlBlocker,
@@ -393,5 +394,193 @@ describe('AutoBlocker selection order', () => {
       activeSince: null,
       detail: null,
     });
+  });
+});
+
+describe('PfctlBlocker.reconcileStaleAnchor (PR 4)', () => {
+  it('returns skippedReason="unavailable" when the mechanism cannot be probed', async () => {
+    const exec = makeMockExec();
+    exec.run.mockRejectedValueOnce(new Error('sudo required'));
+    const b = new PfctlBlocker({ exec, tempFile: makeMockTempFile() });
+    await expect(b.reconcileStaleAnchor()).resolves.toEqual({
+      reconciled: false,
+      rulesFound: 0,
+      skippedReason: 'unavailable',
+    });
+  });
+
+  it('returns skippedReason="anchor_empty" when no rules are present', async () => {
+    const exec = makeMockExec();
+    exec.run.mockResolvedValueOnce(''); // pfctl -a <anchor> -sr yields nothing
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+    });
+    const result = await b.reconcileStaleAnchor();
+    expect(result).toEqual({ reconciled: false, rulesFound: 0, skippedReason: 'anchor_empty' });
+    // only one exec call — no flush attempted
+    expect(exec.run).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores comment/blank lines when counting rules', async () => {
+    const exec = makeMockExec();
+    exec.run.mockResolvedValueOnce('# some header\n\n# another comment\n');
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+    });
+    const result = await b.reconcileStaleAnchor();
+    expect(result.skippedReason).toBe('anchor_empty');
+  });
+
+  it('flushes when leftover rules are detected and returns reconciled:true', async () => {
+    const exec = makeMockExec();
+    exec.run
+      .mockResolvedValueOnce('block drop out on ! lo0 all\n') // sr probe
+      .mockResolvedValueOnce(''); // flush
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+      anchorName: 'test-anchor',
+    });
+    const result = await b.reconcileStaleAnchor();
+    expect(result).toEqual({ reconciled: true, rulesFound: 1 });
+    expect(exec.run).toHaveBeenCalledTimes(2);
+    expect(exec.run).toHaveBeenNthCalledWith(
+      2,
+      '/usr/bin/sudo',
+      ['-n', '/sbin/pfctl', '-a', 'test-anchor', '-F', 'all'],
+      expect.objectContaining({ timeoutMs: 5000 }),
+    );
+  });
+
+  it('wraps flush failures in PfctlCommandError with op="reconcile"', async () => {
+    const exec = makeMockExec();
+    exec.run
+      .mockResolvedValueOnce('block drop out on ! lo0 all\n')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('pfctl: not root'), {
+          stderr: 'pfctl: not root',
+          code: 1,
+        }),
+      );
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+    });
+    await expect(b.reconcileStaleAnchor()).rejects.toBeInstanceOf(PfctlCommandError);
+  });
+
+  it('returns skippedReason="probe_failed" when the probe itself throws', async () => {
+    const exec = makeMockExec();
+    exec.run.mockRejectedValueOnce(new Error('sudo timeout'));
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+    });
+    const result = await b.reconcileStaleAnchor();
+    expect(result).toEqual({
+      reconciled: false,
+      rulesFound: 0,
+      skippedReason: 'probe_failed',
+    });
+  });
+});
+
+describe('PfctlBlocker cleanup registration (PR 4)', () => {
+  it('registers a cleanup handler on successful apply', async () => {
+    const exec = makeMockExec();
+    exec.run
+      .mockResolvedValueOnce('Status: Enabled\n') // assertPfEnabled
+      .mockResolvedValueOnce(''); // pfctl load
+    const cleanup = new NodeCleanupRegistry();
+    cleanup.disableForTests();
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+      cleanup,
+    });
+
+    expect(cleanup.size()).toBe(0);
+    await b.apply(DEVICE_ID);
+    expect(cleanup.size()).toBe(1);
+    expect(b.__hasCleanupHandlerForTests()).toBe(true);
+  });
+
+  it('unregisters the cleanup handler on successful revert', async () => {
+    const exec = makeMockExec();
+    exec.run
+      .mockResolvedValueOnce('Status: Enabled\n')
+      .mockResolvedValueOnce('') // apply
+      .mockResolvedValueOnce(''); // revert
+    const cleanup = new NodeCleanupRegistry();
+    cleanup.disableForTests();
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+      cleanup,
+    });
+    await b.apply(DEVICE_ID);
+    expect(cleanup.size()).toBe(1);
+    await b.revert(DEVICE_ID);
+    expect(cleanup.size()).toBe(0);
+    expect(b.__hasCleanupHandlerForTests()).toBe(false);
+  });
+
+  it('keeps the cleanup handler registered when revert fails', async () => {
+    const exec = makeMockExec();
+    exec.run
+      .mockResolvedValueOnce('Status: Enabled\n')
+      .mockResolvedValueOnce('') // apply
+      .mockRejectedValueOnce(
+        Object.assign(new Error('pfctl revert failed'), {
+          stderr: 'err',
+          code: 1,
+        }),
+      );
+    const cleanup = new NodeCleanupRegistry();
+    cleanup.disableForTests();
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+      cleanup,
+    });
+    await b.apply(DEVICE_ID);
+    expect(cleanup.size()).toBe(1);
+    await expect(b.revert(DEVICE_ID)).rejects.toBeInstanceOf(PfctlCommandError);
+    // Still registered — caller can retry and cleanup will fire on shutdown.
+    expect(cleanup.size()).toBe(1);
+  });
+
+  it('fired cleanup handler issues a flush against the anchor', async () => {
+    const exec = makeMockExec();
+    exec.run
+      .mockResolvedValueOnce('Status: Enabled\n')
+      .mockResolvedValueOnce('') // apply
+      .mockResolvedValueOnce(''); // flush via cleanup
+    const cleanup = new NodeCleanupRegistry();
+    cleanup.disableForTests();
+    const b = new PfctlBlocker({
+      exec,
+      tempFile: makeMockTempFile(),
+      assumeAvailable: true,
+      anchorName: 'cleanup-test',
+      cleanup,
+    });
+    await b.apply(DEVICE_ID);
+    await cleanup.fireForTests();
+    expect(exec.run).toHaveBeenLastCalledWith(
+      '/usr/bin/sudo',
+      ['-n', '/sbin/pfctl', '-a', 'cleanup-test', '-F', 'all'],
+      expect.objectContaining({ timeoutMs: 5000 }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Delivers the crash-safety half of the issue's acceptance criterion:

> Killing the MCP server (`SIGTERM` / `SIGKILL`) while a block is active restores connectivity within 30 s of next server start (registered cleanup hook OR startup reconciliation removes the anchor).

Two complementary paths:

1. **Runtime cleanup hooks** — covers SIGINT/SIGTERM and normal `beforeExit`.
2. **Startup reconciliation** — covers SIGKILL and host crashes where no in-process handler gets to run.

> **Stacked on [#676](https://github.com/shaun0927/opensafari/pull/676).** Review that PR first; this one targets `feat/640-device-network-pr3-pfctl` and will rebase automatically when #676 merges.

## What changes

### New: `NodeCleanupRegistry`
- `src/simulator/network-blockers/cleanup.ts` — a shared process-wide registry that lazily installs `SIGINT` / `SIGTERM` / `beforeExit` handlers on first registration.
- Handlers drain via `Promise.allSettled` so a failing handler doesn't block its peers.
- **Jest-safe by construction**: the registry reads `process.env.JEST_WORKER_ID` in its constructor and self-disables under Jest so unit tests never install real process signal handlers.
- Test-only helpers: `fireForTests()`, `clearForTests()`, `disableForTests()`, `size()`.

### `PfctlBlocker` cleanup registration
- On successful `apply()` the blocker registers a cleanup handler that runs `sudo pfctl -a <anchor> -F all`.
- On successful `revert()` the handler is unregistered — we don't re-fire revert against an anchor that's already clean.
- On failed `revert()` the handler **stays registered** so shutdown-time cleanup still fires; a new `__hasCleanupHandlerForTests()` helper lets unit tests assert this.
- Registry is injectable via new `cleanup?: CleanupRegistry` option.

### `PfctlBlocker.reconcileStaleAnchor()`
- Probes the anchor with `sudo -n pfctl -a <anchor> -sr`, counts non-comment rule lines, and flushes via `-F all` when stale rules are found.
- Returns `PfctlReconcileResult { reconciled, rulesFound, skippedReason? }` — `skippedReason` is one of `'unavailable' | 'probe_failed' | 'anchor_empty'` so callers can distinguish "no problem" from "couldn't check".
- Flush failures raise `PfctlCommandError(op: 'reconcile')`.

### Tool layer
- `device-network.ts` gains `reconcileHostBlockers(bundle)` + a one-shot `ensureReconciled()` gate.
- Run on the first `device_network_set` invocation; subsequent calls skip.
- Logs flushed-rule counts via `console.error` (stdout belongs to MCP JSON-RPC per CLAUDE.md).
- NLC reconciliation lands with the NLC backend in PR 5; pfctl is the only reconciliation target in this PR.

## Verification

| Check | Result |
|---|---|
| `npm test -- tests/unit/{network-blockers,device-network,cleanup-registry}.test.ts` | **68/68 green** (49 from PR 3 + 19 new) |
| `npx tsc --noEmit` | 0 errors |
| `npm run lint` | 0 errors (pre-existing warnings only) |

New test coverage:

- `NodeCleanupRegistry`: register/unregister, fire order isolation, allSettled under failures, selective unregister.
- `PfctlBlocker.reconcileStaleAnchor`: `unavailable` / `probe_failed` / `anchor_empty` branches; comment-line handling; flush on real leftover rules; error wrapping.
- `PfctlBlocker` cleanup registration: registered on apply, unregistered on revert, **stays registered when revert fails**, fired handler issues the correct `pfctl -F all` command.
- `device_network_set`: reconciliation runs exactly once across multiple tool calls; `reconcileHostBlockers` flushes a stale anchor; pfctl errors during reconciliation are swallowed rather than blocking startup.

No live pfctl verification here — that's PR 6's job on a configured simulator host.

## Out of scope

- **PR 5** — NLC fallback backend and `docs/tools/device-network.md` (the one-time host setup this PR already references).
- **PR 6** — live acceptance test (`OPENSAFARI_LIVE_NET=1` gated) verifying the SIGTERM / SIGKILL cycle actually restores connectivity.

## Test plan

- [ ] Reviewer confirms the Jest self-disable sentinel is safe (read `process.env.JEST_WORKER_ID` once at construction).
- [ ] Reviewer confirms error handling doesn't block server start: reconciliation is wrapped in `try/catch` in both layers.
- [ ] Manual verification on a configured host:
  - [ ] `SIGTERM` the server while offline — next `device_network_get` on restart reports online; anchor is empty.
  - [ ] `SIGKILL -9` the server while offline — first `device_network_set` call on restart logs `flushed N stale rules` and connectivity is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)