### PR TITLE
docs: README + api-reference for new tools (#641 T1/T4, #640 PR5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Headless Capabilities
 
-OpenSafari runs fully headless on CI — no display server, no mouse focus, no `Simulator.app` window required. See [docs/headless-architecture.md](docs/headless-architecture.md) for the full technical design.
+OpenSafari runs fully headless on CI — no display server, no mouse focus, no `Simulator.app` window required. See [docs/headless-architecture.md](docs/headless-architecture.md) for the full technical design. For Universal Link channel recipes (Notes paste-and-tap, `captureLogs`, channel matrix), see [docs/recipes/universal-link-channels.md](docs/recipes/universal-link-channels.md).
 
 | Scenario | Query (AX Tree) | Input (Tap/Type) | Headless | Backend |
 |---|---|---|---|---|
@@ -263,6 +263,8 @@ OpenSafari shares battle-tested infrastructure with [OpenChrome](https://github.
 | `device_shutdown` | Shutdown simulator |
 | `device_rotate` | Toggle portrait/landscape |
 | `appearance_toggle` | Switch light/dark mode via `simctl ui` |
+| `device_network_set` | Toggle host-level network state (`online` / `offline` / `airplane`) so native apps see real `SocketException` / `NSURLErrorNotConnectedToInternet` — see [docs/tools/device-network.md](docs/tools/device-network.md) |
+| `device_network_get` | Read the current simulated network state set by `device_network_set` |
 
 ### App Lifecycle (Tier 2)
 
@@ -274,6 +276,7 @@ OpenSafari shares battle-tested infrastructure with [OpenChrome](https://github.
 | `app_list_running` | List running foreground apps with PIDs |
 | `app_context` | Report the current mobile context and optionally guard on an expected bundle |
 | `app_reset` | Reset app state: terminate, clear permissions, uninstall |
+| `app_notes_paste_and_tap_url` | Reviewer-equivalent Universal Link tap: launches Notes.app, paste-injects the URL, waits for iOS Data Detector to produce an `AXLink`, and taps it — see [docs/recipes/universal-link-channels.md](docs/recipes/universal-link-channels.md) |
 
 ### Auth Tools (Tier 3)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -199,6 +199,133 @@ Accept or dismiss the currently visible simulator alert using a locale-aware det
 - **Additional output when Tier 3 runs:** `permissionReset: { service, servicesConsidered, executed, dryRun, command?, error? }`.
 - **Use when:** a system permission prompt (location, photos, ATT, etc.) blocks automation and you do not know the exact locale-specific label. Opt in to `fallback: 'permission_reset'` as a recovery option when the dialog itself cannot be detected. Use `app_alert_handle` instead when you want to press a specific in-app button by label.
 
+#### app_open_url
+
+Open a URL or deep link on an iOS Simulator via `xcrun simctl openurl`. Routes to the appropriate app handler (e.g. Safari for `https://`, or a custom scheme like `myapp://`).
+
+- **Input:**
+  - `url: string` — URL or deep link to open (required).
+  - `deviceId?: string` — Simulator UDID. Uses active device if omitted.
+  - `captureLogs?: object` — If provided, synchronously captures `os_log` entries around the URL-open event and returns them in `result.logs`. See [`captureLogs` parameters](#capturelogs-parameters) below.
+- **Output:** `{ url, deviceId, openedAt, logs? }`
+  - `logs` is present only when `captureLogs` is supplied; shape is the [`captureLogs` response](#capturelogs-response).
+
+#### app_deeplink
+
+Open deep links or Universal Links in the iOS Simulator. Supports custom URL schemes (`myapp://path`) and Universal Links (`https://…`).
+
+- **Input:**
+  - `url: string` — Deep link URL (required). Must include a scheme (`://`).
+  - `deviceId?: string` — Simulator UDID. Uses active device if omitted.
+  - `captureLogs?: object` — If provided, synchronously captures `os_log` entries around the deep-link open. See [`captureLogs` parameters](#capturelogs-parameters) below.
+- **Output:** `{ url, deviceId, openedAt, logs? }`
+  - `logs` is present only when `captureLogs` is supplied; shape is the [`captureLogs` response](#capturelogs-response).
+
+#### `captureLogs` parameters
+
+Both `app_open_url` and `app_deeplink` accept an optional `captureLogs` object. All fields are optional.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `bundleId` | `string` | — | `os_log` process filter (`process == <bundleId>`). |
+| `level` | `'default' \| 'info' \| 'debug' \| 'error' \| 'fault'` | — | Minimum message severity. |
+| `search` | `string` | — | Substring filter applied to the composed message. |
+| `prerollMs` | `number` | `2000` | How far back to pull logs relative to the URL-open timestamp. |
+| `silenceMs` | `number` | `1500` | Stop collecting once this many ms elapse with no new matching entry. |
+| `maxDurationMs` | `number` | `8000` | Hard upper bound on the collection window. |
+
+#### `captureLogs` response
+
+When `captureLogs` is supplied the tool appends a `logs` field to its response:
+
+```jsonc
+{
+  "entries": [ /* unified-log JSON objects from `log show --style json` */ ],
+  "windowStart": "2026-04-27T10:00:00.000Z",  // ISO-8601 start of log query window
+  "windowEnd":   "2026-04-27T10:00:08.000Z",  // ISO-8601 end of collection
+  "truncated": false,                           // always false (reserved)
+  "stopReason": "silence"                       // "silence" | "max_duration"
+}
+```
+
+On error the `logs` field is instead:
+
+```jsonc
+{
+  "error": "<message>",
+  "stopReason": "error",
+  "windowStart": "...",
+  "windowEnd": "..."
+}
+```
+
+See [docs/recipes/universal-link-channels.md](recipes/universal-link-channels.md) for end-to-end usage examples.
+
+#### app_notes_paste_and_tap_url
+
+Reviewer-equivalent Universal Link tap via Notes.app. Launches Notes (`com.apple.mobilenotes`), paste-injects the URL into the note body, waits for iOS Data Detector to produce an `AXLink`, and taps it. Use this instead of `app_open_url` when Apple-review parity matters.
+
+- **Input:**
+  - `url: string` — Universal Link or HTTPS URL to paste (required). Must include `://`.
+  - `deviceId?: string` — Simulator UDID. Uses active device if omitted.
+  - `settleMs?: number` — Ms to wait after paste before scanning for the detected link. Default: `500`.
+  - `focusTimeoutMs?: number` — Max ms to wait for the Notes editor to be AX-queryable. Default: `4000`.
+  - `linkTapTimeoutMs?: number` — Max ms to wait for iOS Data Detector to expose an `AXLink`. Default: `4000`.
+  - `restorePasteboard?: boolean` — Restore the simulator pasteboard after paste. Default: `true`.
+- **Output:**
+  ```jsonc
+  {
+    "url": "https://example.com/detail/abc",
+    "deviceId": "...",
+    "notesLaunchedAt": "2026-04-27T10:00:00.000Z",
+    "linkTappedAt":    "2026-04-27T10:00:02.500Z",
+    "linkElement": { "path": "0/1/3", "label": "example.com/detail/abc" },
+    "durationMs": 2500
+  }
+  ```
+- **Errors:** Thrown as `{ error: string }` with `isError: true` when Notes editor never becomes queryable, Data Detector produces no link within `linkTapTimeoutMs`, or the `AXPress` on the link fails.
+- **Notes:** See [docs/recipes/universal-link-channels.md](recipes/universal-link-channels.md) for the full channel comparison and recommended close-gate flow.
+
+#### device_network_set
+
+Toggle the iOS Simulator host-level network state so native apps (Flutter, UIKit) see real `SocketException` / `NSURLErrorNotConnectedToInternet`. Unlike `network_offline` (WebKit-only), this targets `URLSession` and `dart:io HttpClient` traffic.
+
+Requires one-time host setup (passwordless sudoers + `/etc/pf.conf` anchor). See [docs/tools/device-network.md](tools/device-network.md).
+
+- **Input:**
+  - `mode: 'online' | 'offline' | 'airplane'` — Target network state (required). `"offline"` and `"airplane"` share a code path; `"online"` restores connectivity and is idempotent.
+  - `udid?: string` — Device UDID. Defaults to the sole booted simulator.
+  - `mechanism?: 'pfctl' | 'nlc' | 'auto'` — Blocking mechanism. `"auto"` selects `pfctl` when elevated privileges are configured, otherwise falls back to Network Link Conditioner. Default: `"auto"`.
+- **Output (success):**
+  ```jsonc
+  {
+    "ok": true,
+    "deviceId": "...",
+    "mode": "offline",
+    "mechanism": "pfctl",   // resolved mechanism, or null when going online
+    "appliedAt": "2026-04-27T10:00:00.000Z",
+    "previousMode": "online"
+  }
+  ```
+- **Errors:** `{ ok: false, error: string, ... }` with `isError: true` for `invalid_mode`, `invalid_mechanism`, `udid_not_booted`, `no_booted_device`, `ambiguous_device`, `mechanism_conflict`, and blocker failures.
+
+#### device_network_get
+
+Read the current simulated network state set by `device_network_set`. Returns the last-applied mode and mechanism for a given device.
+
+- **Input:**
+  - `udid?: string` — Device UDID. Defaults to the sole booted simulator.
+- **Output:**
+  ```jsonc
+  {
+    "ok": true,
+    "deviceId": "...",
+    "mode": "offline",       // "online" | "offline" | "airplane"
+    "mechanism": "pfctl",    // "pfctl" | "nlc" | null
+    "activeSince": "2026-04-27T10:00:00.000Z"  // null when mode is "online"
+  }
+  ```
+
 ### Advanced Tools (Tier 2)
 
 inspect, wait_for, long_press, swipe, press, dismiss_keyboard, select_option, device_list, device_rotate, appearance_toggle


### PR DESCRIPTION
## Summary

- **#641 T1**: Added `app_notes_paste_and_tap_url` to the App Lifecycle tools table in README. Added cross-link from the Headless Capabilities section to `docs/recipes/universal-link-channels.md`.
- **#641 T4**: Added `app_open_url` and `app_deeplink` entries to `docs/api-reference.md` with full `captureLogs` parameter table and response shape documentation (fields: `bundleId`, `level`, `search`, `prerollMs`, `silenceMs`, `maxDurationMs`; response: `entries[]`, `windowStart`, `windowEnd`, `truncated`, `stopReason`).
- **#640 PR5**: Added `device_network_set` and `device_network_get` to the Device Management table in README (with link to `docs/tools/device-network.md`). Added full API entries for both tools in `docs/api-reference.md`.
- Also added `app_notes_paste_and_tap_url` and `device_network_set`/`device_network_get` entries in `docs/api-reference.md` with verbatim param shapes from the source files.

## Checkboxes satisfied

- [x] #641 T1 — README tools table entry for `app_notes_paste_and_tap_url`
- [x] #641 T1 — Headless Capabilities cross-link to `docs/recipes/universal-link-channels.md`
- [x] #641 T4 — `captureLogs` parameter section under `app_open_url` in api-reference
- [x] #641 T4 — `captureLogs` parameter section under `app_deeplink` in api-reference
- [x] #640 PR5 — README mentions `device_network_set` / `device_network_get` with link to `docs/tools/device-network.md`
- [x] #640 PR5 — `device_network_set` / `device_network_get` entries in api-reference

## Test plan

- [x] `npm run build` passes (docs-only change, no source touched)
- [x] All param shapes copied verbatim from `src/tools/app-open-url.ts`, `src/tools/app-deeplink.ts`, `src/observability/capture-logs-window.ts`, `src/tools/app-notes-paste-and-tap-url.ts`, `src/tools/device-network.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)