### PR TITLE
fix(device-network): unblock device-network test suite (#640)

### DIFF
--- a/tests/unit/device-network.test.ts
+++ b/tests/unit/device-network.test.ts
@@ -334,6 +334,7 @@ describe('device_network_set handler — offline path (pfctl wired)', () => {
 
 describe('device_network_set handler — reference-counting revert', () => {
   let setHandler: ToolHandler;
+  let getHandler: ToolHandler;
   let auto: MockBlocker;
 
   beforeEach(() => {
@@ -343,6 +344,7 @@ describe('device_network_set handler — reference-counting revert', () => {
     __setHostBlockerForTests(bundle.bundle);
     registerDeviceNetworkTools(server as unknown as MCPServer);
     setHandler = extractHandler(server, 'device_network_set');
+    getHandler = extractHandler(server, 'device_network_get');
   });
 
   it('does not revert when one of several offline devices returns online', async () => {


### PR DESCRIPTION
## Summary
- Declare \`getHandler\` in the reference-counting-revert describe block so test at line 379 compiles.
- Restores the entire \`tests/unit/device-network.test.ts\` suite, which currently fails with TS2552 on develop.

## Verification
- [x] \`npm test -- device-network.test.ts\` passes.
- [x] \`npm run build\` passes.

Refs #640.