### PR TITLE
feat(app-type-element): TEXT_INPUT_DROPPED structured error (#639)

### DIFF
--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -396,12 +396,24 @@ export function registerAppTypeElementTool(server: MCPServer): void {
         // layout is non-Latin, attach a structured TEXT_INPUT_LAYOUT_MISMATCH
         // payload so callers can programmatically pick the recommended
         // remediation (issue #639 Problem 1). Latin-layout mismatches use a
-        // different code (TEXT_INPUT_DROPPED — see PR A) and are intentionally
+        // different code (TEXT_INPUT_DROPPED — see below) and are intentionally
         // skipped here.
         if (mismatched && verify.observed !== undefined) {
           const hint = mismatchHint(textToType, verify.observed, keyboardLayoutDetected);
           if (hint) {
             responseBody.error = hint;
+          } else {
+            // Latin layout (or layout detection unavailable) with a readback
+            // mismatch: characters were silently dropped by the field or IME.
+            // Emit TEXT_INPUT_DROPPED so callers can identify exactly which
+            // positions are missing and decide on a remediation strategy
+            // (issue #639 Problem 2).
+            responseBody.error = {
+              code: 'TEXT_INPUT_DROPPED',
+              expected: textToType,
+              actual: verify.observed,
+              droppedIndices: computeDroppedIndices(textToType, verify.observed),
+            };
           }
         }
         const result: {
@@ -533,4 +545,43 @@ function jsonError(error: string, extra: Record<string, unknown> = {}) {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Compute the 0-based indices of characters in `expected` that are absent
+ * (dropped) relative to `actual`.
+ *
+ * Algorithm: greedy forward scan. For each character at position `i` in
+ * `expected`, advance through `actual` from the current cursor looking up to
+ * `LOOKAHEAD` positions ahead. If the character is found within the window,
+ * consume it and move the cursor past it. If not found, the position `i` is
+ * recorded as dropped.
+ *
+ * This is a pragmatic heuristic — not a full Levenshtein alignment — but it
+ * gives correct results for the common case of a field silently skipping one
+ * or more characters while preserving the relative order of the rest
+ * (issue #639 Problem 2).
+ */
+const DROP_LOOKAHEAD = 2;
+
+function computeDroppedIndices(expected: string, actual: string): number[] {
+  const dropped: number[] = [];
+  let cursor = 0; // current position in `actual`
+
+  for (let i = 0; i < expected.length; i++) {
+    const ch = expected[i];
+    let found = false;
+    for (let w = 0; w <= DROP_LOOKAHEAD && cursor + w < actual.length; w++) {
+      if (actual[cursor + w] === ch) {
+        cursor = cursor + w + 1;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      dropped.push(i);
+    }
+  }
+
+  return dropped;
 }

--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -404,16 +404,41 @@ export function registerAppTypeElementTool(server: MCPServer): void {
             responseBody.error = hint;
           } else {
             // Latin layout (or layout detection unavailable) with a readback
-            // mismatch: characters were silently dropped by the field or IME.
-            // Emit TEXT_INPUT_DROPPED so callers can identify exactly which
-            // positions are missing and decide on a remediation strategy
-            // (issue #639 Problem 2).
-            responseBody.error = {
-              code: 'TEXT_INPUT_DROPPED',
-              expected: textToType,
-              actual: verify.observed,
-              droppedIndices: computeDroppedIndices(textToType, verify.observed),
-            };
+            // mismatch. Two codex review issues on PR #680 are addressed
+            // here:
+            //
+            // P1 — `expected`/`actual` previously echoed the raw caller
+            // input. That regresses the file's PII protection (a typed
+            // password / token / email would surface in tool responses
+            // and downstream logs). The same `truncate()` helper that
+            // sanitises `verify_reason` and `TEXT_INPUT_LAYOUT_MISMATCH`
+            // is applied here so the payload caps at `VERIFY_ECHO_LEN`
+            // characters per side.
+            //
+            // P2 — every Latin/unknown-layout mismatch was being labelled
+            // `TEXT_INPUT_DROPPED`, even when the divergence was an
+            // insertion (e.g. an auto-format `123` → `123 456`) that
+            // produces an empty `droppedIndices` array. The
+            // `code = TEXT_INPUT_DROPPED` + empty-array combination is
+            // contradictory and would mislead callers that key
+            // remediation off this code. We now check
+            // `computeDroppedIndices(...).length > 0` first; non-empty
+            // → `TEXT_INPUT_DROPPED` (real drop); empty → the neutral
+            // `TEXT_INPUT_MISMATCH` code.
+            const droppedIndices = computeDroppedIndices(textToType, verify.observed);
+            const hasDrops = droppedIndices.length > 0;
+            responseBody.error = hasDrops
+              ? {
+                  code: 'TEXT_INPUT_DROPPED',
+                  expected: truncate(textToType),
+                  actual: truncate(verify.observed),
+                  droppedIndices,
+                }
+              : {
+                  code: 'TEXT_INPUT_MISMATCH',
+                  expected: truncate(textToType),
+                  actual: truncate(verify.observed),
+                };
           }
         }
         const result: {

--- a/tests/unit/app-type-element.test.ts
+++ b/tests/unit/app-type-element.test.ts
@@ -625,4 +625,39 @@ describe('app_type_element — Tier 3 readback verification (issue #39)', () => 
     expect(body.verify_reason).toContain('…');
     expect(body.verify_reason).not.toContain(longObserved);
   });
+
+  it('emits TEXT_INPUT_DROPPED with droppedIndices when readback mismatches on a Latin layout', async () => {
+    // Issue #639 Problem 2: when the keyboard layout is Latin (or unknown)
+    // and readback diverges, the tool must return a structured
+    // TEXT_INPUT_DROPPED error with code, expected, actual, and droppedIndices.
+    mockBackendKind = 'simhid';
+    const node = mkNode({ path: '0/6' });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+    // Simulate a field that silently dropped characters at indices 1 and 3:
+    // expected "123456" → actual "1356" (chars '2' at idx 1 and '4' at idx 3 dropped).
+    mockInspect.mockResolvedValueOnce({
+      ...node,
+      value: '1356',
+    });
+    // detectKeyboardLayout calls execFile(xcrun simctl ...) — mock it to
+    // return null (layout detection unavailable), which is the Latin/unknown
+    // branch that should trigger TEXT_INPUT_DROPPED instead of
+    // TEXT_INPUT_LAYOUT_MISMATCH.
+
+    const result = await handler('session', {
+      identifier: 'otp-field',
+      text: '123456',
+      timeout: 0,
+      focusDelay: 0,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(body.verified).toBe(false);
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe('TEXT_INPUT_DROPPED');
+    expect(body.error.expected).toBe('123456');
+    expect(body.error.actual).toBe('1356');
+    expect(body.error.droppedIndices).toEqual([1, 3]);
+  });
 });

--- a/tests/unit/app-type-element.test.ts
+++ b/tests/unit/app-type-element.test.ts
@@ -660,4 +660,78 @@ describe('app_type_element — Tier 3 readback verification (issue #39)', () => 
     expect(body.error.actual).toBe('1356');
     expect(body.error.droppedIndices).toEqual([1, 3]);
   });
+
+  // Codex P1 review on PR #680 — the readback mismatch payload was
+  // echoing the raw caller input, exposing PII (passwords, tokens,
+  // emails) in tool responses and downstream telemetry. The same
+  // VERIFY_ECHO_LEN truncation that protects `verify_reason` now
+  // protects the structured error payload.
+  it('truncates expected/actual in TEXT_INPUT_DROPPED to avoid PII leakage (codex P1 #680)', async () => {
+    mockBackendKind = 'simhid';
+    const node = mkNode({ path: '0/6' });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+    // Long sensitive-looking input ( > VERIFY_ECHO_LEN = 24 chars ) so we
+    // can assert truncation. The trailing characters are dropped, so
+    // droppedIndices is non-empty and the error code stays
+    // TEXT_INPUT_DROPPED. Pattern is intentionally generic to avoid
+    // tripping the host's secret scanners on a test fixture.
+    const long = 'CorrectHorseBatteryStapleSentinel';
+    const dropped = 'CorrectHorseBatteryStaple';
+    mockInspect.mockResolvedValueOnce({ ...node, value: dropped });
+
+    const result = await handler('session', {
+      identifier: 'token-field',
+      text: long,
+      timeout: 0,
+      focusDelay: 0,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(body.error.code).toBe('TEXT_INPUT_DROPPED');
+    expect(body.error.expected).toMatch(/…$/);
+    expect(body.error.expected.length).toBeLessThanOrEqual(25); // 24 + ellipsis
+    expect(body.error.expected).not.toContain('Sentinel');
+    expect(body.error.actual.length).toBeLessThanOrEqual(25);
+    // The full caller input must NOT leak through to the response.
+    expect(body.error.expected).not.toBe(long);
+  });
+
+  // Codex P2 review on PR #680 — when the divergence is an insertion
+  // (e.g. auto-format inserts a space) rather than a drop, the payload
+  // would have carried `code: TEXT_INPUT_DROPPED` with empty
+  // droppedIndices, which is contradictory and misleads remediation
+  // logic. The branch now returns the neutral TEXT_INPUT_MISMATCH code
+  // when no drops are detected.
+  it('emits TEXT_INPUT_MISMATCH (not TEXT_INPUT_DROPPED) on insertion-only divergence (codex P2 #680)', async () => {
+    mockBackendKind = 'simhid';
+    const node = mkNode({ path: '0/6' });
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+    // Insertion-only: input "123456" → readback "123 456" (auto-format
+    // added a space). Every expected char is still present in actual,
+    // so computeDroppedIndices returns []; the code must NOT claim a
+    // drop occurred.
+    mockInspect.mockResolvedValueOnce({
+      ...node,
+      value: '123 456',
+    });
+
+    const result = await handler('session', {
+      identifier: 'card-field',
+      text: '123456',
+      timeout: 0,
+      focusDelay: 0,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(body.verified).toBe(false);
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe('TEXT_INPUT_MISMATCH');
+    expect(body.error.code).not.toBe('TEXT_INPUT_DROPPED');
+    expect(body.error.expected).toBe('123456');
+    expect(body.error.actual).toBe('123 456');
+    // Drop-specific field MUST be absent on the neutral code.
+    expect(body.error.droppedIndices).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Closes the unmet acceptance criterion in issue #639 Problem 2 AC3: when `verifyTypedText` returns `verified: false` **and** the keyboard layout is Latin (or layout detection is unavailable), the tool now returns `isError: true` with a structured error payload:
  ```json
  {
    "code": "TEXT_INPUT_DROPPED",
    "expected": "123456",
    "actual": "1356",
    "droppedIndices": [1, 3]
  }
  ```
- Adds `computeDroppedIndices(expected, actual)` — a greedy forward-scan with a look-ahead window of 2. For each character in `expected`, the algorithm advances through `actual`; if the character isn't found within the window, its index is recorded as dropped. This is intentionally pragmatic: a perfect Levenshtein alignment is not required for the OTP / segmented-field drop pattern this targets.
- The `TEXT_INPUT_LAYOUT_MISMATCH` path (non-Latin keyboards, issue #639 Problem 1) is untouched — the new branch fires only when `mismatchHint()` returns `null`.

## Test plan

- [x] New unit test: `emits TEXT_INPUT_DROPPED with droppedIndices when readback mismatches on a Latin layout` — mocks readback returning `{ verified: false, expected: "123456", actual: "1356" }`, asserts `error.code === "TEXT_INPUT_DROPPED"`, `error.droppedIndices === [1, 3]`
- [x] All 21 existing `app-type-element` tests pass (including Tier-3 readback and layout-mismatch coverage)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)