### PR TITLE
fix(security): gate high-risk tools in http mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ HTTP mode listens on `127.0.0.1` by default. The `/health` endpoint is unauthent
 
 Browser CORS for `/mcp` is restricted to local origins (`localhost`, `127.0.0.1`, `::1`) plus any comma-separated origins passed with `--http-allow-origin`. Use `--http-host` only when you intentionally need a non-loopback bind.
 
+HTTP mode also blocks high-risk MCP tools that execute page/app code or move authentication material: `javascript`, `flutter_evaluate`, `auth_save`, `auth_restore`, and `cookies`. Stdio mode is unchanged. To intentionally expose those tools over HTTP, start with `--http-enable-high-risk-tools` or set `OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS=1`; allowed and blocked high-risk HTTP calls are audit-logged with sensitive arguments redacted.
+
 ```bash
 OPENSAFARI_HTTP_TOKEN="$OPENSAFARI_HTTP_TOKEN" opensafari serve --http 3100
 curl -H "Authorization: Bearer $OPENSAFARI_HTTP_TOKEN" \

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -40,6 +40,7 @@ program
   .option('--http-token <token>', 'Bearer token required for HTTP /mcp requests')
   .option('--http-allow-origin <origins>', 'Allowed browser origins for HTTP /mcp CORS (comma-separated)')
   .option('--http-insecure-local', 'Disable HTTP /mcp token auth for explicit local-only insecure use')
+  .option('--http-enable-high-risk-tools', 'Allow high-risk code execution and credential movement tools over HTTP')
   .option('--devices <presets>', 'Auto-boot devices (comma-separated)')
   .option('--auth <path>', 'Auth profile to auto-restore')
   .option('--all-tools', 'Expose all tool tiers immediately (equivalent to OPENSAFARI_TOOL_TIER=3)')
@@ -146,6 +147,7 @@ program
       authToken: options.httpToken,
       httpInsecure: options.httpInsecureLocal,
       allowedOrigins,
+      httpHighRiskTools: options.httpEnableHighRiskTools,
     });
     console.error('[OpenSafari] MCP server running');
   });

--- a/docs/ci-recipes.md
+++ b/docs/ci-recipes.md
@@ -25,6 +25,8 @@ Every CI machine that runs OpenSafari must satisfy the following requirements.
 
 `opensafari serve --http` binds to `127.0.0.1` by default and requires a bearer token for `/mcp`. Store the token in your CI secret manager as `OPENSAFARI_HTTP_TOKEN`; do not echo it. HTTP health checks may call `/health` without the token, but MCP JSON-RPC calls must include `Authorization: Bearer $OPENSAFARI_HTTP_TOKEN`.
 
+High-risk tools that execute code or move authentication/session material are disabled in HTTP mode unless explicitly enabled: `javascript`, `flutter_evaluate`, `auth_save`, `auth_restore`, and `cookies`. Prefer leaving them disabled in CI. If a controlled job requires them, set `OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS=1` or pass `--http-enable-high-risk-tools`; OpenSafari records high-risk HTTP calls in the audit log with sensitive arguments redacted.
+
 ## GitHub Actions Recipe
 
 A complete workflow that covers three jobs:

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ export async function createServer(options?: {
   authToken?: string;
   httpInsecure?: boolean;
   allowedOrigins?: string[];
+  httpHighRiskTools?: boolean;
   allTools?: boolean;
 }): Promise<MCPServer> {
   const server = new MCPServer();
@@ -88,6 +89,7 @@ export async function createServer(options?: {
     authToken: options?.authToken,
     httpInsecure: options?.httpInsecure,
     allowedOrigins: options?.allowedOrigins,
+    httpHighRiskTools: options?.httpHighRiskTools,
   });
   return server;
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -222,7 +222,7 @@ export class MCPServer {
         return this.handleInitialize(request);
 
       case 'tools/list':
-        return this.handleToolsList(request);
+        return this.handleToolsList(request, context);
 
       case 'tools/call':
         return this.handleToolsCall(request, context);
@@ -260,9 +260,10 @@ export class MCPServer {
     };
   }
 
-  private handleToolsList(request: MCPRequest): MCPResponse {
+  private handleToolsList(request: MCPRequest, context: MCPMessageContext): MCPResponse {
     const visibleTools = Array.from(this.tools.values())
       .filter((t) => t.tier <= this.currentTier)
+      .filter((t) => this.shouldAdvertiseTool(t.definition.name, context))
       .map((t) => t.definition);
 
     return {
@@ -270,6 +271,12 @@ export class MCPServer {
       id: request.id,
       result: { tools: visibleTools },
     };
+  }
+
+  private shouldAdvertiseTool(name: string, context: MCPMessageContext): boolean {
+    if (context.transport !== 'http') return true;
+    if (this.httpHighRiskToolsEnabled) return true;
+    return getHighRiskToolMetadata(name) === undefined;
   }
 
   private async handleToolsCall(request: MCPRequest, context: MCPMessageContext): Promise<MCPResponse> {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14,11 +14,17 @@ import {
   MCPToolDefinition,
   ToolHandler,
   MCPErrorCodes,
+  MCPMessageContext,
 } from './types/mcp';
 import { createTransport, MCPTransport, TransportMode } from './transports';
 import { TOOL_TIERS, getToolTier } from './config/tool-tiers';
 import { BrowserBackend } from './types/browser-backend';
 import { logAuditEntry } from './security/audit-logger';
+import {
+  buildHttpHighRiskToolError,
+  getHighRiskToolMetadata,
+  parseHttpHighRiskToolsEnabled,
+} from './security/high-risk-tools';
 import { getSessionManager } from './session-manager';
 import { getVersion } from './version';
 
@@ -103,6 +109,8 @@ export interface MCPServerOptions {
   httpInsecure?: boolean;
   /** Extra allowed browser origins for HTTP /mcp CORS. */
   allowedOrigins?: string[];
+  /** Allow high-risk code execution / credential movement tools over HTTP. */
+  httpHighRiskTools?: boolean;
 }
 
 export class MCPServer {
@@ -110,6 +118,7 @@ export class MCPServer {
   private transport: MCPTransport | null = null;
   private currentTier: number = 2;
   private auditLogEnabled = false;
+  private httpHighRiskToolsEnabled = false;
 
   // ------------------------------------------------------------------
   // Tool registration
@@ -134,6 +143,9 @@ export class MCPServer {
 
   async start(options: MCPServerOptions = {}): Promise<void> {
     const mode: TransportMode = options.transport ?? 'stdio';
+    this.httpHighRiskToolsEnabled =
+      options.httpHighRiskTools === true ||
+      parseHttpHighRiskToolsEnabled(process.env.OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS);
     this.transport = await createTransport(mode, {
       port: options.port,
       host: options.host,
@@ -142,7 +154,7 @@ export class MCPServer {
       allowedOrigins: options.allowedOrigins,
     });
 
-    this.transport.onMessage((msg) => this.handleMessage(msg));
+    this.transport.onMessage((msg, context) => this.handleMessage(msg, context));
     await this.transport.start();
 
     console.error(`[OpenSafari] MCP server started (${mode})`);
@@ -178,6 +190,7 @@ export class MCPServer {
 
   private async handleMessage(
     msg: Record<string, unknown>,
+    context: MCPMessageContext = { transport: 'stdio' },
   ): Promise<MCPResponse | null> {
     // Notifications have no id — process but return null (no response)
     const hasId = 'id' in msg && msg.id !== undefined;
@@ -212,7 +225,7 @@ export class MCPServer {
         return this.handleToolsList(request);
 
       case 'tools/call':
-        return this.handleToolsCall(request);
+        return this.handleToolsCall(request, context);
 
       default:
         return {
@@ -259,7 +272,7 @@ export class MCPServer {
     };
   }
 
-  private async handleToolsCall(request: MCPRequest): Promise<MCPResponse> {
+  private async handleToolsCall(request: MCPRequest, context: MCPMessageContext): Promise<MCPResponse> {
     const params = request.params as
       | { name?: string; arguments?: Record<string, unknown> }
       | undefined;
@@ -290,15 +303,29 @@ export class MCPServer {
       };
     }
 
-    // Session ID: use Mcp-Session-Id from context if available; fall back to
-    // a stable placeholder until the HTTP transport propagates it here.
-    const sessionId = (request.params as Record<string, unknown> | undefined)
-      ?._sessionId as string | undefined ?? 'default';
+    const sessionId = context.sessionId ?? 'default';
+    const highRiskTool = getHighRiskToolMetadata(name);
+    const isHighRiskHttp = context.transport === 'http' && highRiskTool !== undefined;
+
+    if (isHighRiskHttp && !this.httpHighRiskToolsEnabled) {
+      logAuditEntry(name, sessionId, args, undefined, 'blocked');
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        result: {
+          content: [{
+            type: 'text',
+            text: `Error: ${buildHttpHighRiskToolError(name)}`,
+          }],
+          isError: true,
+        },
+      };
+    }
 
     try {
       const result: MCPResult = await tool.handler(sessionId, args);
-      if (this.auditLogEnabled) {
-        logAuditEntry(name, sessionId, args);
+      if (this.auditLogEnabled || isHighRiskHttp) {
+        logAuditEntry(name, sessionId, args, undefined, result.isError ? 'error' : 'allowed');
       }
       return {
         jsonrpc: '2.0',
@@ -306,8 +333,8 @@ export class MCPServer {
         result,
       };
     } catch (err) {
-      if (this.auditLogEnabled) {
-        logAuditEntry(name, sessionId, args);
+      if (this.auditLogEnabled || isHighRiskHttp) {
+        logAuditEntry(name, sessionId, args, undefined, 'error');
       }
       const message = err instanceof Error ? err.message : String(err);
       return {

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -12,6 +12,7 @@ interface AuditEntry {
   tool: string;           // tool name
   domain: string | null;  // extracted from page URL, null if N/A
   sessionId: string;
+  status?: string;
   args_summary: string;   // brief summary, no sensitive data
 }
 
@@ -28,35 +29,48 @@ function extractDomain(url?: string): string | null {
   return extractHostname(url) || null;
 }
 
-const SENSITIVE_KEYS = ['password', 'cookie', 'token', 'secret', 'auth', 'credential', 'value', 'text'];
+const SENSITIVE_KEYS = ['password', 'cookie', 'token', 'secret', 'auth', 'credential', 'value', 'text', 'expression', 'script', 'code'];
 
 function isSensitiveKey(key: string): boolean {
   const lower = key.toLowerCase();
   return SENSITIVE_KEYS.some(s => lower.includes(s));
 }
 
-// Summarize args (redact sensitive values)
-function summarizeArgs(args: Record<string, unknown>): string {
-  // Include keys like tabId, url, action but redact values of sensitive keys
-  const safe: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(args)) {
-    if (isSensitiveKey(key)) {
-      safe[key] = '[REDACTED]';
-    } else if (typeof value === 'string' && value.length > 100) {
-      safe[key] = value.slice(0, 100) + '...';
-    } else {
-      safe[key] = value;
-    }
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactValue);
   }
-  return JSON.stringify(safe);
+  if (value && typeof value === 'object') {
+    const safe: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+      safe[key] = isSensitiveKey(key) ? '[REDACTED]' : redactValue(nestedValue);
+    }
+    return safe;
+  }
+  if (typeof value === 'string' && value.length > 100) {
+    return value.slice(0, 100) + '...';
+  }
+  return value;
 }
 
-export function logAuditEntry(tool: string, sessionId: string, args: Record<string, unknown>, pageUrl?: string): void {
+// Summarize args (redact sensitive values)
+function summarizeArgs(args: Record<string, unknown>): string {
+  return JSON.stringify(redactValue(args));
+}
+
+export function logAuditEntry(
+  tool: string,
+  sessionId: string,
+  args: Record<string, unknown>,
+  pageUrl?: string,
+  status?: string,
+): void {
   const entry: AuditEntry = {
     timestamp: new Date().toISOString(),
     tool,
     domain: extractDomain(pageUrl || (args.url as string)),
     sessionId,
+    ...(status ? { status } : {}),
     args_summary: summarizeArgs(args),
   };
 

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -29,7 +29,18 @@ function extractDomain(url?: string): string | null {
   return extractHostname(url) || null;
 }
 
-const SENSITIVE_KEYS = ['password', 'cookie', 'token', 'secret', 'auth', 'credential', 'value', 'text', 'expression', 'script', 'code'];
+const SENSITIVE_KEYS = [
+  'password',
+  'passwd',
+  'pwd',
+  'cookie',
+  'token',
+  'secret',
+  'auth',
+  'credential',
+  'authorization',
+  'session',
+];
 
 function isSensitiveKey(key: string): boolean {
   const lower = key.toLowerCase();

--- a/src/security/high-risk-tools.ts
+++ b/src/security/high-risk-tools.ts
@@ -14,7 +14,32 @@ export const HIGH_RISK_MCP_TOOLS: Readonly<Record<string, HighRiskToolMetadata>>
     category: 'code-execution',
     requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
   },
+  // batch_execute fans out an arbitrary JS expression to every active simulator
+  // (src/tools/batch-execute.ts), so it is a code-execution surface equivalent to `javascript`.
+  batch_execute: {
+    category: 'code-execution',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
   flutter_evaluate: {
+    category: 'code-execution',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
+  // flutter_call_service_extension explicitly documents itself as accepting
+  // arbitrary VM-service extension code in `args` and must be treated like flutter_evaluate
+  // (src/tools/flutter-service-extensions.ts).
+  flutter_call_service_extension: {
+    category: 'code-execution',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
+  // run_scenario evaluates a caller-supplied JS `assertion` in the page context
+  // (src/tools/scenario-tools.ts), so it can run arbitrary code in HTTP mode.
+  run_scenario: {
+    category: 'code-execution',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
+  // assert_all_devices accepts a JS `assertion` for the "custom" check
+  // (src/tools/assert-all-devices.ts), executed in the page context across all devices.
+  assert_all_devices: {
     category: 'code-execution',
     requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
   },

--- a/src/security/high-risk-tools.ts
+++ b/src/security/high-risk-tools.ts
@@ -43,6 +43,14 @@ export const HIGH_RISK_MCP_TOOLS: Readonly<Record<string, HighRiskToolMetadata>>
     category: 'code-execution',
     requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
   },
+  // mock_geolocation interpolates `latitude`/`longitude`/`accuracy`/`altitude` directly into
+  // a JS template that is then run via `client.evaluate` (src/tools/mock-geolocation.ts).
+  // MCP does not enforce JSON Schema at runtime, so a string payload that survives the numeric
+  // range check (e.g. NaN-on-coercion) yields arbitrary code execution in the page context.
+  mock_geolocation: {
+    category: 'code-execution',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
   auth_save: {
     category: 'credential-movement',
     requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,

--- a/src/security/high-risk-tools.ts
+++ b/src/security/high-risk-tools.ts
@@ -1,0 +1,46 @@
+export type HighRiskToolCategory = 'code-execution' | 'credential-movement';
+
+export interface HighRiskToolMetadata {
+  category: HighRiskToolCategory;
+  requiredCapability: 'http-high-risk-tools';
+}
+
+export const HTTP_HIGH_RISK_TOOL_CAPABILITY = 'http-high-risk-tools' as const;
+export const HTTP_HIGH_RISK_TOOLS_ENV = 'OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS' as const;
+export const HTTP_HIGH_RISK_TOOLS_FLAG = '--http-enable-high-risk-tools' as const;
+
+export const HIGH_RISK_MCP_TOOLS: Readonly<Record<string, HighRiskToolMetadata>> = Object.freeze({
+  javascript: {
+    category: 'code-execution',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
+  flutter_evaluate: {
+    category: 'code-execution',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
+  auth_save: {
+    category: 'credential-movement',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
+  auth_restore: {
+    category: 'credential-movement',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
+  cookies: {
+    category: 'credential-movement',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
+});
+
+export function getHighRiskToolMetadata(toolName: string): HighRiskToolMetadata | undefined {
+  return HIGH_RISK_MCP_TOOLS[toolName];
+}
+
+export function parseHttpHighRiskToolsEnabled(value: string | undefined): boolean {
+  if (!value) return false;
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}
+
+export function buildHttpHighRiskToolError(toolName: string): string {
+  return `HTTP high-risk tool "${toolName}" requires ${HTTP_HIGH_RISK_TOOLS_FLAG} or ${HTTP_HIGH_RISK_TOOLS_ENV}=1. Stdio mode is unchanged.`;
+}

--- a/src/tools/flutter-evaluate.ts
+++ b/src/tools/flutter-evaluate.ts
@@ -67,10 +67,9 @@ export function registerFlutterEvaluateTool(server: MCPServer): void {
         }
         const expression = rawExpression;
 
-        // Security audit: log every evaluate call. Truncated to avoid
-        // huge payloads in the transport log.
-        const preview = expression.length > 200 ? `${expression.slice(0, 200)}…` : expression;
-        console.error(`[flutter_evaluate] audit: evaluating expression (len=${expression.length}): ${preview}`);
+        // Security audit: never log the expression body; the MCP audit log
+        // records a redacted argument summary when HTTP high-risk access is enabled.
+        console.error(`[flutter_evaluate] audit: evaluating expression (len=${expression.length})`);
 
         const scope: EvalScope = (params.scope as EvalScope | undefined) ?? 'root';
         if (scope !== 'root' && scope !== 'frame') {

--- a/src/tools/mock-geolocation.ts
+++ b/src/tools/mock-geolocation.ts
@@ -37,23 +37,42 @@ export function registerMockGeolocationTool(server: MCPServer): void {
           isError: true,
         };
 
-      const latitude = params.latitude as number;
-      const longitude = params.longitude as number;
-      const accuracy = (params.accuracy as number) ?? 10;
-      const altitude = params.altitude as number | undefined;
+      const coerceFinite = (raw: unknown): number | undefined => {
+        if (raw === undefined || raw === null) return undefined;
+        if (typeof raw !== 'number') return Number.NaN;
+        return Number.isFinite(raw) ? raw : Number.NaN;
+      };
 
-      if (latitude < -90 || latitude > 90) {
+      const latitude = coerceFinite(params.latitude);
+      const longitude = coerceFinite(params.longitude);
+      const accuracyRaw = coerceFinite(params.accuracy);
+      const altitude = coerceFinite(params.altitude);
+
+      if (latitude === undefined || !Number.isFinite(latitude) || latitude < -90 || latitude > 90) {
         return {
-          content: [{ type: 'text' as const, text: 'Error: latitude must be between -90 and 90' }],
+          content: [{ type: 'text' as const, text: 'Error: latitude must be a finite number between -90 and 90' }],
           isError: true,
         };
       }
-      if (longitude < -180 || longitude > 180) {
+      if (longitude === undefined || !Number.isFinite(longitude) || longitude < -180 || longitude > 180) {
         return {
-          content: [{ type: 'text' as const, text: 'Error: longitude must be between -180 and 180' }],
+          content: [{ type: 'text' as const, text: 'Error: longitude must be a finite number between -180 and 180' }],
           isError: true,
         };
       }
+      if (accuracyRaw !== undefined && !Number.isFinite(accuracyRaw)) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: accuracy must be a finite number' }],
+          isError: true,
+        };
+      }
+      if (altitude !== undefined && !Number.isFinite(altitude)) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: altitude must be a finite number' }],
+          isError: true,
+        };
+      }
+      const accuracy = accuracyRaw ?? 10;
 
       const altitudeJs = altitude !== undefined ? String(altitude) : 'null';
       const altitudeAccuracyJs = altitude !== undefined ? '10' : 'null';

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -13,7 +13,7 @@
 import * as http from 'node:http';
 import * as crypto from 'node:crypto';
 import type { AddressInfo } from 'node:net';
-import { MCPResponse, MCPErrorCodes } from '../types/mcp';
+import { MCPMessageContext, MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { MCPTransport } from './index';
 import type { TransportOptions } from './index';
 
@@ -40,7 +40,7 @@ function logTransportEvent(event: string, details: Record<string, unknown>): voi
 
 export class HTTPTransport implements MCPTransport {
   private server: http.Server | null = null;
-  private messageHandler: ((msg: Record<string, unknown>) => Promise<MCPResponse | null>) | null = null;
+  private messageHandler: ((msg: Record<string, unknown>, context?: MCPMessageContext) => Promise<MCPResponse | null>) | null = null;
   private port: number;
   private host: string;
   private authToken?: string;
@@ -66,7 +66,7 @@ export class HTTPTransport implements MCPTransport {
     this.sessionDeleteHandler = handler;
   }
 
-  onMessage(handler: (msg: Record<string, unknown>) => Promise<MCPResponse | null>): void {
+  onMessage(handler: (msg: Record<string, unknown>, context?: MCPMessageContext) => Promise<MCPResponse | null>): void {
     this.messageHandler = handler;
   }
 
@@ -416,7 +416,7 @@ export class HTTPTransport implements MCPTransport {
       }
 
       try {
-        const response = await this.messageHandler(msg);
+        const response = await this.messageHandler(msg, { transport: 'http', sessionId });
 
         if (sessionId) {
           res.setHeader('Mcp-Session-Id', sessionId);
@@ -559,7 +559,7 @@ export class HTTPTransport implements MCPTransport {
       const record = msg as Record<string, unknown>;
 
       try {
-        return await handler(record);
+        return await handler(record, { transport: 'http', sessionId });
       } catch (error) {
         const id = (record.id as string | number) ?? 0;
         return {

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -3,7 +3,7 @@
  * Decouples the wire protocol (stdio, HTTP) from the MCP protocol logic.
  */
 
-import { MCPResponse } from '../types/mcp';
+import { MCPMessageContext, MCPResponse } from '../types/mcp';
 
 /**
  * Abstraction over the wire protocol (stdio or HTTP).
@@ -16,7 +16,7 @@ export interface MCPTransport {
    * The handler returns a response for requests (those with an id),
    * or null for notifications (no id).
    */
-  onMessage(handler: (msg: Record<string, unknown>) => Promise<MCPResponse | null>): void;
+  onMessage(handler: (msg: Record<string, unknown>, context?: MCPMessageContext) => Promise<MCPResponse | null>): void;
 
   /**
    * Send a JSON-RPC response or notification to the client.

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -5,14 +5,14 @@
  */
 
 import * as readline from 'readline';
-import { MCPResponse, MCPErrorCodes } from '../types/mcp';
+import { MCPMessageContext, MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { MCPTransport } from './index';
 
 export class StdioTransport implements MCPTransport {
   private rl: readline.Interface | null = null;
-  private messageHandler: ((msg: Record<string, unknown>) => Promise<MCPResponse | null>) | null = null;
+  private messageHandler: ((msg: Record<string, unknown>, context?: MCPMessageContext) => Promise<MCPResponse | null>) | null = null;
 
-  onMessage(handler: (msg: Record<string, unknown>) => Promise<MCPResponse | null>): void {
+  onMessage(handler: (msg: Record<string, unknown>, context?: MCPMessageContext) => Promise<MCPResponse | null>): void {
     this.messageHandler = handler;
   }
 
@@ -53,7 +53,7 @@ export class StdioTransport implements MCPTransport {
         return;
       }
 
-      this.messageHandler(parsed)
+      this.messageHandler(parsed, { transport: 'stdio' })
         .then((response) => {
           if (response) {
             this.send(response);

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -22,6 +22,11 @@ export interface MCPResponse {
   error?: MCPError;
 }
 
+export interface MCPMessageContext {
+  transport: 'stdio' | 'http';
+  sessionId?: string;
+}
+
 export interface MCPResult {
   [key: string]: unknown;
   content?: MCPContent[];

--- a/tests/unit/http-high-risk-tools.test.ts
+++ b/tests/unit/http-high-risk-tools.test.ts
@@ -1,0 +1,214 @@
+import fs from 'fs';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { MCPServer } from '../../src/mcp-server';
+import { HTTP_HIGH_RISK_TOOLS_ENV, HTTP_HIGH_RISK_TOOLS_FLAG } from '../../src/security/high-risk-tools';
+import { MCPMessageContext, MCPResponse } from '../../src/types/mcp';
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+function mcpPost(
+  port: number,
+  body: Record<string, unknown>,
+  headers?: Record<string, string>,
+): Promise<{ body: Record<string, unknown>; status?: number; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': data.length,
+          ...headers,
+        },
+      },
+      (res) => {
+        let buf = '';
+        res.on('data', (chunk) => (buf += chunk));
+        res.on('end', () => {
+          resolve({ body: JSON.parse(buf), status: res.statusCode, headers: res.headers });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+function registerHighRiskFixtures(server: MCPServer, calls: string[] = []): void {
+  server.registerTool(
+    {
+      name: 'javascript',
+      description: 'fixture high-risk code execution tool',
+      inputSchema: {
+        type: 'object' as const,
+        properties: { expression: { type: 'string' } },
+        required: ['expression'],
+      },
+    },
+    async (_sessionId, params) => {
+      calls.push(String(params.expression));
+      return { content: [{ type: 'text' as const, text: 'executed' }] };
+    },
+  );
+
+  server.registerTool(
+    {
+      name: 'auth_save',
+      description: 'fixture high-risk credential movement tool',
+      inputSchema: {
+        type: 'object' as const,
+        properties: { site: { type: 'string' } },
+        required: ['site'],
+      },
+    },
+    async () => ({ content: [{ type: 'text' as const, text: 'saved' }] }),
+  );
+}
+
+describe('HTTP high-risk MCP tool gate', () => {
+  const originalEnv = process.env.OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS;
+  let mkdirSpy: jest.SpyInstance;
+  let appendSpy: jest.SpyInstance;
+  let auditLines: string[];
+
+  beforeEach(() => {
+    delete process.env.OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS;
+    auditLines = [];
+    mkdirSpy = jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as unknown as string);
+    appendSpy = jest.spyOn(fs, 'appendFile').mockImplementation(((_path, data, cb) => {
+      auditLines.push(String(data));
+      if (typeof cb === 'function') cb(null);
+    }) as typeof fs.appendFile);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS;
+    } else {
+      process.env.OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS = originalEnv;
+    }
+    appendSpy.mockRestore();
+    mkdirSpy.mockRestore();
+  });
+
+  test('HTTP blocks code execution and auth movement tools without the capability', async () => {
+    const server = new MCPServer();
+    const port = await getFreePort();
+    const calls: string[] = [];
+    registerHighRiskFixtures(server, calls);
+
+    await server.start({ transport: 'http', port, httpInsecure: true });
+    try {
+      const js = await mcpPost(port, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'javascript', arguments: { expression: 'document.cookie' } },
+      }, { 'Mcp-Session-Id': 'http-session' });
+
+      const jsResult = js.body.result as Record<string, unknown>;
+      const jsContent = jsResult.content as Array<Record<string, unknown>>;
+      expect(jsResult.isError).toBe(true);
+      expect(jsContent[0].text).toContain(HTTP_HIGH_RISK_TOOLS_FLAG);
+      expect(jsContent[0].text).toContain(`${HTTP_HIGH_RISK_TOOLS_ENV}=1`);
+      expect(calls).toEqual([]);
+
+      const auth = await mcpPost(port, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'auth_save', arguments: { site: 'example.test' } },
+      }, { 'Mcp-Session-Id': 'http-session' });
+
+      const authResult = auth.body.result as Record<string, unknown>;
+      expect(authResult.isError).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test('HTTP allows high-risk tools with capability and audits redacted arguments', async () => {
+    const server = new MCPServer();
+    const port = await getFreePort();
+    registerHighRiskFixtures(server);
+
+    await server.start({
+      transport: 'http',
+      port,
+      httpInsecure: true,
+      httpHighRiskTools: true,
+    });
+    try {
+      const res = await mcpPost(port, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'javascript',
+          arguments: {
+            expression: 'document.cookie',
+            nested: {
+              cookieValue: 'sid=secret-cookie',
+              safe: 'kept',
+            },
+          },
+        },
+      }, { 'Mcp-Session-Id': 'audit-session' });
+
+      const result = res.body.result as Record<string, unknown>;
+      const content = result.content as Array<Record<string, unknown>>;
+      expect(content[0].text).toBe('executed');
+
+      expect(auditLines).toHaveLength(1);
+      const audit = JSON.parse(auditLines[0]) as Record<string, unknown>;
+      expect(audit.tool).toBe('javascript');
+      expect(audit.sessionId).toBe('audit-session');
+      expect(audit.status).toBe('allowed');
+      const summary = JSON.parse(audit.args_summary as string) as Record<string, unknown>;
+      expect(summary.expression).toBe('[REDACTED]');
+      expect((summary.nested as Record<string, unknown>).cookieValue).toBe('[REDACTED]');
+      expect((summary.nested as Record<string, unknown>).safe).toBe('kept');
+      expect(auditLines[0]).not.toContain('document.cookie');
+      expect(auditLines[0]).not.toContain('secret-cookie');
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test('stdio context preserves high-risk tool availability without HTTP capability', async () => {
+    const server = new MCPServer();
+    registerHighRiskFixtures(server);
+
+    const response = await (server as unknown as {
+      handleMessage: (
+        msg: Record<string, unknown>,
+        context?: MCPMessageContext,
+      ) => Promise<MCPResponse | null>;
+    }).handleMessage({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: { name: 'javascript', arguments: { expression: '1 + 1' } },
+    }, { transport: 'stdio' });
+
+    const result = response?.result as Record<string, unknown>;
+    const content = result.content as Array<Record<string, unknown>>;
+    expect(content[0].text).toBe('executed');
+    expect(auditLines).toHaveLength(0);
+  });
+});

--- a/tests/unit/http-high-risk-tools.test.ts
+++ b/tests/unit/http-high-risk-tools.test.ts
@@ -1,52 +1,23 @@
 import fs from 'fs';
-import http from 'http';
-import type { AddressInfo } from 'net';
 import { MCPServer } from '../../src/mcp-server';
 import { HTTP_HIGH_RISK_TOOLS_ENV, HTTP_HIGH_RISK_TOOLS_FLAG } from '../../src/security/high-risk-tools';
 import { MCPMessageContext, MCPResponse } from '../../src/types/mcp';
 
-function getFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer();
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address() as AddressInfo;
-      server.close(() => resolve(address.port));
-    });
-  });
+function handleMessage(
+  server: MCPServer,
+  msg: Record<string, unknown>,
+  context: MCPMessageContext,
+): Promise<MCPResponse | null> {
+  return (server as unknown as {
+    handleMessage: (
+      msg: Record<string, unknown>,
+      context?: MCPMessageContext,
+    ) => Promise<MCPResponse | null>;
+  }).handleMessage(msg, context);
 }
 
-function mcpPost(
-  port: number,
-  body: Record<string, unknown>,
-  headers?: Record<string, string>,
-): Promise<{ body: Record<string, unknown>; status?: number; headers: http.IncomingHttpHeaders }> {
-  return new Promise((resolve, reject) => {
-    const data = JSON.stringify(body);
-    const req = http.request(
-      {
-        hostname: '127.0.0.1',
-        port,
-        path: '/mcp',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': data.length,
-          ...headers,
-        },
-      },
-      (res) => {
-        let buf = '';
-        res.on('data', (chunk) => (buf += chunk));
-        res.on('end', () => {
-          resolve({ body: JSON.parse(buf), status: res.statusCode, headers: res.headers });
-        });
-      },
-    );
-    req.on('error', reject);
-    req.write(data);
-    req.end();
-  });
+function enableHttpHighRiskTools(server: MCPServer): void {
+  (server as unknown as { httpHighRiskToolsEnabled: boolean }).httpHighRiskToolsEnabled = true;
 }
 
 function registerHighRiskFixtures(server: MCPServer, calls: string[] = []): void {
@@ -106,100 +77,147 @@ describe('HTTP high-risk MCP tool gate', () => {
     mkdirSpy.mockRestore();
   });
 
+  test('HTTP tools/list hides high-risk tools without the capability', async () => {
+    const server = new MCPServer();
+    registerHighRiskFixtures(server);
+    server.setTier(3);
+
+    const res = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 10,
+      method: 'tools/list',
+      params: {},
+    }, { transport: 'http', sessionId: 'list-session' });
+
+    const result = res?.result as Record<string, unknown>;
+    const tools = result.tools as Array<Record<string, unknown>>;
+    const names = tools.map((tool) => tool.name);
+    expect(names).not.toContain('javascript');
+    expect(names).not.toContain('auth_save');
+  });
+
+  test('HTTP tools/list advertises high-risk tools with the capability', async () => {
+    const server = new MCPServer();
+    registerHighRiskFixtures(server);
+    server.setTier(3);
+
+    enableHttpHighRiskTools(server);
+    const res = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 11,
+      method: 'tools/list',
+      params: {},
+    }, { transport: 'http', sessionId: 'list-session' });
+
+    const result = res?.result as Record<string, unknown>;
+    const tools = result.tools as Array<Record<string, unknown>>;
+    const names = tools.map((tool) => tool.name);
+    expect(names).toContain('javascript');
+    expect(names).toContain('auth_save');
+  });
+
   test('HTTP blocks code execution and auth movement tools without the capability', async () => {
     const server = new MCPServer();
-    const port = await getFreePort();
     const calls: string[] = [];
     registerHighRiskFixtures(server, calls);
 
-    await server.start({ transport: 'http', port, httpInsecure: true });
-    try {
-      const js = await mcpPost(port, {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tools/call',
-        params: { name: 'javascript', arguments: { expression: 'document.cookie' } },
-      }, { 'Mcp-Session-Id': 'http-session' });
+    const js = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'javascript', arguments: { expression: 'document.cookie' } },
+    }, { transport: 'http', sessionId: 'http-session' });
 
-      const jsResult = js.body.result as Record<string, unknown>;
-      const jsContent = jsResult.content as Array<Record<string, unknown>>;
-      expect(jsResult.isError).toBe(true);
-      expect(jsContent[0].text).toContain(HTTP_HIGH_RISK_TOOLS_FLAG);
-      expect(jsContent[0].text).toContain(`${HTTP_HIGH_RISK_TOOLS_ENV}=1`);
-      expect(calls).toEqual([]);
+    const jsResult = js?.result as Record<string, unknown>;
+    const jsContent = jsResult.content as Array<Record<string, unknown>>;
+    expect(jsResult.isError).toBe(true);
+    expect(jsContent[0].text).toContain(HTTP_HIGH_RISK_TOOLS_FLAG);
+    expect(jsContent[0].text).toContain(`${HTTP_HIGH_RISK_TOOLS_ENV}=1`);
+    expect(calls).toEqual([]);
 
-      const auth = await mcpPost(port, {
-        jsonrpc: '2.0',
-        id: 2,
-        method: 'tools/call',
-        params: { name: 'auth_save', arguments: { site: 'example.test' } },
-      }, { 'Mcp-Session-Id': 'http-session' });
+    const auth = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'auth_save', arguments: { site: 'example.test' } },
+    }, { transport: 'http', sessionId: 'http-session' });
 
-      const authResult = auth.body.result as Record<string, unknown>;
-      expect(authResult.isError).toBe(true);
-    } finally {
-      await server.stop();
-    }
+    const authResult = auth?.result as Record<string, unknown>;
+    expect(authResult.isError).toBe(true);
   });
 
   test('HTTP allows high-risk tools with capability and audits redacted arguments', async () => {
     const server = new MCPServer();
-    const port = await getFreePort();
     registerHighRiskFixtures(server);
 
-    await server.start({
-      transport: 'http',
-      port,
-      httpInsecure: true,
-      httpHighRiskTools: true,
-    });
-    try {
-      const res = await mcpPost(port, {
-        jsonrpc: '2.0',
-        id: 3,
-        method: 'tools/call',
-        params: {
-          name: 'javascript',
-          arguments: {
-            expression: 'document.cookie',
-            nested: {
-              cookieValue: 'sid=secret-cookie',
-              safe: 'kept',
-            },
+    enableHttpHighRiskTools(server);
+    const res = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'javascript',
+        arguments: {
+          expression: 'document.querySelector("button")?.textContent',
+          text: 'ordinary text is kept',
+          value: 'ordinary value is kept',
+          password: 'secret-password',
+          accessToken: 'secret-token',
+          authorization: 'Bearer secret-auth',
+          sessionId: 'secret-session',
+          nested: {
+            cookieValue: 'sid=secret-cookie',
+            safe: 'kept',
           },
         },
-      }, { 'Mcp-Session-Id': 'audit-session' });
+      },
+    }, { transport: 'http', sessionId: 'audit-session' });
 
-      const result = res.body.result as Record<string, unknown>;
-      const content = result.content as Array<Record<string, unknown>>;
-      expect(content[0].text).toBe('executed');
+    const result = res?.result as Record<string, unknown>;
+    const content = result.content as Array<Record<string, unknown>>;
+    expect(content[0].text).toBe('executed');
 
-      expect(auditLines).toHaveLength(1);
-      const audit = JSON.parse(auditLines[0]) as Record<string, unknown>;
-      expect(audit.tool).toBe('javascript');
-      expect(audit.sessionId).toBe('audit-session');
-      expect(audit.status).toBe('allowed');
-      const summary = JSON.parse(audit.args_summary as string) as Record<string, unknown>;
-      expect(summary.expression).toBe('[REDACTED]');
-      expect((summary.nested as Record<string, unknown>).cookieValue).toBe('[REDACTED]');
-      expect((summary.nested as Record<string, unknown>).safe).toBe('kept');
-      expect(auditLines[0]).not.toContain('document.cookie');
-      expect(auditLines[0]).not.toContain('secret-cookie');
-    } finally {
-      await server.stop();
-    }
+    expect(auditLines).toHaveLength(1);
+    const audit = JSON.parse(auditLines[0]) as Record<string, unknown>;
+    expect(audit.tool).toBe('javascript');
+    expect(audit.sessionId).toBe('audit-session');
+    expect(audit.status).toBe('allowed');
+    const summary = JSON.parse(audit.args_summary as string) as Record<string, unknown>;
+    expect(summary.expression).toBe('document.querySelector("button")?.textContent');
+    expect(summary.text).toBe('ordinary text is kept');
+    expect(summary.value).toBe('ordinary value is kept');
+    expect(summary.password).toBe('[REDACTED]');
+    expect(summary.accessToken).toBe('[REDACTED]');
+    expect(summary.authorization).toBe('[REDACTED]');
+    expect(summary.sessionId).toBe('[REDACTED]');
+    expect((summary.nested as Record<string, unknown>).cookieValue).toBe('[REDACTED]');
+    expect((summary.nested as Record<string, unknown>).safe).toBe('kept');
+    expect(auditLines[0]).not.toContain('secret-password');
+    expect(auditLines[0]).not.toContain('secret-token');
+    expect(auditLines[0]).not.toContain('secret-auth');
+    expect(auditLines[0]).not.toContain('secret-session');
+    expect(auditLines[0]).not.toContain('secret-cookie');
   });
 
   test('stdio context preserves high-risk tool availability without HTTP capability', async () => {
     const server = new MCPServer();
     registerHighRiskFixtures(server);
+    server.setTier(3);
 
-    const response = await (server as unknown as {
-      handleMessage: (
-        msg: Record<string, unknown>,
-        context?: MCPMessageContext,
-      ) => Promise<MCPResponse | null>;
-    }).handleMessage({
+    const listResponse = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 12,
+      method: 'tools/list',
+      params: {},
+    }, { transport: 'stdio' });
+
+    const listResult = listResponse?.result as Record<string, unknown>;
+    const tools = listResult.tools as Array<Record<string, unknown>>;
+    const names = tools.map((tool) => tool.name);
+    expect(names).toContain('javascript');
+    expect(names).toContain('auth_save');
+
+    const response = await handleMessage(server, {
       jsonrpc: '2.0',
       id: 4,
       method: 'tools/call',

--- a/tests/unit/http-high-risk-tools.test.ts
+++ b/tests/unit/http-high-risk-tools.test.ts
@@ -257,6 +257,7 @@ describe('HTTP high-risk MCP tool gate', () => {
     'flutter_call_service_extension',
     'run_scenario',
     'assert_all_devices',
+    'mock_geolocation',
   ])('HTTP gates code-execution tool %s without the capability', async (toolName) => {
     expect(getHighRiskToolMetadata(toolName)).toEqual({
       category: 'code-execution',

--- a/tests/unit/http-high-risk-tools.test.ts
+++ b/tests/unit/http-high-risk-tools.test.ts
@@ -204,6 +204,54 @@ describe('HTTP high-risk MCP tool gate', () => {
     expect(auditLines[0]).not.toContain('secret-cookie');
   });
 
+  test('HTTP audit log redacts the cookies tool arguments including nested cookie values', async () => {
+    const server = new MCPServer();
+    server.registerTool(
+      {
+        name: 'cookies',
+        description: 'fixture cookies tool',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            action: { type: 'string' },
+            cookies: { type: 'array' },
+            domain: { type: 'string' },
+          },
+        },
+      },
+      async () => ({ content: [{ type: 'text' as const, text: 'cookies set' }] }),
+    );
+    enableHttpHighRiskTools(server);
+
+    await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 30,
+      method: 'tools/call',
+      params: {
+        name: 'cookies',
+        arguments: {
+          action: 'set',
+          cookies: [
+            { name: 'sid', value: 'super-secret-session', domain: 'example.com', path: '/' },
+            { name: 'auth_token', value: 'super-secret-auth', domain: '.example.com' },
+          ],
+          domain: 'example.com',
+        },
+      },
+    }, { transport: 'http', sessionId: 'cookie-audit' });
+
+    expect(auditLines).toHaveLength(1);
+    const audit = JSON.parse(auditLines[0]) as Record<string, unknown>;
+    expect(audit.tool).toBe('cookies');
+    expect(audit.status).toBe('allowed');
+    const summary = JSON.parse(audit.args_summary as string) as Record<string, unknown>;
+    expect(summary.action).toBe('set');
+    expect(summary.cookies).toBe('[REDACTED]');
+    expect(summary.domain).toBe('example.com');
+    expect(auditLines[0]).not.toContain('super-secret-session');
+    expect(auditLines[0]).not.toContain('super-secret-auth');
+  });
+
   test.each([
     'batch_execute',
     'flutter_call_service_extension',

--- a/tests/unit/http-high-risk-tools.test.ts
+++ b/tests/unit/http-high-risk-tools.test.ts
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import { MCPServer } from '../../src/mcp-server';
-import { HTTP_HIGH_RISK_TOOLS_ENV, HTTP_HIGH_RISK_TOOLS_FLAG } from '../../src/security/high-risk-tools';
+import {
+  HIGH_RISK_MCP_TOOLS,
+  HTTP_HIGH_RISK_TOOLS_ENV,
+  HTTP_HIGH_RISK_TOOLS_FLAG,
+  getHighRiskToolMetadata,
+} from '../../src/security/high-risk-tools';
 import { MCPMessageContext, MCPResponse } from '../../src/types/mcp';
 
 function handleMessage(
@@ -197,6 +202,86 @@ describe('HTTP high-risk MCP tool gate', () => {
     expect(auditLines[0]).not.toContain('secret-auth');
     expect(auditLines[0]).not.toContain('secret-session');
     expect(auditLines[0]).not.toContain('secret-cookie');
+  });
+
+  test.each([
+    'batch_execute',
+    'flutter_call_service_extension',
+    'run_scenario',
+    'assert_all_devices',
+  ])('HTTP gates code-execution tool %s without the capability', async (toolName) => {
+    expect(getHighRiskToolMetadata(toolName)).toEqual({
+      category: 'code-execution',
+      requiredCapability: 'http-high-risk-tools',
+    });
+
+    const server = new MCPServer();
+    const calls: string[] = [];
+    server.registerTool(
+      {
+        name: toolName,
+        description: `fixture for ${toolName}`,
+        inputSchema: {
+          type: 'object' as const,
+          properties: { expression: { type: 'string' } },
+        },
+      },
+      async (_sessionId, params) => {
+        calls.push(JSON.stringify(params));
+        return { content: [{ type: 'text' as const, text: 'executed' }] };
+      },
+    );
+    server.setTier(3);
+
+    const blocked = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 20,
+      method: 'tools/call',
+      params: { name: toolName, arguments: { expression: 'document.cookie' } },
+    }, { transport: 'http', sessionId: 'gate-session' });
+
+    const blockedResult = blocked?.result as Record<string, unknown>;
+    const blockedContent = blockedResult.content as Array<Record<string, unknown>>;
+    expect(blockedResult.isError).toBe(true);
+    expect(blockedContent[0].text).toContain(HTTP_HIGH_RISK_TOOLS_FLAG);
+    expect(blockedContent[0].text).toContain(`${HTTP_HIGH_RISK_TOOLS_ENV}=1`);
+    expect(calls).toEqual([]);
+
+    const listResponse = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 21,
+      method: 'tools/list',
+      params: {},
+    }, { transport: 'http', sessionId: 'gate-session' });
+
+    const listResult = listResponse?.result as Record<string, unknown>;
+    const tools = listResult.tools as Array<Record<string, unknown>>;
+    expect(tools.map((t) => t.name)).not.toContain(toolName);
+
+    enableHttpHighRiskTools(server);
+    const allowed = await handleMessage(server, {
+      jsonrpc: '2.0',
+      id: 22,
+      method: 'tools/call',
+      params: { name: toolName, arguments: { expression: '1 + 1' } },
+    }, { transport: 'http', sessionId: 'gate-session' });
+
+    const allowedResult = allowed?.result as Record<string, unknown>;
+    const allowedContent = allowedResult.content as Array<Record<string, unknown>>;
+    expect(allowedContent[0].text).toBe('executed');
+    expect(calls).toHaveLength(1);
+  });
+
+  test('high-risk denylist still covers the originally hardened code/credential tools', () => {
+    for (const expectedTool of [
+      'javascript',
+      'flutter_evaluate',
+      'auth_save',
+      'auth_restore',
+      'cookies',
+    ]) {
+      expect(HIGH_RISK_MCP_TOOLS[expectedTool]).toBeDefined();
+    }
   });
 
   test('stdio context preserves high-risk tool availability without HTTP capability', async () => {

--- a/tests/unit/mock-geolocation.test.ts
+++ b/tests/unit/mock-geolocation.test.ts
@@ -112,6 +112,31 @@ describe('mock_geolocation tool', () => {
     expect((result.content as any)[0].text).toContain('longitude');
   });
 
+  test('rejects non-number latitude/longitude (defense in depth against schema bypass)', async () => {
+    // MCP does not enforce JSON-Schema types at runtime, so callers can send strings even when
+    // the schema declares numbers. Without strict coercion, a string payload would be interpolated
+    // into the JS template (`latitude: ${latitude}`) and executed via `client.evaluate`, giving
+    // arbitrary code execution. Each non-number / non-finite input must be rejected.
+    const mock = createMockClient();
+    setWebKitClient(mock as any);
+    const handler = server.getToolHandler('mock_geolocation')!;
+
+    for (const bad of [
+      { latitude: '0; window.__pwn = 1', longitude: 0 },
+      { latitude: 0, longitude: '0\n;alert(1)' },
+      { latitude: Number.NaN, longitude: 0 },
+      { latitude: 0, longitude: Number.POSITIVE_INFINITY },
+      { latitude: 0, longitude: 0, accuracy: '5; foo()' },
+      { latitude: 0, longitude: 0, altitude: '10; bar()' },
+    ]) {
+      const result = await handler('test', bad as Record<string, unknown>);
+      expect(result.isError).toBe(true);
+    }
+
+    // None of the rejected calls should have reached client.evaluate.
+    expect(mock.calls.find((c) => c.method === 'evaluate')).toBeUndefined();
+  });
+
   test('attempts Page.addScriptToEvaluateOnLoad for persistence', async () => {
     const mock = createMockClient();
     setWebKitClient(mock as any);


### PR DESCRIPTION
## Summary
- Gate high-risk MCP tools in HTTP mode by default while preserving stdio behavior.
- Add an explicit `--http-enable-high-risk-tools` / `OPENSAFARI_HTTP_ENABLE_HIGH_RISK_TOOLS=1` opt-in for HTTP code execution and credential/session movement tools.
- Add audit logging for blocked/allowed/error high-risk HTTP calls with recursive sensitive argument redaction.
- Document the HTTP-mode capability in README and CI recipes.

## Stacking
- Stacked on PR #714 (`harden/http-mcp-transport-697`) because this depends on the HTTP transport context/session hardening from #697.
- Base branch for this PR: `harden/http-mcp-transport-697`.

## Validation
- `git diff --check`
- `PATH=/opt/data/projects/opensafari/node_modules/.bin:$PATH npm test -- --runInBand tests/unit/http-high-risk-tools.test.ts --silent`
- `PATH=/opt/data/projects/opensafari/node_modules/.bin:$PATH npm test -- --runInBand tests/unit/http-high-risk-tools.test.ts tests/unit/http-transport-security.test.ts tests/unit/mcp-server.test.ts --silent`
- `PATH=/opt/data/projects/opensafari/node_modules/.bin:$PATH tsc --noEmit --pretty false`
- `PATH=/opt/data/projects/opensafari/node_modules/.bin:$PATH timeout 300s eslint cli/index.ts src/index.ts src/mcp-server.ts src/security/audit-logger.ts src/security/high-risk-tools.ts src/tools/flutter-evaluate.ts src/transports/http.ts src/transports/index.ts src/transports/stdio.ts src/types/mcp.ts tests/unit/http-high-risk-tools.test.ts --quiet`

Closes #698.