### PR TITLE
feat(ax-bridge): bound AX messaging at 1.5s per element (#660)

### DIFF
--- a/src/native/ax-bridge.swift
+++ b/src/native/ax-bridge.swift
@@ -127,6 +127,34 @@ struct PressResponseJSON: Codable {
 
 // MARK: - AXUIElement Helpers
 
+// Issue #660: Per-element messaging timeout for every AXUIElement the
+// bridge touches. Without this, `AXUIElementCopyAttributeValue` against
+// an unresponsive system process (SpringBoard hosting a permission
+// sheet, a Simulator window whose AX server has degraded) blocks for
+// the AX framework's 6 s default — long enough that the wrapper's own
+// timeout fires first and the bridge looks like it has hung silently.
+//
+// Setting a 1.5 s timeout makes those blocks return
+// `kAXErrorCannotComplete` (-25204) which the call sites already treat
+// as "attribute unavailable", so the dump returns a partial tree
+// quickly instead of dragging the whole pipeline. The TS wrapper then
+// surfaces the partial result and the caller can fall back to its
+// keyboard-fallback path (#659) or its retry policy.
+//
+// `AXUIElementSetMessagingTimeout` is per-element: it does NOT
+// propagate from a parent to children, so we apply it everywhere a new
+// element enters the bridge — at the application root in `main()` and
+// at every child returned by `getChildren()`. The matched-window and
+// content-root paths are covered transitively because both arrive via
+// `getChildren()` walks.
+let AX_MESSAGING_TIMEOUT_SECONDS: Float = 1.5
+
+@discardableResult
+func setAxMessagingTimeoutSafe(_ element: AXUIElement,
+                               _ seconds: Float = AX_MESSAGING_TIMEOUT_SECONDS) -> AXError {
+    return AXUIElementSetMessagingTimeout(element, seconds)
+}
+
 func getStringAttr(_ element: AXUIElement, _ attr: String) -> String? {
     var value: CFTypeRef?
     guard AXUIElementCopyAttributeValue(element, attr as CFString, &value) == .success else { return nil }
@@ -164,7 +192,15 @@ func getChildren(_ element: AXUIElement) -> [AXUIElement] {
     guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as String as CFString, &value) == .success else {
         return []
     }
-    return (value as? [AXUIElement]) ?? []
+    let children = (value as? [AXUIElement]) ?? []
+    // Issue #660: every child entering the bridge gets the messaging
+    // timeout applied so subsequent attribute reads on it can't hang
+    // for the framework's 6 s default. See `setAxMessagingTimeoutSafe`
+    // for rationale.
+    for child in children {
+        setAxMessagingTimeoutSafe(child)
+    }
+    return children
 }
 
 // MARK: - Tree Building
@@ -887,6 +923,11 @@ func main() {
     }
 
     let app = AXUIElementCreateApplication(pid)
+    // Issue #660: bound every attribute read against the Simulator
+    // application root at 1.5 s so a degraded AX server can't hang the
+    // bridge silently for the 6 s framework default. Every child
+    // discovered through `getChildren()` inherits the same bound.
+    setAxMessagingTimeoutSafe(app)
 
     // Wake up the AX server on the target process.
     //


### PR DESCRIPTION
## Summary
- Wrap every `AXUIElement` entering the bridge with `AXUIElementSetMessagingTimeout(element, 1.5)` so a degraded AX server on the target process can't hang individual attribute reads for the framework's 6 s default.
- Coverage:
  - Application root from `AXUIElementCreateApplication(pid)` is bound immediately in `main()` before any attribute read.
  - `getChildren()` applies the same bound to every child it returns — the entire descendant walk (windows, content root, every element visited by `buildNode`, every element resolved by `findMatchingWindow` which itself uses `getChildren`) inherits the timeout transitively.
- Hangs against an unresponsive process now surface as `kAXErrorCannotComplete` (-25204) quickly instead of accumulating into the silent non-zero exits #651 described.

## Why
Implements the third bullet in m13v's recommendation on #660:
> wrap every AX call in AXUIElementSetMessagingTimeout at 1-2s

`AXUIElementSetMessagingTimeout` is per-element and does **not** propagate from a parent to children, which is why the bound has to be applied wherever an element first enters the bridge.

## PR sequence

This is the second of three independent PRs cleaving the work in #660:

| PR | Scope | Status |
|---|---|---|
| A | `--debug` flag — diagnostic only | #685 |
| B | Wrap AX calls with `AXUIElementSetMessagingTimeout` | this PR |
| C | SpringBoard explicit AXApplication union walk | later (depends on A's stderr instrumentation to characterise the failure tree) |

PR A and PR B are independent — they touch different lines and can land in any order.

## Test plan
- [x] `swiftc -O src/native/ax-bridge.swift -o dist/ax-bridge-native` — compiles cleanly
- [x] `dist/ax-bridge-native dump --device <udid> --max-depth 2` against a booted `iPhone 17 Pro` (no permission sheet visible) — returns the same JSON shape as the pre-PR baseline **byte-for-byte** on the happy path
- [x] `dist/ax-bridge-native dump --device any` with no booted simulator — exits with the existing `SIMULATOR_NOT_RUNNING` JSON, no regression
- [ ] Reviewer manual: run against a degraded simulator (background it briefly so the AX server enters the documented `kAXErrorCannotComplete` state) — confirm the dump returns within ~1.5 s instead of hanging on the previous 6 s default

## Notes for reviewer
- The timeout only manifests on degraded paths. On the happy path the AX server replies well under 1.5 s, so this PR is a no-op for typical dump / query / inspect / press calls.
- 1.5 s was chosen to be slightly under the 1–2 s window m13v recommended, leaving headroom for the wrapper's own retry/backoff before the framework's default kicks in. If the reviewer prefers 1.0 s or 2.0 s, the constant `AX_MESSAGING_TIMEOUT_SECONDS` is a single edit at the top of the helpers section.
- No new external symbols. The `setAxMessagingTimeoutSafe` helper is module-private and the timeout constant is too. The behaviour is fully contained in `src/native/ax-bridge.swift`.
- This PR does **not** add the SpringBoard explicit walk (PR C). That walker change requires live AX-tree data from a `ko-KR` cold-launch with the omofictions push-permission sheet visible to confirm where the sheet renders in the Simulator.app window hierarchy. PR A's stderr instrumentation is the prerequisite for capturing that data; PR C will land afterwards.

## Related
- Parent issue: #660
- Originating bug: #651 (closed; TS-side workarounds in #658 and #659 already shipped)
- Sibling PR: #685 (`--debug` flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)