### PR TITLE
fix(ax-bridge-wrapper): surface structured ErrorJSON from STDOUT (#693 WU1)

### DIFF
--- a/src/native/accessibility-bridge.ts
+++ b/src/native/accessibility-bridge.ts
@@ -18,6 +18,35 @@ const DEFAULT_MAX_DEPTH = 10;
 const DEFAULT_MAX_RESULTS = 50;
 const DEFAULT_TIMEOUT_MS = 15_000;
 
+/**
+ * Maximum characters retained per line in the diagnostic tails on the
+ * `BRIDGE_EXEC_FAILED` path. The bridge runs with `maxBuffer: 10 MB` so a
+ * degenerate single-line output could otherwise produce a multi-megabyte
+ * error message. 512 chars is roughly one terminal screen and enough to
+ * carry a stack frame, a `swiftc` diagnostic, or a JSON fragment without
+ * blowing log volume.
+ */
+const STREAM_TAIL_MAX_LINES = 5;
+const STREAM_TAIL_MAX_LINE_LENGTH = 512;
+
+function formatStreamTail(label: string, value: string | undefined): string {
+  if (!value) return '';
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return '';
+  const truncated = trimmed
+    .split('\n')
+    .slice(-STREAM_TAIL_MAX_LINES)
+    .map((line) =>
+      line.length > STREAM_TAIL_MAX_LINE_LENGTH
+        ? `${line.slice(0, STREAM_TAIL_MAX_LINE_LENGTH)}…[+${
+            line.length - STREAM_TAIL_MAX_LINE_LENGTH
+          } chars]`
+        : line,
+    )
+    .join(' / ');
+  return ` | ${label}: ${truncated}`;
+}
+
 export interface AccessibilityBridgeOptions {
   /**
    * Pre-resolve the bridge path, bypassing the filesystem search.
@@ -112,11 +141,21 @@ export class AccessibilityBridge {
       cmdArgs = args;
     }
 
+    // Captured outside the inner `try` so the SyntaxError path on
+    // `JSON.parse(stdout)` can still surface diagnostic tails — Node's
+    // `SyntaxError` does not carry stdout/stderr, so without this the
+    // catch block would degrade to `BRIDGE_EXEC_FAILED: SyntaxError …`
+    // with no clue what the bridge actually printed.
+    let capturedStdout: string | undefined;
+    let capturedStderr: string | undefined;
+
     try {
       const { stdout, stderr } = await execFileAsync(cmd, cmdArgs, {
         timeout: DEFAULT_TIMEOUT_MS,
         maxBuffer: 10 * 1024 * 1024, // 10MB for large trees
       });
+      capturedStdout = stdout;
+      capturedStderr = stderr;
 
       if (stderr) {
         console.error(`[ax-bridge] ${stderr.trim()}`);
@@ -147,6 +186,14 @@ export class AccessibilityBridge {
         );
       }
 
+      // Prefer the captured streams (populated only on the resolve path
+      // before `JSON.parse` throws) over `error.stdout/stderr` (populated
+      // by Node when `execFile` rejects with non-zero exit). Either source
+      // gives us actual bridge output; both are undefined for unrelated
+      // errors (e.g. spawn failure, ENOENT).
+      const stdoutForDiag = error.stdout ?? capturedStdout;
+      const stderrForDiag = error.stderr ?? capturedStderr;
+
       // Issue #693 WU1: the bridge writes its structured ErrorJSON
       // (`{ error, code }`) to STDOUT and then `exit(1)`, NOT to stderr —
       // see `outputError()` in `src/native/ax-bridge.swift`. The previous
@@ -157,7 +204,7 @@ export class AccessibilityBridge {
       // `code`. Try stdout first; keep stderr as a fallback so legacy
       // callers that emit JSON on stderr (or `swift` interpreter compile
       // errors) still surface cleanly.
-      const structuredCandidates = [error.stdout, error.stderr];
+      const structuredCandidates = [stdoutForDiag, stderrForDiag];
       for (const candidate of structuredCandidates) {
         if (!candidate) continue;
         try {
@@ -179,17 +226,14 @@ export class AccessibilityBridge {
       // the bridge wrote to. Without this the message degrades to
       // `Command failed: <cmd>` and every CI failure looks identical
       // regardless of root cause (unsigned binary, missing TCC, simulator
-      // not booted, swift interpreter compile error, etc.).
-      const tail = (label: string, value: string | undefined): string => {
-        if (!value) return '';
-        const trimmed = value.trim();
-        if (trimmed.length === 0) return '';
-        return ` | ${label}: ${trimmed.split('\n').slice(-5).join(' / ')}`;
-      };
+      // not booted, swift interpreter compile error, etc.). Per-line
+      // truncation prevents a single mega-line from exploding the error
+      // message — `maxBuffer` is 10 MB and a degenerate dump on a deep
+      // tree could fill it.
       throw new AccessibilityBridgeError(
         `ax-bridge failed (${cmd}): ${error.message}` +
-          tail('stdout', error.stdout) +
-          tail('stderr', error.stderr),
+          formatStreamTail('stdout', stdoutForDiag) +
+          formatStreamTail('stderr', stderrForDiag),
         'BRIDGE_EXEC_FAILED',
       );
     }

--- a/src/native/accessibility-bridge.ts
+++ b/src/native/accessibility-bridge.ts
@@ -133,7 +133,12 @@ export class AccessibilityBridge {
     } catch (err) {
       if (err instanceof AccessibilityBridgeError) throw err;
 
-      const error = err as Error & { stderr?: string; code?: string; killed?: boolean };
+      const error = err as Error & {
+        stdout?: string;
+        stderr?: string;
+        code?: string;
+        killed?: boolean;
+      };
 
       if (error.killed) {
         throw new AccessibilityBridgeError(
@@ -142,28 +147,49 @@ export class AccessibilityBridge {
         );
       }
 
-      // Try to parse error JSON from stderr
-      if (error.stderr) {
+      // Issue #693 WU1: the bridge writes its structured ErrorJSON
+      // (`{ error, code }`) to STDOUT and then `exit(1)`, NOT to stderr —
+      // see `outputError()` in `src/native/ax-bridge.swift`. The previous
+      // implementation only inspected `error.stderr` here, so every typed
+      // bridge error (DEVICE_CONTENT_ROOT_EMPTY, DEVICE_RESOLUTION_FAILED,
+      // SIMULATOR_NOT_RUNNING, etc.) collapsed to the generic
+      // `Command failed: <cmd>` tail and the caller could not branch on
+      // `code`. Try stdout first; keep stderr as a fallback so legacy
+      // callers that emit JSON on stderr (or `swift` interpreter compile
+      // errors) still surface cleanly.
+      const structuredCandidates = [error.stdout, error.stderr];
+      for (const candidate of structuredCandidates) {
+        if (!candidate) continue;
         try {
-          const errJson = JSON.parse(error.stderr);
-          if (errJson.error) {
-            throw new AccessibilityBridgeError(errJson.error, errJson.code ?? 'AX_ERROR');
+          const errJson = JSON.parse(candidate);
+          if (errJson && typeof errJson === 'object' && typeof errJson.error === 'string') {
+            throw new AccessibilityBridgeError(
+              errJson.error,
+              typeof errJson.code === 'string' ? errJson.code : 'AX_ERROR',
+            );
           }
         } catch (parseErr) {
           if (parseErr instanceof AccessibilityBridgeError) throw parseErr;
-          // Not JSON, fall through to surface raw stderr below.
+          // Not JSON — fall through and try the next stream.
         }
       }
 
-      // Include the bridge's stderr tail in the thrown message. Without this
-      // the caller only sees `Command failed: <cmd>` and every CI failure
-      // looks identical regardless of root cause (unsigned binary, missing
-      // TCC, simulator not booted, swift interpreter compile error, etc.).
-      const stderrTail = error.stderr
-        ? ` | stderr: ${error.stderr.trim().split('\n').slice(-5).join(' / ')}`
-        : '';
+      // Include both stdout and stderr tails in the thrown message so the
+      // caller sees the same diagnostic shape regardless of which stream
+      // the bridge wrote to. Without this the message degrades to
+      // `Command failed: <cmd>` and every CI failure looks identical
+      // regardless of root cause (unsigned binary, missing TCC, simulator
+      // not booted, swift interpreter compile error, etc.).
+      const tail = (label: string, value: string | undefined): string => {
+        if (!value) return '';
+        const trimmed = value.trim();
+        if (trimmed.length === 0) return '';
+        return ` | ${label}: ${trimmed.split('\n').slice(-5).join(' / ')}`;
+      };
       throw new AccessibilityBridgeError(
-        `ax-bridge failed (${cmd}): ${error.message}${stderrTail}`,
+        `ax-bridge failed (${cmd}): ${error.message}` +
+          tail('stdout', error.stdout) +
+          tail('stderr', error.stderr),
         'BRIDGE_EXEC_FAILED',
       );
     }

--- a/tests/unit/native-accessibility-bridge.test.ts
+++ b/tests/unit/native-accessibility-bridge.test.ts
@@ -310,6 +310,47 @@ describe('AccessibilityBridge', () => {
       }
     });
 
+    it('surfaces captured stdout in error message when JSON.parse throws SyntaxError on successful exit', async () => {
+      // Bridge exits 0 but stdout is not valid JSON (e.g. `swiftc` produced
+      // a binary that printed a partial dump before crashing). The previous
+      // implementation discarded the captured streams in this branch
+      // because Node's `SyntaxError` does not carry stdout/stderr.
+      mockExecSuccess('this is not json', 'some warning on stderr');
+
+      const promise = bridge.dumpTree();
+      try {
+        await promise;
+        throw new Error('expected throw');
+      } catch (err) {
+        const e = err as AccessibilityBridgeError;
+        expect(e.code).toBe('BRIDGE_EXEC_FAILED');
+        expect(e.message).toContain('stdout: this is not json');
+        expect(e.message).toContain('stderr: some warning on stderr');
+      }
+    });
+
+    it('truncates oversized single-line stdout in error tails', async () => {
+      const longLine = 'x'.repeat(2000);
+      mockExecFailure({
+        stdout: longLine,
+        stderr: '',
+        message: 'Command failed',
+      });
+
+      const promise = bridge.dumpTree();
+      try {
+        await promise;
+        throw new Error('expected throw');
+      } catch (err) {
+        const e = err as AccessibilityBridgeError;
+        expect(e.code).toBe('BRIDGE_EXEC_FAILED');
+        // Truncated form: 512 chars + ellipsis + `[+1488 chars]` marker.
+        expect(e.message).toContain('…[+1488 chars]');
+        // The full 2000-char line must not survive verbatim.
+        expect(e.message).not.toContain(longLine);
+      }
+    });
+
     it('still surfaces a typed AX_TIMEOUT for killed processes', async () => {
       mockExecFile.mockImplementation(
         (_cmd: string, _args: string[], _opts: unknown, cb?: ExecCallback) => {

--- a/tests/unit/native-accessibility-bridge.test.ts
+++ b/tests/unit/native-accessibility-bridge.test.ts
@@ -226,4 +226,112 @@ describe('AccessibilityBridge', () => {
       await expect(bridge.inspect('99/99')).rejects.toThrow('Element not found');
     });
   });
+
+  /**
+   * Issue #693 WU1: the Swift bridge writes its structured ErrorJSON
+   * (`{ error, code }`) to STDOUT on the typed-error path and then
+   * `exit(1)`. Before this fix, the wrapper only inspected `error.stderr`
+   * on a non-zero exit and every typed bridge error collapsed to the
+   * generic `BRIDGE_EXEC_FAILED` / `Command failed: <cmd>` shape so the
+   * caller could not branch on `code`. These tests prove the structured
+   * error now passes through verbatim from either stream.
+   */
+  describe('non-zero exit error parsing (#693 WU1)', () => {
+    function mockExecFailure(opts: { stdout?: string; stderr?: string; message?: string }) {
+      mockExecFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb?: ExecCallback) => {
+          const err = Object.assign(new Error(opts.message ?? 'Command failed'), {
+            stdout: opts.stdout ?? '',
+            stderr: opts.stderr ?? '',
+          });
+          if (cb) cb(err, { stdout: opts.stdout ?? '', stderr: opts.stderr ?? '' });
+          return { stdout: opts.stdout ?? '', stderr: opts.stderr ?? '' };
+        },
+      );
+    }
+
+    it('parses structured ErrorJSON from STDOUT on non-zero exit (DEVICE_CONTENT_ROOT_EMPTY)', async () => {
+      mockExecFailure({
+        stdout: JSON.stringify({
+          error:
+            'Matched simulator window, but no descendant exposes app-level accessibility semantics.',
+          code: 'DEVICE_CONTENT_ROOT_EMPTY',
+        }),
+        message: 'Command failed',
+      });
+
+      const promise = bridge.dumpTree();
+      await expect(promise).rejects.toBeInstanceOf(AccessibilityBridgeError);
+      try {
+        await promise;
+      } catch (err) {
+        const e = err as AccessibilityBridgeError;
+        expect(e.code).toBe('DEVICE_CONTENT_ROOT_EMPTY');
+        expect(e.message).toContain('no descendant exposes app-level accessibility semantics');
+        expect(e.message).not.toMatch(/^ax-bridge failed/);
+      }
+    });
+
+    it('falls back to STDERR-encoded ErrorJSON when STDOUT is empty', async () => {
+      mockExecFailure({
+        stderr: JSON.stringify({
+          error: 'Simulator.app is not running.',
+          code: 'SIMULATOR_NOT_RUNNING',
+        }),
+      });
+
+      const promise = bridge.dumpTree();
+      await expect(promise).rejects.toBeInstanceOf(AccessibilityBridgeError);
+      try {
+        await promise;
+      } catch (err) {
+        const e = err as AccessibilityBridgeError;
+        expect(e.code).toBe('SIMULATOR_NOT_RUNNING');
+        expect(e.message).toContain('Simulator.app is not running');
+      }
+    });
+
+    it('surfaces both stdout and stderr tails when neither stream parses as ErrorJSON', async () => {
+      mockExecFailure({
+        stdout: 'partial output before crash',
+        stderr: 'swift: dyld: Library not loaded',
+        message: 'Command failed: ax-bridge-native dump',
+      });
+
+      const promise = bridge.dumpTree();
+      await expect(promise).rejects.toBeInstanceOf(AccessibilityBridgeError);
+      try {
+        await promise;
+      } catch (err) {
+        const e = err as AccessibilityBridgeError;
+        expect(e.code).toBe('BRIDGE_EXEC_FAILED');
+        expect(e.message).toContain('stdout: partial output before crash');
+        expect(e.message).toContain('stderr: swift: dyld: Library not loaded');
+      }
+    });
+
+    it('still surfaces a typed AX_TIMEOUT for killed processes', async () => {
+      mockExecFile.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb?: ExecCallback) => {
+          const err = Object.assign(new Error('killed'), {
+            killed: true,
+            stdout: '',
+            stderr: '',
+          });
+          if (cb) cb(err, { stdout: '', stderr: '' });
+          return { stdout: '', stderr: '' };
+        },
+      );
+
+      const promise = bridge.dumpTree();
+      try {
+        await promise;
+        throw new Error('expected throw');
+      } catch (err) {
+        const e = err as AccessibilityBridgeError;
+        expect(e.code).toBe('AX_TIMEOUT');
+        expect(e.message).toContain('timed out');
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Issue #693 WU1: the Swift bridge writes its structured ErrorJSON (`{ error, code }`) to **STDOUT** and then `exit(1)`, NOT to stderr — see `outputError()` in `src/native/ax-bridge.swift`. The wrapper's non-zero-exit branch only inspected `error.stderr`, so every typed bridge error (`DEVICE_CONTENT_ROOT_EMPTY`, `DEVICE_RESOLUTION_FAILED`, `SIMULATOR_NOT_RUNNING`, `DEVICE_WINDOW_NOT_FOUND`, etc.) collapsed to the generic `BRIDGE_EXEC_FAILED` shape with a `Command failed: <cmd>` tail and the caller could not branch on `code`.

The user-reported repro on iPhone 17 Pro / iOS 26.4 (#693) showed exactly this — every `app_tree` / `app_query` / `app_tap_element` diagnostic from the omofictions session read `Command failed: ... dump --device ... --max-depth 6` and gave no hint that the underlying condition was `DEVICE_CONTENT_ROOT_EMPTY`.

## Changes

- `src/native/accessibility-bridge.ts:exec()` non-zero-exit branch now inspects `error.stdout` first for parseable ErrorJSON; falls back to `error.stderr` for legacy paths (and `swift` interpreter compile errors that emit JSON on stderr).
- When neither stream parses as ErrorJSON, the thrown message includes both stdout and stderr tails so the caller sees the same diagnostic shape regardless of which stream the bridge wrote to.
- `AX_TIMEOUT` (killed-process) handling unchanged.

This is a strictly additive change to the error-surfacing layer. Stdout parsing on the success path is untouched. No call site assumes `BRIDGE_EXEC_FAILED` for typed-error responses, so this fix does not break callers that branch on `code` — it gives them the structured codes they were always supposed to see.

## Why this is WU1 of #693

Issue #693 has two entangled failure surfaces (AX-empty Flutter sub-screens + AX-frame to iOS-point coordinate mismatch). Localising either requires the wrapper to surface the bridge's typed error code rather than `Command failed: …`. WU1 unblocks all subsequent work units; WU2-WU5 in the issue body cover the substantive Flutter Semantics activation + coordinate conversion fixes.

## Test plan

- [x] 4 new unit tests in `tests/unit/native-accessibility-bridge.test.ts`:
  - structured ErrorJSON from STDOUT (`DEVICE_CONTENT_ROOT_EMPTY` round-trip)
  - fallback parse from STDERR (`SIMULATOR_NOT_RUNNING` legacy shape)
  - unstructured both-stream output (BRIDGE_EXEC_FAILED with both tails)
  - killed-process (`AX_TIMEOUT` preserved)
- [x] `npx jest tests/unit/` — 2187 tests pass across 149 suites
- [x] `npx eslint src/native/accessibility-bridge.ts tests/unit/native-accessibility-bridge.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)