### PR TITLE
fix(cli): audit auto-spawns proxy; doctor probes /json for -F compat

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -22,6 +22,7 @@ import { setBlockedDomains } from '../src/security/domain-guard';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from '../src/watchdog/event-loop-monitor';
 import { SimulatorMonitor } from '../src/watchdog/simulator-monitor';
 import { AuthManager } from '../src/auth';
+import { parseAuditProxyPort, resolveAuditProxyPort } from '../src/cli/audit-port';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const pkg = require('../package.json');
@@ -234,7 +235,7 @@ program
   .command('audit')
   .description('Run QA audit and export results in CI-friendly formats')
   .requiredOption('--url <url>', 'URL to audit')
-  .option('--port <port>', 'WebKit debug proxy device port (default: 9322 or $OPENSAFARI_PROXY_PORT)', (v) => parseInt(v, 10))
+  .option('--port <port>', 'WebKit debug proxy device port (default: 9322 or $OPENSAFARI_PROXY_PORT)', parseAuditProxyPort)
   .option('--host <host>', 'WebKit debug proxy host', 'localhost')
   .option('--no-spawn-proxy', 'Do not auto-spawn ios_webkit_debug_proxy; assume one is already running')
   .option('--format <format>', 'Output format: markdown, junit, json', 'markdown')
@@ -253,13 +254,7 @@ program
     // Prefer the existing OPENSAFARI_PROXY_PORT env var (also honored by
     // WebInspectorProxy) so audit picks up the same value as `serve` in
     // CI / port-conflict setups.
-    const envPortRaw = process.env.OPENSAFARI_PROXY_PORT;
-    const envPort = envPortRaw ? parseInt(envPortRaw, 10) : undefined;
-    const port: number = options.port ?? (envPort !== undefined && !Number.isNaN(envPort) ? envPort : 9322);
-    if (Number.isNaN(port)) {
-      console.error(`Error: Invalid port value: ${options.port ?? envPortRaw}`);
-      process.exit(1);
-    }
+    const port: number = resolveAuditProxyPort(options.port, process.env.OPENSAFARI_PROXY_PORT);
     const host: string = options.host;
 
     // Auto-spawn proxy when targeting localhost unless --no-spawn-proxy is set.
@@ -267,13 +262,40 @@ program
     const shouldSpawn = options.spawnProxy !== false && host === 'localhost';
 
     let proxy: InstanceType<typeof WebInspectorProxy> | undefined;
+    let client: InstanceType<typeof WebKitClient> | undefined;
+    let preSpawnError: unknown;
+
     if (shouldSpawn) {
+      // Preserve compatibility with the documented device-port-only setup:
+      //   ios_webkit_debug_proxy -c "$UDID":9322
+      // In that mode the derived device-list port (9321) is closed, so
+      // WebInspectorProxy.start() cannot detect reuse and would fail with
+      // "port in use". Try the normal audit connection first; only spawn if
+      // nothing is listening/useful on the configured device port.
+      client = new WebKitClient({ host, port });
+      try {
+        await client.connect();
+      } catch (err) {
+        preSpawnError = err;
+        await client.disconnect().catch(() => { /* ignore */ });
+        client = undefined;
+      }
+    }
+
+    const existingProxyWithoutTargets = preSpawnError instanceof Error
+      && preSpawnError.message.includes('No Safari targets found');
+
+    if (shouldSpawn && !client && !existingProxyWithoutTargets) {
       proxy = new WebInspectorProxy({ port });
       try {
         await proxy.start();
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        const previous = preSpawnError instanceof Error ? preSpawnError.message : undefined;
         console.error(`Error: Could not start ios_webkit_debug_proxy on port ${port}. ${msg}`);
+        if (previous) {
+          console.error(`Previous connection attempt at ${host}:${port} also failed: ${previous}`);
+        }
         console.error('Hint: ensure a simulator is booted (xcrun simctl boot <device>) and ios-webkit-debug-proxy is installed (brew install ios-webkit-debug-proxy).');
         // start() may have spawned the child and registered a ref before
         // throwing (e.g. waitForReady timeout). Tear it down so we don't
@@ -283,10 +305,11 @@ program
       }
     }
 
-    let client: InstanceType<typeof WebKitClient> | undefined;
     try {
-      client = new WebKitClient({ host, port });
-      await client.connect();
+      client ??= new WebKitClient({ host, port });
+      if (!client.isConnected()) {
+        await client.connect();
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`Error: Could not connect to Safari at ${host}:${port}. ${msg}`);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -234,6 +234,9 @@ program
   .command('audit')
   .description('Run QA audit and export results in CI-friendly formats')
   .requiredOption('--url <url>', 'URL to audit')
+  .option('--port <port>', 'WebKit debug proxy device port (default: 9322 or $OPENSAFARI_WEBKIT_DEBUG_PORT)', (v) => parseInt(v, 10))
+  .option('--host <host>', 'WebKit debug proxy host', 'localhost')
+  .option('--no-spawn-proxy', 'Do not auto-spawn ios_webkit_debug_proxy; assume one is already running')
   .option('--format <format>', 'Output format: markdown, junit, json', 'markdown')
   .option('--output <path>', 'Write report to file instead of stdout')
   .option('--fail-on-high', 'Exit with code 1 if high-severity issues found')
@@ -245,49 +248,85 @@ program
     const { generateAuditJUnit } = await import('../src/qa/report-junit');
     const { generateAuditJSON } = await import('../src/qa/report-json');
     const { WebKitClient } = await import('../src/webkit/client');
+    const { WebInspectorProxy } = await import('../src/simulator/proxy');
+
+    const envPort = process.env.OPENSAFARI_WEBKIT_DEBUG_PORT
+      ? parseInt(process.env.OPENSAFARI_WEBKIT_DEBUG_PORT, 10)
+      : undefined;
+    const port: number = options.port ?? (envPort && !Number.isNaN(envPort) ? envPort : 9322);
+    const host: string = options.host;
+
+    // Auto-spawn proxy when targeting localhost unless --no-spawn-proxy is set.
+    // For non-localhost hosts the user is bringing their own proxy, so we never spawn.
+    const shouldSpawn = options.spawnProxy !== false && host === 'localhost';
+
+    let proxy: InstanceType<typeof WebInspectorProxy> | undefined;
+    if (shouldSpawn) {
+      proxy = new WebInspectorProxy({ port });
+      try {
+        await proxy.start();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`Error: Could not start ios_webkit_debug_proxy on port ${port}. ${msg}`);
+        console.error('Hint: ensure a simulator is booted (xcrun simctl boot <device>) and ios-webkit-debug-proxy is installed (brew install ios-webkit-debug-proxy).');
+        process.exit(1);
+      }
+    }
 
     let client: InstanceType<typeof WebKitClient> | undefined;
     try {
-      client = new WebKitClient({ host: 'localhost', port: 9322 });
+      client = new WebKitClient({ host, port });
       await client.connect();
-    } catch {
-      console.error('Error: Could not connect to Safari. Ensure a simulator is booted and ios-webkit-debug-proxy is running.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Error: Could not connect to Safari at ${host}:${port}. ${msg}`);
+      if (!shouldSpawn) {
+        console.error('Hint: ensure ios_webkit_debug_proxy is running on the configured port, or omit --no-spawn-proxy to auto-spawn it.');
+      }
+      if (proxy) await proxy.stop().catch(() => { /* ignore */ });
       process.exit(1);
     }
 
-    const audit = new QAAudit(client);
-    const report = await audit.runFullAudit(options.url);
-    const history = new QAHistory();
-    await history.save(report);
+    try {
+      const audit = new QAAudit(client);
+      const report = await audit.runFullAudit(options.url);
+      const history = new QAHistory();
+      await history.save(report);
 
-    let output: string;
-    switch (options.format) {
-      case 'junit':
-        output = generateAuditJUnit(report);
-        break;
-      case 'json':
-        output = JSON.stringify(generateAuditJSON(report), null, 2);
-        break;
-      default:
-        output = generateAuditMarkdown(report);
+      let output: string;
+      switch (options.format) {
+        case 'junit':
+          output = generateAuditJUnit(report);
+          break;
+        case 'json':
+          output = JSON.stringify(generateAuditJSON(report), null, 2);
+          break;
+        default:
+          output = generateAuditMarkdown(report);
+      }
+
+      if (options.output) {
+        const fs = await import('fs/promises');
+        await fs.writeFile(options.output, output, 'utf-8');
+        console.error(`Report written to ${options.output}`);
+      } else {
+        console.log(output);
+      }
+
+      const exitCode = history.getExitCode(report, {
+        failOnCritical: true,
+        failOnHigh: !!options.failOnHigh,
+        minScore: options.minScore,
+      });
+
+      await client.disconnect();
+      if (proxy) await proxy.stop();
+      process.exit(exitCode);
+    } catch (err) {
+      if (client) await client.disconnect().catch(() => { /* ignore */ });
+      if (proxy) await proxy.stop().catch(() => { /* ignore */ });
+      throw err;
     }
-
-    if (options.output) {
-      const fs = await import('fs/promises');
-      await fs.writeFile(options.output, output, 'utf-8');
-      console.error(`Report written to ${options.output}`);
-    } else {
-      console.log(output);
-    }
-
-    const exitCode = history.getExitCode(report, {
-      failOnCritical: true,
-      failOnHigh: !!options.failOnHigh,
-      minScore: options.minScore,
-    });
-
-    await client.disconnect();
-    process.exit(exitCode);
   });
 
 program.parse();

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -275,6 +275,10 @@ program
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`Error: Could not start ios_webkit_debug_proxy on port ${port}. ${msg}`);
         console.error('Hint: ensure a simulator is booted (xcrun simctl boot <device>) and ios-webkit-debug-proxy is installed (brew install ios-webkit-debug-proxy).');
+        // start() may have spawned the child and registered a ref before
+        // throwing (e.g. waitForReady timeout). Tear it down so we don't
+        // leak the proxy process or the ref file into the next run.
+        await proxy.stop().catch(() => { /* ignore */ });
         process.exit(1);
       }
     }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -234,7 +234,7 @@ program
   .command('audit')
   .description('Run QA audit and export results in CI-friendly formats')
   .requiredOption('--url <url>', 'URL to audit')
-  .option('--port <port>', 'WebKit debug proxy device port (default: 9322 or $OPENSAFARI_WEBKIT_DEBUG_PORT)', (v) => parseInt(v, 10))
+  .option('--port <port>', 'WebKit debug proxy device port (default: 9322 or $OPENSAFARI_PROXY_PORT)', (v) => parseInt(v, 10))
   .option('--host <host>', 'WebKit debug proxy host', 'localhost')
   .option('--no-spawn-proxy', 'Do not auto-spawn ios_webkit_debug_proxy; assume one is already running')
   .option('--format <format>', 'Output format: markdown, junit, json', 'markdown')
@@ -250,10 +250,16 @@ program
     const { WebKitClient } = await import('../src/webkit/client');
     const { WebInspectorProxy } = await import('../src/simulator/proxy');
 
-    const envPort = process.env.OPENSAFARI_WEBKIT_DEBUG_PORT
-      ? parseInt(process.env.OPENSAFARI_WEBKIT_DEBUG_PORT, 10)
-      : undefined;
-    const port: number = options.port ?? (envPort && !Number.isNaN(envPort) ? envPort : 9322);
+    // Prefer the existing OPENSAFARI_PROXY_PORT env var (also honored by
+    // WebInspectorProxy) so audit picks up the same value as `serve` in
+    // CI / port-conflict setups.
+    const envPortRaw = process.env.OPENSAFARI_PROXY_PORT;
+    const envPort = envPortRaw ? parseInt(envPortRaw, 10) : undefined;
+    const port: number = options.port ?? (envPort !== undefined && !Number.isNaN(envPort) ? envPort : 9322);
+    if (Number.isNaN(port)) {
+      console.error(`Error: Invalid port value: ${options.port ?? envPortRaw}`);
+      process.exit(1);
+    }
     const host: string = options.host;
 
     // Auto-spawn proxy when targeting localhost unless --no-spawn-proxy is set.

--- a/src/cli/audit-port.ts
+++ b/src/cli/audit-port.ts
@@ -1,0 +1,34 @@
+const DEFAULT_AUDIT_PROXY_PORT = 9322;
+
+function isValidPort(value: number): boolean {
+  return Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+function parsePortValue(raw: string | number): number {
+  if (typeof raw === 'number') {
+    if (isValidPort(raw)) return raw;
+    throw new Error(`Invalid port value: ${String(raw)}`);
+  }
+
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid port value: ${raw}`);
+  }
+
+  const parsed = Number(raw);
+  if (isValidPort(parsed)) return parsed;
+  throw new Error(`Invalid port value: ${raw}`);
+}
+
+export function parseAuditProxyPort(raw: string): number {
+  return parsePortValue(raw);
+}
+
+export function resolveAuditProxyPort(optionPort?: number, envPortRaw?: string): number {
+  if (optionPort !== undefined) {
+    return parsePortValue(optionPort);
+  }
+  if (envPortRaw !== undefined && envPortRaw !== '') {
+    return parsePortValue(envPortRaw);
+  }
+  return DEFAULT_AUDIT_PROXY_PORT;
+}

--- a/src/simulator/proxy.ts
+++ b/src/simulator/proxy.ts
@@ -270,8 +270,12 @@ export class WebInspectorProxy {
     const start = Date.now();
     while (Date.now() - start < timeout) {
       try {
-        const body = await this.httpGet(`http://localhost:${this._deviceListPort}`);
-        if (body.includes('iOS Devices')) return;
+        // Probe /json — works under both default frontend and -F (no-frontend)
+        // modes. Always returns a JSON array (possibly empty) when the proxy
+        // is alive. We spawn with -F (see start()), so probing `/` directly
+        // can return non-HTML content and miss the readiness signal.
+        const body = await this.httpGet(`http://localhost:${this._deviceListPort}/json`);
+        if (body.trimStart().startsWith('[')) return;
       } catch { /* retry */ }
       await new Promise(r => setTimeout(r, 500));
     }
@@ -318,8 +322,9 @@ export class WebInspectorProxy {
 
   private async isProxyHealthy(): Promise<boolean> {
     try {
-      const body = await this.httpGet(`http://localhost:${this._deviceListPort}`);
-      return body.includes('iOS Devices');
+      // See waitForReady — probe /json so the check works under -F mode.
+      const body = await this.httpGet(`http://localhost:${this._deviceListPort}/json`);
+      return body.trimStart().startsWith('[');
     } catch {
       return false;
     }

--- a/src/simulator/xcode-check.ts
+++ b/src/simulator/xcode-check.ts
@@ -4,7 +4,8 @@ import * as http from 'http';
 import { findSocketPath } from './socket-finder';
 
 const execFileAsync = promisify(execFile);
-// Device-list ports serve the "iOS Devices" HTML listing.
+// Device-list ports serve the JSON device list (and an HTML listing under the
+// default frontend). We probe via /json so the check works under -F mode too.
 // 9321 = opensafari default, 9221 = traditional ios_webkit_debug_proxy default.
 const PROXY_DEVICE_LIST_PORTS = [9321, 9221];
 // Device ports serve JSON target lists when a simulator device is connected.
@@ -149,8 +150,10 @@ async function findWebInspectorSocket(): Promise<string | undefined> {
  */
 async function checkProxyReachable(): Promise<{ reachable: boolean; port?: number }> {
   for (const port of PROXY_DEVICE_LIST_PORTS) {
-    // Device-list /json contains an array of {"deviceId": ...} entries.
-    const ok = await httpProbe(port, '/json', '"deviceId"');
+    // /json always returns a JSON array (possibly empty when no simulator is
+    // connected). Match the leading `[` so an alive-but-empty proxy still
+    // reports reachable, matching the previous HTML probe's semantics.
+    const ok = await httpProbe(port, '/json', '[');
     if (ok) return { reachable: true, port };
   }
   return { reachable: false };

--- a/src/simulator/xcode-check.ts
+++ b/src/simulator/xcode-check.ts
@@ -142,12 +142,15 @@ async function findWebInspectorSocket(): Promise<string | undefined> {
 
 /**
  * Try to reach ios_webkit_debug_proxy on known device-list and device ports.
- * Device-list ports serve an HTML page containing "iOS Devices".
- * Device ports serve JSON target lists when a device is connected.
+ *
+ * The probes hit `/json` rather than `/` so they work in both default and
+ * `-F` (no-frontend) modes — `/` serves the HTML DevTools UI which is omitted
+ * under `-F`, but `/json` always returns the JSON device/target list.
  */
 async function checkProxyReachable(): Promise<{ reachable: boolean; port?: number }> {
   for (const port of PROXY_DEVICE_LIST_PORTS) {
-    const ok = await httpProbe(port, 'iOS Devices');
+    // Device-list /json contains an array of {"deviceId": ...} entries.
+    const ok = await httpProbe(port, '/json', '"deviceId"');
     if (ok) return { reachable: true, port };
   }
   return { reachable: false };
@@ -159,15 +162,15 @@ async function checkProxyReachable(): Promise<{ reachable: boolean; port?: numbe
  */
 async function checkDevicePortReachable(): Promise<{ reachable: boolean; port?: number }> {
   for (const port of PROXY_DEVICE_PORTS) {
-    const ok = await httpProbe(port, '[');
+    const ok = await httpProbe(port, '/json', '[');
     if (ok) return { reachable: true, port };
   }
   return { reachable: false };
 }
 
-function httpProbe(port: number, expectedBody: string): Promise<boolean> {
+function httpProbe(port: number, path: string, expectedBody: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const req = http.get(`http://localhost:${port}`, { timeout: 2000 }, (res) => {
+    const req = http.get(`http://localhost:${port}${path}`, { timeout: 2000 }, (res) => {
       let body = '';
       res.on('data', (chunk: Buffer) => { body += chunk.toString(); });
       res.on('end', () => { resolve(body.includes(expectedBody)); });

--- a/tests/unit/cli-audit-port.test.ts
+++ b/tests/unit/cli-audit-port.test.ts
@@ -1,0 +1,31 @@
+import { resolveAuditProxyPort } from '../../src/cli/audit-port';
+
+describe('resolveAuditProxyPort', () => {
+  const defaultPort = 9322;
+
+  it('uses the explicit --port value before OPENSAFARI_PROXY_PORT', () => {
+    expect(resolveAuditProxyPort(9500, '9600')).toBe(9500);
+  });
+
+  it('uses OPENSAFARI_PROXY_PORT when --port is absent', () => {
+    expect(resolveAuditProxyPort(undefined, '9600')).toBe(9600);
+  });
+
+  it('falls back to the default port when no port is configured', () => {
+    expect(resolveAuditProxyPort(undefined, undefined)).toBe(defaultPort);
+  });
+
+  it('rejects an invalid explicit --port value', () => {
+    expect(() => resolveAuditProxyPort(Number.NaN, '9600')).toThrow('Invalid port value: NaN');
+  });
+
+  it('rejects an invalid OPENSAFARI_PROXY_PORT value instead of silently falling back', () => {
+    expect(() => resolveAuditProxyPort(undefined, 'not-a-port')).toThrow('Invalid port value: not-a-port');
+  });
+
+  it('rejects partial numeric strings and out-of-range ports', () => {
+    expect(() => resolveAuditProxyPort(undefined, '9322abc')).toThrow('Invalid port value: 9322abc');
+    expect(() => resolveAuditProxyPort(0, undefined)).toThrow('Invalid port value: 0');
+    expect(() => resolveAuditProxyPort(65536, undefined)).toThrow('Invalid port value: 65536');
+  });
+});

--- a/tests/unit/proxy-timing.test.ts
+++ b/tests/unit/proxy-timing.test.ts
@@ -32,6 +32,7 @@ import { WebKitClient } from '../../src/webkit/client';
 type ProxyPrivate = {
   waitForForwarding(timeout?: number): Promise<void>;
   waitForReady(timeout?: number): Promise<void>;
+  isProxyHealthy(): Promise<boolean>;
   httpGet(url: string): Promise<string>;
 };
 
@@ -140,6 +141,22 @@ describe('WebInspectorProxy initialization timing', () => {
       );
     });
 
+    it('does not treat an empty target list as forwarding-ready but resolves with warning after timeout', async () => {
+      httpGetSpy = jest
+        .spyOn(privateProxy(proxy) as unknown as { httpGet: (url: string) => Promise<string> }, 'httpGet')
+        .mockResolvedValue('[]');
+
+      jest.useFakeTimers();
+      const forwardingPromise = privateProxy(proxy).waitForForwarding(2000);
+      await jest.advanceTimersByTimeAsync(3000);
+
+      await expect(forwardingPromise).resolves.toBeUndefined();
+      expect(httpGetSpy).toHaveBeenCalledWith(`http://localhost:${proxy.port}/json`);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Forwarding port not ready within timeout'),
+      );
+    });
+
     it('polls the correct forwarding port URL', async () => {
       const capturedUrls: string[] = [];
       httpGetSpy = jest
@@ -194,6 +211,25 @@ describe('WebInspectorProxy initialization timing', () => {
       await privateProxy(proxy).waitForReady(5000);
 
       expect(capturedUrls[0]).toBe(`http://localhost:${proxy.deviceListPort}/json`);
+    });
+  });
+
+  describe('isProxyHealthy', () => {
+    it('probes device-list /json and accepts an empty JSON array under -F mode', async () => {
+      httpGetSpy = jest
+        .spyOn(privateProxy(proxy) as unknown as { httpGet: (url: string) => Promise<string> }, 'httpGet')
+        .mockResolvedValue('[]');
+
+      await expect(privateProxy(proxy).isProxyHealthy()).resolves.toBe(true);
+      expect(httpGetSpy).toHaveBeenCalledWith(`http://localhost:${proxy.deviceListPort}/json`);
+    });
+
+    it('rejects non-array device-list responses', async () => {
+      jest
+        .spyOn(privateProxy(proxy) as unknown as { httpGet: (url: string) => Promise<string> }, 'httpGet')
+        .mockResolvedValue('<html>iOS Devices</html>');
+
+      await expect(privateProxy(proxy).isProxyHealthy()).resolves.toBe(false);
     });
   });
 });

--- a/tests/unit/proxy-timing.test.ts
+++ b/tests/unit/proxy-timing.test.ts
@@ -156,16 +156,16 @@ describe('WebInspectorProxy initialization timing', () => {
   });
 
   describe('waitForReady', () => {
-    it('resolves when device-list port returns "iOS Devices"', async () => {
+    it('resolves when device-list /json returns a JSON array', async () => {
       httpGetSpy = jest
         .spyOn(privateProxy(proxy) as unknown as { httpGet: (url: string) => Promise<string> }, 'httpGet')
-        .mockResolvedValue('<html>iOS Devices</html>');
+        .mockResolvedValue('[]');
 
       await expect(privateProxy(proxy).waitForReady(5000)).resolves.toBeUndefined();
       expect(httpGetSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('throws when timeout expires without "iOS Devices" response', async () => {
+    it('throws when timeout expires without a JSON-array response', async () => {
       jest.useFakeTimers();
 
       httpGetSpy = jest
@@ -182,18 +182,18 @@ describe('WebInspectorProxy initialization timing', () => {
       await assertion;
     });
 
-    it('polls the device-list port URL', async () => {
+    it('polls the device-list /json URL', async () => {
       const capturedUrls: string[] = [];
       httpGetSpy = jest
         .spyOn(privateProxy(proxy) as unknown as { httpGet: (url: string) => Promise<string> }, 'httpGet')
         .mockImplementation(async (url: string) => {
           capturedUrls.push(url);
-          return 'iOS Devices';
+          return '[]';
         });
 
       await privateProxy(proxy).waitForReady(5000);
 
-      expect(capturedUrls[0]).toBe(`http://localhost:${proxy.deviceListPort}`);
+      expect(capturedUrls[0]).toBe(`http://localhost:${proxy.deviceListPort}/json`);
     });
   });
 });

--- a/tests/unit/xcode-check.test.ts
+++ b/tests/unit/xcode-check.test.ts
@@ -3,21 +3,37 @@ import type { XcodeCheckResult } from '../../src/simulator/xcode-check';
 // Mock all external I/O to make tests fully deterministic on any CI runner.
 // jest.mock calls are hoisted — factories must not reference outer-scope imports.
 
+const mockHttpResponses = new Map<string, string>();
+const mockHttpRequestedUrls: string[] = [];
+
 jest.mock('http', () => ({
-  get: jest.fn((...args: unknown[]) => {
+  get: jest.fn((url: string, ...args: unknown[]) => {
+    mockHttpRequestedUrls.push(url);
     const handlers: Record<string, (...a: unknown[]) => void> = {};
     const req: Record<string, unknown> = {
       on: jest.fn((event: string, handler: (...a: unknown[]) => void) => { handlers[event] = handler; return req; }),
       destroy: jest.fn(),
     };
-    process.nextTick(() => handlers['error']?.(new Error('ECONNREFUSED')));
-    const cb = typeof args[1] === 'function' ? args[1] as (...a: unknown[]) => void
-      : typeof args[2] === 'function' ? args[2] as (...a: unknown[]) => void
+    const cb = typeof args[0] === 'function' ? args[0] as (...a: unknown[]) => void
+      : typeof args[1] === 'function' ? args[1] as (...a: unknown[]) => void
       : null;
-    if (cb) {
-      const res: Record<string, unknown> = { statusCode: 0 };
-      res.on = jest.fn(() => res);
-      process.nextTick(() => cb(res));
+    const body = mockHttpResponses.get(url);
+    if (cb && body !== undefined) {
+      const responseHandlers: Record<string, (...a: unknown[]) => void> = {};
+      const res: Record<string, unknown> = {
+        statusCode: 200,
+        on: jest.fn((event: string, handler: (...a: unknown[]) => void) => {
+          responseHandlers[event] = handler;
+          return res;
+        }),
+      };
+      process.nextTick(() => {
+        cb(res);
+        responseHandlers['data']?.(Buffer.from(body));
+        responseHandlers['end']?.();
+      });
+    } else {
+      process.nextTick(() => handlers['error']?.(new Error('ECONNREFUSED')));
     }
     return req;
   }),
@@ -85,6 +101,17 @@ describe('XcodeCheckResult interface', () => {
 });
 
 describe('checkXcodeInstallation behavioral', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockHttpResponses.clear();
+    mockHttpRequestedUrls.length = 0;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
   it('sets devicePortReachable to false when proxy is not reachable', async () => {
     const result = await checkXcodeInstallation();
     expect(result.devicePortReachable).toBe(false);
@@ -106,5 +133,29 @@ describe('checkXcodeInstallation behavioral', () => {
   it('returns iOS runtimes from simctl', async () => {
     const result = await checkXcodeInstallation();
     expect(result.iosRuntimes).toContain('iOS 18.4');
+  });
+
+  it('treats device-list /json [] as a reachable proxy under -F mode', async () => {
+    mockHttpResponses.set('http://localhost:9321/json', '[]');
+
+    const result = await checkXcodeInstallation();
+
+    expect(result.proxyReachable).toBe(true);
+    expect(result.proxyPort).toBe(9321);
+    expect(mockHttpRequestedUrls).toContain('http://localhost:9321/json');
+    expect(mockHttpRequestedUrls).not.toContain('http://localhost:9321');
+  });
+
+  it('treats device-port /json [] as reachable when the proxy is reachable', async () => {
+    mockHttpResponses.set('http://localhost:9321/json', '[]');
+    mockHttpResponses.set('http://localhost:9322/json', '[]');
+
+    const result = await checkXcodeInstallation();
+
+    expect(result.proxyReachable).toBe(true);
+    expect(result.devicePortReachable).toBe(true);
+    expect(result.devicePort).toBe(9322);
+    expect(mockHttpRequestedUrls).toContain('http://localhost:9322/json');
+    expect(mockHttpRequestedUrls).not.toContain('http://localhost:9322');
   });
 });


### PR DESCRIPTION
## Problem

Two CLI commands fail in common host environments:

**1. `opensafari audit` is unusable standalone.** It hard-codes `port: 9322` and assumes a proxy is already running, but the README/getting-started doesn't document how to start one for the audit path. Running it cold just prints:

> Error: Could not connect to Safari. Ensure a simulator is booted and ios-webkit-debug-proxy is running.

…with no actionable next step. Users have to discover the right `ios_webkit_debug_proxy -s unix:... -c null:9321,:9322-9422` invocation from the proxy's own help.

**2. `opensafari doctor` reports "Device Port ✗" against `-F` proxies.** The HTTP probe hits `/` and looks for `iOS Devices` / `[`. The `-F` (no-frontend) mode strips the HTML DevTools UI from `/`, so the probe fails even when the proxy is healthy and `/json` returns the expected data.

## Changes

### `audit` now auto-spawns its proxy

`audit` reuses `WebInspectorProxy` — the same class `serve` already uses, with the same ref-counted reuse logic. When invoked:

- If a proxy on the configured device-list port is already healthy, it is reused (ref-counted, not killed on exit).
- Otherwise, audit spawns one, runs, and stops it on exit.
- New flags: `--port`, `--host`, `--no-spawn-proxy`. Honors the existing **`OPENSAFARI_PROXY_PORT`** env var (same one `WebInspectorProxy` already uses) so audit picks up the same port as `serve` in CI / port-conflict setups.
- Invalid `--port` / env values now fail fast with `Error: Invalid port value: …` instead of silently defaulting.
- Error messages include `host:port` so users know what was attempted.

### `doctor` and `WebInspectorProxy` probe `/json`

- `doctor.httpProbe` now takes a path; both probes hit `/json`. Device-list match is `[` (the JSON array prefix), so a healthy proxy with no simulator booted (`/json` → `[]`) is still reported reachable — preserving the previous HTML probe's semantics. The match also avoids an incorrect assumption about the device-list schema (entries are `{url: ...}`, not `{deviceId: ...}`).
- `WebInspectorProxy.waitForReady` and `isProxyHealthy` were also probing `/` for `iOS Devices`, but `start()` spawns the proxy with `-F` (no-frontend). Switched both to `/json` so the readiness/health checks remain reliable under `-F`. (Previously the proxy was relying on whatever fallback content the underlying `ios_webkit_debug_proxy` build returned at `/` under `-F` — moving to `/json` removes that dependency.)

## User-facing impact

| Scenario | Before | After |
|---|---|---|
| `opensafari audit --url X` cold (sim booted) | "Could not connect to Safari" | Audit runs |
| `opensafari audit --url X` with running proxy | Worked only if on 9322 | Reuses proxy, no port assumption |
| CI with pre-spawned proxy on non-default port | Worked on 9322 only | `--no-spawn-proxy` (or `OPENSAFARI_PROXY_PORT`) keeps current behavior on any port |
| `opensafari audit --port abc` (invalid) | Silent default to 9322 → confusing later error | Fails fast: `Error: Invalid port value: abc` |
| `opensafari doctor` against `-F` proxy | Device Port ✗ | Device Port ✓ |
| `opensafari serve` (MCP) | Internally relied on `/` returning `iOS Devices` under `-F` | Probes `/json` — strictly more reliable across `ios_webkit_debug_proxy` builds |

## Risks & trade-offs

- **+1–2s on first audit** for proxy startup (skipped if already running thanks to ref-counted reuse).
- **Audit still requires a booted simulator.** That is unchanged; the new error message points users at `xcrun simctl boot <device>`.
- The `audit` lifecycle now relies on `WebInspectorProxy.stop()`'s ref-counted teardown — already exercised by `serve`, so this is the same code path with one more caller.
- Proxy ref counts live in `/tmp/opensafari-proxy-<port>.refs`; the TOCTOU window noted in `proxy.ts` is unchanged by this PR.
- `WebInspectorProxy` probe change is a behavior change for `serve` too (not just audit). It should be strictly more correct — `/json` is part of the public proxy API and is served regardless of frontend mode — but worth a careful look from a maintainer.

## Test plan

- [x] `npm run lint` — 0 errors (warnings unchanged from `main`)
- [x] `npx jest --config jest.config.js` — 1686 / 1686 passing, including updated `proxy-timing.test.ts`
- [x] `npm run build` — webpack server + cli bundles compile
- [x] `node dist/cli/index.js audit --help` shows new flags
- [ ] Manual: `opensafari audit --url https://example.com` against a booted iPhone simulator (no pre-existing proxy) — runs end-to-end and cleans up
- [ ] Manual: `opensafari audit --url ... --no-spawn-proxy` against a pre-spawned external proxy — connects without spawning a second
- [ ] Manual: `OPENSAFARI_PROXY_PORT=9500 opensafari audit ...` — both serve and audit pick up 9500 consistently
- [ ] Manual: `opensafari doctor` against `-F` proxy — Device Port ✓

## Notes for reviewers

- The patch keeps `audit` strictly localhost-aware: when `--host` is non-`localhost` we never spawn, on the assumption that the user is pointing at a remote/CI proxy.
- I deliberately did **not** add `--device <preset>` boot logic to keep this PR focused. Happy to follow up with that if it's wanted — `SimulatorPool` makes it straightforward.
- Two integration-test helpers (`tests/integration/{single-device,multi-tab}-e2e.test.ts`) still grep for `"iOS Devices"` against the proxy's `/`. They're untouched here (out of scope), but flagging in case you want to migrate them too.

## Review feedback addressed

- **High** [@gemini-code-assist] proxy `waitForReady`/`isProxyHealthy` would have timed out under `-F` → both switched to `/json`.
- **Medium** [@gemini-code-assist] `--port abc` → `NaN` silent fallthrough → explicit `Number.isNaN` check, fail fast.
- **Medium** [@gemini-code-assist] `"deviceId"` regression on un-booted proxy → matched by `[`.
- **P2** [@chatgpt-codex-connector] Honor existing `OPENSAFARI_PROXY_PORT` instead of inventing `OPENSAFARI_WEBKIT_DEBUG_PORT`.
- **P2** [@chatgpt-codex-connector] device-list `/json` schema is `{url: ...}`, not `{deviceId: ...}` → matched by `[` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)