### PR TITLE
fix(device-network): seed bootedFixture for runtime suite (#640)

### DIFF
--- a/tests/unit/device-network.test.ts
+++ b/tests/unit/device-network.test.ts
@@ -252,6 +252,12 @@ describe('device_network_set handler — offline path (pfctl wired)', () => {
   let auto: MockBlocker;
 
   beforeEach(() => {
+    bootedFixture = [
+      { udid: 'device-a', state: 'Booted' },
+      { udid: 'device-b', state: 'Booted' },
+      { udid: 'device-c', state: 'Booted' },
+      { udid: 'device-d', state: 'Booted' },
+    ];
     const server = makeServer();
     const bundle = makeMockBundle();
     pfctl = bundle.pfctl;
@@ -338,6 +344,10 @@ describe('device_network_set handler — reference-counting revert', () => {
   let auto: MockBlocker;
 
   beforeEach(() => {
+    bootedFixture = [
+      { udid: 'device-a', state: 'Booted' },
+      { udid: 'device-b', state: 'Booted' },
+    ];
     const server = makeServer();
     const bundle = makeMockBundle();
     auto = bundle.auto;
@@ -387,6 +397,10 @@ describe('device_network_set handler — reference-counting revert', () => {
 });
 
 describe('device_network_set — startup reconciliation (PR 4)', () => {
+  beforeEach(() => {
+    bootedFixture = [{ udid: 'device-a', state: 'Booted' }];
+  });
+
   function makeBundleWithRealPfctl(): {
     bundle: HostBlockerBundle;
     pfctlExec: jest.Mocked<HostExec>;


### PR DESCRIPTION
## Summary

- PR #679 unblocked `tests/unit/device-network.test.ts` from compiling (TS2552), but once it ran the suite produced **9 runtime failures**: every test in the `offline path (pfctl wired)`, `reference-counting revert`, and `startup reconciliation` describe blocks was rejected with `udid_not_booted` before the mocked blocker could be exercised.
- Root cause: those describe blocks pass udids `device-a` / `device-b` / `device-c` / `device-d` to the handler, but the global `beforeEach` resets `bootedFixture` to only `booted-device-id`. The handler validates the udid against the booted list and short-circuits.
- Fix: seed `bootedFixture` per describe block with the udids those tests actually use. The negative-path test that expects `ghost` to be rejected with `udid_not_booted` is unaffected — `ghost` is still intentionally absent from the seeded fixture.
- No production code changed.

## Verification

```
$ npx jest tests/unit/device-network.test.ts
Test Suites: 1 passed, 1 total
Tests:       24 passed, 24 total
```

(previously 15 passed / 9 failed on develop HEAD)

Full local `npm run build && npm test` is green except for pre-existing `ax-bridge-help` failures that depend on a freshly built `dist/` (those pass after `npm run build`, unrelated to this change).

## Issue alignment

Closes the last live test gap on #640's `device_network_get rejects explicit udid that is not booted` and `Get accuracy` checkboxes that the audit expected to land with #679.

## Test plan

- [x] `npx jest tests/unit/device-network.test.ts` → 24/24 ✓
- [x] `npm run build` → green
- [x] `npx jest tests/unit/network-blockers.test.ts` → 44/44 ✓ (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)