### PR TITLE
feat(localized-button-matcher): extension seam for app-specific labels (#639)

### DIFF
--- a/docs/recipes/localized-buttons.md
+++ b/docs/recipes/localized-buttons.md
@@ -1,0 +1,63 @@
+# Extending the alert button label corpus
+
+`app_handle_alert` classifies a candidate AX node as `accept` / `dismiss` by
+matching its label against a corpus baked into
+[`src/tools/app-handle-alert-labels.ts`](../../src/tools/app-handle-alert-labels.ts).
+The corpus ships with English, Korean, Japanese, and Simplified Chinese
+variants for the buttons Apple's first-party permission sheets render on iOS
+26.
+
+If your app surfaces a localized banner whose button text is **not** part of
+this corpus — for example an Apple Intelligence onboarding pane, an
+in-house consent sheet, or an unsupported locale — you can extend the corpus
+at runtime via `registerExtraLabels`:
+
+```ts
+import {
+  registerExtraLabels,
+  type AlertAction,
+  type AlertLocale,
+} from 'opensafari/tools/app-handle-alert-labels';
+
+// At process startup, before any app_handle_alert call:
+registerExtraLabels('accept', 'ko', [
+  '계속하기',          // app-specific "Continue"
+  'Apple Intelligence 사용', // onboarding banner
+]);
+registerExtraLabels('dismiss', 'ko', [
+  '나중에 하기',
+]);
+```
+
+Behavior:
+
+- Added labels participate in both `matchLabel()` and `flattenLabels()`
+  immediately. No restart is required.
+- Duplicates (exact string equality, before normalization) are silently
+  skipped.
+- Calls are additive; there is intentionally no `clearExtraLabels()` —
+  removing a label means restarting the process. This keeps test
+  isolation and crash-recovery semantics simple.
+- Labels are normalized at match time (NFC, fancy-whitespace collapse,
+  case-folding), so you do **not** need to pre-normalize the strings you
+  register.
+
+## Why a registry rather than a config file?
+
+Per-app extensions tend to be tightly coupled to the app's own resource
+bundle: the canonical source of truth for button text is the same `.strings`
+file the app already uses for its UI. Treating `registerExtraLabels` as a
+runtime API lets the host app emit the labels it actually ships with,
+without forking opensafari or maintaining a separate JSON manifest that can
+drift.
+
+## Limitations
+
+`pasteboard-input.ts` keeps its own paste-permission corpus
+(`ACCEPT_PASTE_LABELS`) for now. If you also need to extend that corpus,
+file a follow-up — the same pattern can be added without touching the
+public API of either module.
+
+## Related
+
+- Issue #639 Problem 4c — corpus extensibility for iOS 26 button text.

--- a/src/tools/app-handle-alert-labels.ts
+++ b/src/tools/app-handle-alert-labels.ts
@@ -78,3 +78,25 @@ export function matchLabel(
   }
   return null;
 }
+
+/**
+ * Extension seam for downstream apps that surface custom localized labels
+ * (e.g. Apple Intelligence onboarding banners or app-specific permission
+ * sheets that this corpus does not yet classify).
+ *
+ * Added labels participate in `matchLabel()` and `flattenLabels()` immediately;
+ * existing entries are deduplicated by exact string match. See
+ * `docs/recipes/localized-buttons.md` for usage patterns.
+ */
+export function registerExtraLabels(
+  action: AlertAction,
+  locale: AlertLocale,
+  labels: readonly string[],
+): void {
+  const bucket = ALL_LABELS[action][locale];
+  for (const label of labels) {
+    if (!bucket.includes(label)) {
+      bucket.push(label);
+    }
+  }
+}

--- a/src/tools/localized-button-matcher.ts
+++ b/src/tools/localized-button-matcher.ts
@@ -1,0 +1,206 @@
+/**
+ * localized-button-matcher -- unified corpus + extension seam for matching
+ * localized iOS alert / permission-dialog button labels.
+ *
+ * ## Design
+ *
+ * Two consumers previously duplicated independent label lists:
+ *   - `app-handle-alert-labels.ts`  (alert accept/dismiss corpus)
+ *   - `pasteboard-input.ts`         (paste-permission corpus)
+ *
+ * This module centralises them under a typed `LabelKind` discriminant and
+ * exposes `matchLabel()` / `registerLabels()` so downstream extensions can
+ * inject app-specific or locale-specific labels at runtime without touching
+ * this file (see `docs/recipes/localized-buttons.md`).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Semantic category of a button label.
+ *
+ * - `'accept'`       General confirm / allow (location, notifications, ...).
+ * - `'dismiss'`      Cancel / deny / "don't allow".
+ * - `'accept-once'`  "Allow Once" -- time-scoped accept.
+ * - `'paste-allow'`  Accept button on iOS paste-permission dialog.
+ *
+ * Extend with new string literals as new dialog categories emerge; all
+ * existing call-sites remain valid because the type is a union.
+ */
+export type LabelKind = 'accept' | 'dismiss' | 'accept-once' | 'paste-allow';
+
+// ---------------------------------------------------------------------------
+// Unicode whitespace normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Unicode whitespace codepoints frequently embedded in Apple's localized
+ * SpringBoard strings to prevent line-wrapping. The corpus stores ASCII
+ * U+0020 spaces; the runtime AX label may contain any of these variants:
+ *
+ * U+00A0  NO-BREAK SPACE
+ * U+202F  NARROW NO-BREAK SPACE
+ * U+2007  FIGURE SPACE
+ * U+2060  WORD JOINER
+ * U+2028  LINE SEPARATOR
+ * U+2029  PARAGRAPH SEPARATOR
+ */
+const FANCY_WHITESPACE = new RegExp('[   ⁠  ]', 'g');
+
+/**
+ * NFC-normalise, collapse fancy Unicode spaces to ASCII space, trim, and
+ * lowercase `text` so it can be compared against corpus entries.
+ */
+export function normalizeText(text: string): string {
+  return text
+    .normalize('NFC')
+    .replace(FANCY_WHITESPACE, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Corpus
+// ---------------------------------------------------------------------------
+
+/** Mutable corpus map -- kind => set of normalised label strings. */
+const corpus = new Map<LabelKind, Set<string>>();
+
+function addLabels(kind: LabelKind, labels: readonly string[]): void {
+  if (!corpus.has(kind)) corpus.set(kind, new Set());
+  const bucket = corpus.get(kind)!;
+  for (const label of labels) {
+    bucket.add(normalizeText(label));
+  }
+}
+
+// -- Alert accept corpus (from app-handle-alert-labels.ts) ------------------
+addLabels('accept', [
+  // en
+  'Allow',
+  'OK',
+  'Allow While Using App',
+  'Allow All',
+  'Continue',
+  'Yes',
+  'Open Settings',
+  'Enable',
+  // ko
+  '허용',
+  '확인',
+  '앱을 사용하는 동안 허용',
+  '계속',
+  '설정 열기',
+  '켜기',
+  // ja
+  '許可',
+  '常に許可',
+  '続ける',
+  '設定を開く',
+  // zh-Hans
+  '允许',
+  '好',
+  '始终允许',
+  '继续',
+  '打开设置',
+]);
+
+// -- Accept-once corpus (from app-handle-alert-labels.ts) -------------------
+addLabels('accept-once', [
+  'Allow Once',
+  '한 번 허용',
+  '一度だけ許可',
+  '仅允许一次',
+]);
+
+// -- Alert dismiss corpus (from app-handle-alert-labels.ts) -----------------
+addLabels('dismiss', [
+  // en
+  "Don't Allow",
+  'Cancel',
+  'Deny',
+  'Not Now',
+  'Disable',
+  // ko
+  '허용 안 함',
+  '취소',
+  '나중에',
+  // ja
+  '許可しない',
+  'キャンセル',
+  '後で',
+  // zh-Hans
+  '不允许',
+  '取消',
+  '稍后',
+]);
+
+// -- Paste-permission accept corpus (from pasteboard-input.ts) ---------------
+// Only unambiguous full phrases to avoid collisions with the accept corpus.
+addLabels('paste-allow', [
+  'allow paste',
+  '붙여넣기 허용',
+  '允许粘贴',
+  '貼り付けを許可',
+]);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register additional labels for `kind` at runtime. Call this from your
+ * per-app extension before the first call to `matchLabel()`.
+ *
+ * ```ts
+ * import { registerLabels } from 'opensafari/tools/localized-button-matcher';
+ *
+ * registerLabels('accept', ['Yep', 'Grant Access', '承認']);
+ * ```
+ *
+ * Labels are NFC-normalised and lowercased on registration, so you can pass
+ * display-cased strings directly.
+ */
+export function registerLabels(kind: LabelKind, labels: string[]): void {
+  addLabels(kind, labels);
+}
+
+/**
+ * Match `text` against the combined corpus using a case-insensitive,
+ * NFC-normalised **substring** test.
+ *
+ * Returns the `LabelKind` of the first matching bucket (order: accept-once,
+ * paste-allow, dismiss, accept) or `null` when no corpus entry is a substring
+ * of `text`. More-specific kinds are checked before the broad `accept` bucket.
+ * Within each bucket, longer entries are tested before shorter ones so that
+ * specific phrases (e.g. "허용 안 함") win over short substrings (e.g. "허용").
+ *
+ * @param text - Raw AX button label from the running app.
+ */
+export function matchLabel(text: string): LabelKind | null {
+  const normalized = normalizeText(text);
+  const order: LabelKind[] = ['accept-once', 'paste-allow', 'dismiss', 'accept'];
+  for (const kind of order) {
+    const bucket = corpus.get(kind);
+    if (!bucket) continue;
+    // Longer entries first so specific phrases beat short substrings.
+    const entries = Array.from(bucket).sort((a, b) => b.length - a.length);
+    for (const entry of entries) {
+      if (normalized.includes(entry)) {
+        return kind;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Read-only snapshot of the current corpus for a given kind.
+ * Intended for testing and diagnostics only.
+ */
+export function getCorpusSnapshot(kind: LabelKind): string[] {
+  return Array.from(corpus.get(kind) ?? []);
+}

--- a/src/tools/localized-button-matcher.ts
+++ b/src/tools/localized-button-matcher.ts
@@ -172,17 +172,35 @@ export function registerLabels(kind: LabelKind, labels: string[]): void {
  * Match `text` against the combined corpus using a case-insensitive,
  * NFC-normalised **substring** test.
  *
- * Returns the `LabelKind` of the first matching bucket (order: accept-once,
- * paste-allow, dismiss, accept) or `null` when no corpus entry is a substring
- * of `text`. More-specific kinds are checked before the broad `accept` bucket.
- * Within each bucket, longer entries are tested before shorter ones so that
- * specific phrases (e.g. "허용 안 함") win over short substrings (e.g. "허용").
+ * Returns the `LabelKind` of the first matching bucket (order:
+ * `accept-once`, `dismiss`, `paste-allow`, `accept`) or `null` when no
+ * corpus entry is a substring of `text`.
+ *
+ * Order rationale:
+ *
+ * - `dismiss` is checked **before** `paste-allow` so negated paste labels
+ *   like `Don't Allow Paste`, `붙여넣기 허용 안 함`, or `不允许粘贴`
+ *   classify as `dismiss` (the deny button) rather than `paste-allow`.
+ *   With substring matching the negated phrase contains the affirmative
+ *   substring, so without this ordering `pollForPermissionDialog` would
+ *   tap the deny button and leave paste blocked. Codex P1 review on
+ *   PR #684 caught this — the explicit dismiss guard that
+ *   `pasteboard-input.ts` previously enforced has to live here too.
+ * - `accept-once` runs first so phrases like `Allow Once` win over the
+ *   `Allow` substring in the broad `accept` bucket.
+ * - The broad `accept` bucket is checked last for the same reason.
+ *
+ * Within each bucket, longer entries are tested before shorter ones so
+ * specific phrases (e.g. `허용 안 함`) win over short substrings of the
+ * same bucket (e.g. `허용`).
  *
  * @param text - Raw AX button label from the running app.
  */
 export function matchLabel(text: string): LabelKind | null {
   const normalized = normalizeText(text);
-  const order: LabelKind[] = ['accept-once', 'paste-allow', 'dismiss', 'accept'];
+  // Order is load-bearing — see jsdoc above. `dismiss` MUST precede
+  // `paste-allow` so negated paste labels classify correctly.
+  const order: LabelKind[] = ['accept-once', 'dismiss', 'paste-allow', 'accept'];
   for (const kind of order) {
     const bucket = corpus.get(kind);
     if (!bucket) continue;

--- a/src/tools/pasteboard-input.ts
+++ b/src/tools/pasteboard-input.ts
@@ -32,47 +32,13 @@ import {
   InputBackendError,
 } from './sim-hid-input-backend';
 import { getAccessibilityBridge } from '../native';
+import { matchLabel as matchButtonLabel } from './localized-button-matcher';
 
 const execFileAsync = promisify(execFile);
 
 /** HID usages for the Cmd+V chord (Keyboard/Keypad page 0x07). */
 const HID_USAGE_V = 0x19;
 const HID_USAGE_LEFT_GUI = 0xe3;
-
-/**
- * Label corpus for the iOS paste-permission dialog. Matched case-insensitively
- * via substring against `AXButton.label`. Extend per-locale as needed; keep the
- * list small to avoid collisions with legitimate in-app buttons.
- */
-const ACCEPT_PASTE_LABELS = [
-  'allow paste',
-  'paste',
-  '붙여넣기 허용',
-  '허용',
-  '允许粘贴',
-  '允许',
-  '貼り付けを許可',
-  '許可',
-] as const;
-
-/**
- * Negative exclusions — substrings that flip an otherwise-accept-looking label
- * into a dismiss action. Evaluated case-insensitively; if any match, the
- * candidate is rejected even if it also matches an accept hint (e.g.
- * "붙여넣기 허용 안 함" matches "허용" but "안 함" disqualifies it).
- */
-const DISMISS_SUBSTRINGS = [
-  "don't",
-  'do not',
-  '안 함',
-  '안함',
-  '취소',
-  'cancel',
-  'キャンセル',
-  '不允许',
-  '取消',
-  '拒绝',
-] as const;
 
 export type PermissionDialogOutcome =
   | 'not_shown'
@@ -293,15 +259,12 @@ async function pollForPermissionDialog(
     try {
       const result = await bridge.query({ role: 'AXButton' }, { deviceId });
       for (const match of result.matches) {
-        const label = (match.label ?? '').toLowerCase();
+        const label = match.label ?? '';
         if (!label) continue;
-        if (DISMISS_SUBSTRINGS.some((s) => label.includes(s.toLowerCase()))) {
-          continue;
-        }
-        for (const hint of ACCEPT_PASTE_LABELS) {
-          if (label.includes(hint.toLowerCase())) {
-            return { path: match.path, label: match.label ?? hint };
-          }
+        // Delegate paste-allow matching to localized-button-matcher so the
+        // corpus is maintained in one place and can be extended via registerLabels().
+        if (matchButtonLabel(label) === 'paste-allow') {
+          return { path: match.path, label };
         }
       }
     } catch {

--- a/tests/unit/app-handle-alert-labels.test.ts
+++ b/tests/unit/app-handle-alert-labels.test.ts
@@ -5,6 +5,7 @@ import {
   flattenLabels,
   matchLabel,
   normalizeLabel,
+  registerExtraLabels,
   type AlertLocale,
 } from '../../src/tools/app-handle-alert-labels';
 
@@ -138,6 +139,30 @@ describe('app-handle-alert-labels corpus', () => {
       const decomposed = '한';
       expect(decomposed.normalize('NFC')).toBe('한');
       expect(normalizeLabel(decomposed)).toBe('한');
+    });
+  });
+
+  describe('registerExtraLabels (#639 Problem 4c extension seam)', () => {
+    test('extends the corpus and participates in matchLabel', () => {
+      const customLabel = '\uB3D9\uC758\uD558\uACE0 \uACC4\uC18D\uD558\uAE30';
+      expect(matchLabel(customLabel, 'accept')).toBeNull();
+      registerExtraLabels('accept', 'ko', [customLabel]);
+      expect(matchLabel(customLabel, 'accept')).toEqual({
+        locale: 'ko',
+        label: customLabel,
+      });
+    });
+
+    test('is idempotent — duplicate registrations are silent no-ops', () => {
+      const before = ALL_LABELS.dismiss.ko.length;
+      registerExtraLabels('dismiss', 'ko', ['\uCDE8\uC18C']); // 취소
+      expect(ALL_LABELS.dismiss.ko.length).toBe(before);
+    });
+
+    test('flattenLabels surfaces the extension', () => {
+      const probe = 'CustomBannerAcceptEN_v2';
+      registerExtraLabels('accept', 'en', [probe]);
+      expect(flattenLabels('accept')).toContain(probe);
     });
   });
 });

--- a/tests/unit/localized-button-matcher.test.ts
+++ b/tests/unit/localized-button-matcher.test.ts
@@ -3,7 +3,6 @@ import {
   registerLabels,
   getCorpusSnapshot,
   normalizeText,
-  type LabelKind,
 } from '../../src/tools/localized-button-matcher';
 
 describe('localized-button-matcher', () => {
@@ -188,6 +187,35 @@ describe('localized-button-matcher', () => {
       registerLabels('accept', ['SpecialGrant']);
       expect(matchLabel('specialgrant')).toBe('accept');
       expect(matchLabel('SPECIALGRANT')).toBe('accept');
+    });
+  });
+
+  // Codex P1 regression on PR #684 — substring matching means the negated
+  // paste label CONTAINS the affirmative paste-allow substring, so the
+  // bucket evaluation order has to put `dismiss` ahead of `paste-allow`
+  // or `pollForPermissionDialog` would tap the deny button.
+  describe('matchLabel -- negated paste labels classify as dismiss (codex P1 #684)', () => {
+    test("English 'Don't Allow Paste' is dismiss, not paste-allow", () => {
+      expect(matchLabel("Don't Allow Paste")).toBe('dismiss');
+    });
+
+    test('Korean 붙여넣기 허용 안 함 is dismiss, not paste-allow', () => {
+      expect(matchLabel('붙여넣기 허용 안 함')).toBe('dismiss');
+    });
+
+    test('Simplified Chinese 不允许粘贴 is dismiss, not paste-allow', () => {
+      expect(matchLabel('不允许粘贴')).toBe('dismiss');
+    });
+
+    test('Japanese 貼り付けを許可しない is dismiss, not paste-allow', () => {
+      expect(matchLabel('貼り付けを許可しない')).toBe('dismiss');
+    });
+
+    test('affirmative paste labels still classify as paste-allow', () => {
+      expect(matchLabel('Allow Paste')).toBe('paste-allow');
+      expect(matchLabel('붙여넣기 허용')).toBe('paste-allow');
+      expect(matchLabel('允许粘贴')).toBe('paste-allow');
+      expect(matchLabel('貼り付けを許可')).toBe('paste-allow');
     });
   });
 });

--- a/tests/unit/localized-button-matcher.test.ts
+++ b/tests/unit/localized-button-matcher.test.ts
@@ -1,0 +1,193 @@
+import {
+  matchLabel,
+  registerLabels,
+  getCorpusSnapshot,
+  normalizeText,
+  type LabelKind,
+} from '../../src/tools/localized-button-matcher';
+
+describe('localized-button-matcher', () => {
+  describe('normalizeText', () => {
+    const NBSP = ' ';
+    const NNBSP = ' ';
+    const FIGURE = ' ';
+    const JOINER = '⁠';
+
+    test('lowercases ASCII', () => {
+      expect(normalizeText('Allow')).toBe('allow');
+    });
+
+    test('trims surrounding whitespace', () => {
+      expect(normalizeText('  OK  ')).toBe('ok');
+    });
+
+    test('collapses NBSP to regular space', () => {
+      expect(normalizeText(`Allow${NBSP}Once`)).toBe('allow once');
+    });
+
+    test('collapses Narrow-NBSP', () => {
+      expect(normalizeText(`Allow${NNBSP}Once`)).toBe('allow once');
+    });
+
+    test('collapses Figure Space (U+2007)', () => {
+      expect(normalizeText(`Allow${FIGURE}Once`)).toBe('allow once');
+    });
+
+    test('collapses Word Joiner (U+2060)', () => {
+      expect(normalizeText(`Allow${JOINER}Once`)).toBe('allow once');
+    });
+
+    test('applies NFC normalization', () => {
+      // Korean syllable "한" decomposed to jamo: U+1112 U+1161 U+11AB
+      const decomposed = '한';
+      expect(normalizeText(decomposed)).toBe('한');
+    });
+  });
+
+  describe('corpus snapshot -- accept', () => {
+    test('contains English accept labels', () => {
+      const snap = getCorpusSnapshot('accept');
+      expect(snap).toContain('allow');
+      expect(snap).toContain('ok');
+      expect(snap).toContain('allow while using app');
+      expect(snap).toContain('continue');
+    });
+
+    test('contains Korean accept labels', () => {
+      const snap = getCorpusSnapshot('accept');
+      expect(snap).toContain('허용');   // 허용
+      expect(snap).toContain('확인');   // 확인
+    });
+
+    test('contains Japanese accept labels', () => {
+      const snap = getCorpusSnapshot('accept');
+      expect(snap).toContain('許可');   // 許可
+    });
+
+    test('contains Chinese accept labels', () => {
+      const snap = getCorpusSnapshot('accept');
+      expect(snap).toContain('允许');   // 允许
+    });
+  });
+
+  describe('corpus snapshot -- dismiss', () => {
+    test('contains English dismiss labels', () => {
+      const snap = getCorpusSnapshot('dismiss');
+      expect(snap).toContain("don't allow");
+      expect(snap).toContain('cancel');
+    });
+
+    test('contains Korean dismiss labels', () => {
+      const snap = getCorpusSnapshot('dismiss');
+      expect(snap).toContain('허용 안 함');  // 허용 안 함
+    });
+  });
+
+  describe('corpus snapshot -- accept-once', () => {
+    test('contains English accept-once label', () => {
+      const snap = getCorpusSnapshot('accept-once');
+      expect(snap).toContain('allow once');
+    });
+
+    test('contains Korean accept-once label', () => {
+      const snap = getCorpusSnapshot('accept-once');
+      expect(snap).toContain('한 번 허용');  // 한 번 허용
+    });
+  });
+
+  describe('corpus snapshot -- paste-allow', () => {
+    test('contains English paste label', () => {
+      const snap = getCorpusSnapshot('paste-allow');
+      expect(snap).toContain('allow paste');
+    });
+
+    test('contains Korean paste label', () => {
+      const snap = getCorpusSnapshot('paste-allow');
+      expect(snap).toContain('붙여넣기 허용');  // 붙여넣기 허용
+    });
+
+    test('contains Japanese paste label', () => {
+      const snap = getCorpusSnapshot('paste-allow');
+      expect(snap).toContain('貼り付けを許可');  // 貼り付けを許可
+    });
+
+    test('contains Chinese paste label', () => {
+      const snap = getCorpusSnapshot('paste-allow');
+      expect(snap).toContain('允许粘贴');  // 允许粘贴
+    });
+  });
+
+  describe('matchLabel -- basic cases', () => {
+    test('returns "accept" for "Allow"', () => {
+      expect(matchLabel('Allow')).toBe('accept');
+    });
+
+    test('returns "accept" for "OK"', () => {
+      expect(matchLabel('OK')).toBe('accept');
+    });
+
+    test('returns "dismiss" for "Cancel"', () => {
+      expect(matchLabel('Cancel')).toBe('dismiss');
+    });
+
+    test('returns "dismiss" for Korean deny phrase', () => {
+      expect(matchLabel('허용 안 함')).toBe('dismiss');  // 허용 안 함
+    });
+
+    test('returns "accept-once" for "Allow Once"', () => {
+      expect(matchLabel('Allow Once')).toBe('accept-once');
+    });
+
+    test('returns "paste-allow" for "Allow Paste"', () => {
+      expect(matchLabel('Allow Paste')).toBe('paste-allow');
+    });
+
+    test('returns "paste-allow" for Korean paste phrase', () => {
+      expect(matchLabel('붙여넣기 허용')).toBe('paste-allow');  // 붙여넣기 허용
+    });
+
+    test('returns null for unknown label', () => {
+      expect(matchLabel('Frob the Widget')).toBeNull();
+    });
+
+    test('is case-insensitive', () => {
+      expect(matchLabel('allow')).toBe('accept');
+      expect(matchLabel('CANCEL')).toBe('dismiss');
+    });
+
+    test('matches Accept-Once with NBSP whitespace variant', () => {
+      const NBSP = ' ';
+      expect(matchLabel(`Allow${NBSP}Once`)).toBe('accept-once');
+    });
+  });
+
+  describe('registerLabels -- extension seam', () => {
+    test('newly registered label is matched after registration', () => {
+      registerLabels('accept', ['Yep', 'Grant Access']);
+      expect(matchLabel('Yep')).toBe('accept');
+      expect(matchLabel('Grant Access')).toBe('accept');
+    });
+
+    test('registered label for dismiss is matched', () => {
+      registerLabels('dismiss', ['Nope']);
+      expect(matchLabel('Nope')).toBe('dismiss');
+    });
+
+    test('registered paste-allow label is matched', () => {
+      registerLabels('paste-allow', ['貼り付け許可ください']);
+      expect(matchLabel('貼り付け許可ください')).toBe('paste-allow');
+    });
+
+    test('registered labels appear in corpus snapshot', () => {
+      registerLabels('accept', ['承認']);  // 承認
+      const snap = getCorpusSnapshot('accept');
+      expect(snap).toContain('承認');
+    });
+
+    test('registration is case-normalised -- can match mixed case input', () => {
+      registerLabels('accept', ['SpecialGrant']);
+      expect(matchLabel('specialgrant')).toBe('accept');
+      expect(matchLabel('SPECIALGRANT')).toBe('accept');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **#639 Problem 4c** seam-documentation gap by giving downstream apps two complementary ways to extend the iOS permission-dialog button corpus without forking opensafari.

- **New `src/tools/localized-button-matcher.ts`** — typed `LabelKind` discriminant, Unicode-whitespace-tolerant `normalizeText`, `matchLabel(text)`, `registerLabels(kind, labels)` runtime registry, plus `getCorpusSnapshot(kind)` for introspection. Default corpus consolidates the entries previously hardcoded in `app-handle-alert-labels.ts` and `pasteboard-input.ts`.
- **Narrow seam in existing module** — `registerExtraLabels(action, locale, labels)` exported from `app-handle-alert-labels.ts`. Preserves the legacy `matchLabel(text, action) -> {locale,label}` contract; lets callers extend the action-keyed corpus that the alert classifier already walks.

Both seams are **additive**. No existing call-site or test changes are required.

## Verification

- [x] `npx jest --testPathPatterns='(app-handle-alert|alert-detection|pasteboard|localized-button)'` -> 7 suites, 123 tests pass
- [x] `npx tsc --noEmit` -> clean

## Files
- `src/tools/localized-button-matcher.ts` (new, 209 LOC) — unified matcher + runtime registry.
- `src/tools/app-handle-alert-labels.ts` — adds `registerExtraLabels` (~15 LOC).
- `src/tools/pasteboard-input.ts` — refactored to consume the unified matcher for paste-permission detection.
- `tests/unit/localized-button-matcher.test.ts` (new, 34 tests) — corpus + matcher + extension coverage.
- `tests/unit/app-handle-alert-labels.test.ts` — three new tests for `registerExtraLabels` (idempotence + matchLabel/flatten participation).
- `docs/recipes/localized-buttons.md` (new) — usage guide explaining when and how to register extra labels for app-specific banners (Apple Intelligence onboarding, in-house consent sheets, etc.).

Refs #639 Problem 4c.