### PR TITLE
fix(security): harden auth profile persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ opensafari serve
   → All simulators start already logged in
 ```
 
+Auth profiles are JSON files stored under `~/.opensafari/auth/`. Each profile contains the site name, capture timestamp, current URL, cookies, cookie domain groups, localStorage, and sessionStorage needed to restore login state. On POSIX systems, OpenSafari creates new auth profile directories as private `0700` directories and profile files as private `0600` files, then updates profiles with an atomic same-directory replacement.
+
+Delete saved login state with `opensafari auth delete myapp.com`, or remove the matching `~/.opensafari/auth/myapp.com.json` file.
+
 ### 4. iOS-Specific Auto-Detection
 
 Built-in QA checks that run on real Safari — no approximation:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,3 +94,7 @@ opensafari auth list
 # Delete a profile
 opensafari auth delete mysite.com
 ```
+
+Saved auth profiles live in `~/.opensafari/auth/` as one JSON file per site, such as `~/.opensafari/auth/mysite.com.json`. A profile stores the site name, saved timestamp, current URL, cookies, cookie domain groups, localStorage, and sessionStorage so later runs can restore the login state. On POSIX systems, newly saved profiles use private directory and file permissions (`0700` for the auth directory, `0600` for profile JSON files) and profile updates are written atomically.
+
+To remove stored login state, run `opensafari auth delete mysite.com` or delete the matching JSON file from `~/.opensafari/auth/`.

--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
+import { randomUUID } from 'crypto';
 import { BrowserBackend, Cookie } from '../types/browser-backend';
 
 export interface DomainGroup {
@@ -29,6 +30,8 @@ export interface ExpiryInfo {
 
 export class AuthManager {
   private authDir: string;
+  private static readonly privateDirMode = 0o700;
+  private static readonly privateFileMode = 0o600;
 
   constructor(authDir?: string) {
     this.authDir = authDir ?? path.join(os.homedir(), '.opensafari', 'auth');
@@ -71,9 +74,9 @@ export class AuthManager {
       sessionStorage: sessionStorage ?? {},
     };
 
-    await fs.mkdir(this.authDir, { recursive: true });
+    await this.ensureAuthDir();
     const filePath = path.join(this.authDir, this.sanitizeSite(site) + '.json');
-    await fs.writeFile(filePath, JSON.stringify(profile, null, 2));
+    await this.atomicWriteProfile(filePath, JSON.stringify(profile, null, 2));
 
     return filePath;
   }
@@ -178,5 +181,48 @@ export class AuthManager {
 
   private sanitizeSite(site: string): string {
     return site.replace(/[^a-zA-Z0-9.-]/g, '_');
+  }
+
+  private async ensureAuthDir(): Promise<void> {
+    await fs.mkdir(this.authDir, { recursive: true, mode: AuthManager.privateDirMode });
+    if (this.supportsPosixModes()) {
+      await fs.chmod(this.authDir, AuthManager.privateDirMode);
+    }
+  }
+
+  private async atomicWriteProfile(filePath: string, contents: string): Promise<void> {
+    const tempPath = path.join(
+      this.authDir,
+      `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+    );
+
+    let handle: fs.FileHandle | undefined;
+    try {
+      handle = await fs.open(tempPath, 'wx', AuthManager.privateFileMode);
+      await handle.writeFile(contents, 'utf-8');
+      await handle.close();
+      handle = undefined;
+
+      if (this.supportsPosixModes()) {
+        await fs.chmod(tempPath, AuthManager.privateFileMode);
+      }
+
+      await fs.rename(tempPath, filePath);
+
+      if (this.supportsPosixModes()) {
+        await fs.chmod(filePath, AuthManager.privateFileMode);
+      }
+    } catch (error) {
+      if (handle) {
+        await handle.close().catch(() => {});
+      }
+      await fs.unlink(tempPath).catch(() => {});
+      throw error;
+    }
+  }
+
+
+  private supportsPosixModes(): boolean {
+    return process.platform !== 'win32';
   }
 }

--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -185,9 +185,7 @@ export class AuthManager {
 
   private async ensureAuthDir(): Promise<void> {
     await fs.mkdir(this.authDir, { recursive: true, mode: AuthManager.privateDirMode });
-    if (this.supportsPosixModes()) {
-      await fs.chmod(this.authDir, AuthManager.privateDirMode);
-    }
+    await this.softChmod(this.authDir, AuthManager.privateDirMode);
   }
 
   private async atomicWriteProfile(filePath: string, contents: string): Promise<void> {
@@ -200,18 +198,12 @@ export class AuthManager {
     try {
       handle = await fs.open(tempPath, 'wx', AuthManager.privateFileMode);
       await handle.writeFile(contents, 'utf-8');
+      await handle.datasync().catch(() => {});
       await handle.close();
       handle = undefined;
 
-      if (this.supportsPosixModes()) {
-        await fs.chmod(tempPath, AuthManager.privateFileMode);
-      }
-
+      await this.softChmod(tempPath, AuthManager.privateFileMode);
       await fs.rename(tempPath, filePath);
-
-      if (this.supportsPosixModes()) {
-        await fs.chmod(filePath, AuthManager.privateFileMode);
-      }
     } catch (error) {
       if (handle) {
         await handle.close().catch(() => {});
@@ -221,6 +213,18 @@ export class AuthManager {
     }
   }
 
+  private async softChmod(target: string, mode: number): Promise<void> {
+    if (!this.supportsPosixModes()) return;
+    try {
+      await fs.chmod(target, mode);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOSYS' || code === 'ENOTSUP' || code === 'EPERM' || code === 'EINVAL') {
+        return;
+      }
+      throw error;
+    }
+  }
 
   private supportsPosixModes(): boolean {
     return process.platform !== 'win32';

--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { BrowserBackend, Cookie } from '../types/browser-backend';
 
 export interface DomainGroup {
@@ -189,9 +189,13 @@ export class AuthManager {
   }
 
   private async atomicWriteProfile(filePath: string, contents: string): Promise<void> {
+    // Use a fixed-length temp name (".<8-char-hash>.<pid>.<uuid>.tmp" ≈ 60 chars) so atomic writes
+    // do not fail with ENAMETOOLONG when `path.basename(filePath)` is close to the 255-byte limit.
+    // Same parent dir as the target keeps `fs.rename` atomic; uniqueness is provided by the uuid.
+    const baseHash = createHash('sha1').update(path.basename(filePath)).digest('hex').slice(0, 8);
     const tempPath = path.join(
       this.authDir,
-      `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+      `.${baseHash}.${process.pid}.${randomUUID()}.tmp`,
     );
 
     let handle: fs.FileHandle | undefined;

--- a/tests/unit/auth-manager-persistence.test.ts
+++ b/tests/unit/auth-manager-persistence.test.ts
@@ -1,0 +1,145 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { AuthManager } from '../../src/auth/manager';
+import { BrowserBackend, Cookie, NavigateOptions, NavigateResult } from '../../src/types/browser-backend';
+
+const POSIX_MODE_MASK = 0o777;
+const isPosix = process.platform !== 'win32';
+
+const fakeCookies: Cookie[] = [
+  {
+    name: 'session',
+    value: 'fake-session-token',
+    domain: '.example.com',
+    path: '/',
+    expires: Math.floor(Date.now() / 1000) + 3600,
+    httpOnly: true,
+    secure: true,
+    sameSite: 'Lax',
+  },
+];
+
+function createFakeBackend(): BrowserBackend {
+  return {
+    connect: async () => {},
+    disconnect: async () => {},
+    isConnected: () => true,
+    navigate: jest.fn(async (opts: NavigateOptions): Promise<NavigateResult> => ({
+      url: opts.url,
+      status: 200,
+      loadTime: 1,
+    })),
+    screenshot: async () => Buffer.from('fake-png'),
+    evaluate: (jest.fn(async (expression: string): Promise<unknown> => {
+      if (expression.includes('localStorage') && !expression.includes('setItem')) {
+        return { theme: 'test-dark' };
+      }
+      if (expression.includes('sessionStorage') && !expression.includes('setItem')) {
+        return { nonce: 'fake-nonce' };
+      }
+      if (expression.includes('location.href')) {
+        return 'https://example.com/account';
+      }
+      return undefined;
+    }) as BrowserBackend['evaluate']),
+    readPage: async () => 'fake page',
+    getCookies: async () => fakeCookies,
+    setCookies: jest.fn(async () => {}),
+    clearCookies: async () => {},
+    click: async () => {},
+    type: async () => {},
+    scroll: async () => {},
+    longPress: async () => {},
+    swipe: async () => {},
+    press: async () => {},
+    dismissKeyboard: async () => {},
+    selectOption: async () => {},
+    querySelector: async () => null,
+    querySelectorAll: async () => [],
+    inspect: async () => ({}),
+    waitFor: async () => {},
+    onConsole: () => {},
+    onRequest: () => {},
+    onResponse: () => {},
+  };
+}
+
+describe('AuthManager secure persistence', () => {
+  let authDir: string;
+  let authManager: AuthManager;
+
+  beforeEach(async () => {
+    authDir = await fs.mkdtemp(path.join(os.tmpdir(), 'opensafari-auth-secure-'));
+    authManager = new AuthManager(authDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(authDir, { recursive: true, force: true });
+  });
+
+  test('save preserves profile schema and restore behavior', async () => {
+    const saveClient = createFakeBackend();
+    const filePath = await authManager.save('example.com', saveClient);
+
+    const profile = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+    expect(Object.keys(profile).sort()).toEqual([
+      'cookies',
+      'currentUrl',
+      'domainGroups',
+      'localStorage',
+      'savedAt',
+      'sessionStorage',
+      'site',
+    ]);
+    expect(profile.site).toBe('example.com');
+    expect(profile.currentUrl).toBe('https://example.com/account');
+    expect(profile.cookies).toEqual(fakeCookies);
+    expect(profile.domainGroups).toEqual([{ domain: 'example.com', cookies: fakeCookies }]);
+    expect(profile.localStorage).toEqual({ theme: 'test-dark' });
+    expect(profile.sessionStorage).toEqual({ nonce: 'fake-nonce' });
+
+    const restoreClient = createFakeBackend();
+    await authManager.restore('example.com', restoreClient);
+
+    expect(restoreClient.setCookies).toHaveBeenCalledWith(fakeCookies);
+    expect(restoreClient.navigate).toHaveBeenNthCalledWith(1, {
+      url: 'https://example.com',
+      waitUntil: 'domcontentloaded',
+    });
+    expect(restoreClient.navigate).toHaveBeenNthCalledWith(2, {
+      url: 'https://example.com/account',
+      waitUntil: 'load',
+    });
+  });
+
+  test('save creates private auth directory and profile file on POSIX', async () => {
+    const filePath = await authManager.save('example.com', createFakeBackend());
+
+    if (!isPosix) {
+      return;
+    }
+
+    const dirMode = (await fs.stat(authDir)).mode & POSIX_MODE_MASK;
+    const fileMode = (await fs.stat(filePath)).mode & POSIX_MODE_MASK;
+
+    expect(dirMode).toBe(0o700);
+    expect(fileMode).toBe(0o600);
+  });
+
+  test('save atomically replaces existing profile without temp-file residue', async () => {
+    const firstPath = await authManager.save('example.com', createFakeBackend());
+    const firstProfile = JSON.parse(await fs.readFile(firstPath, 'utf-8'));
+
+    await authManager.save('example.com', createFakeBackend());
+
+    const files = await fs.readdir(authDir);
+    const secondProfile = JSON.parse(await fs.readFile(firstPath, 'utf-8'));
+
+    expect(files).toEqual(['example.com.json']);
+    expect(secondProfile.site).toBe(firstProfile.site);
+    expect(secondProfile.cookies).toEqual(firstProfile.cookies);
+    expect(secondProfile.localStorage).toEqual(firstProfile.localStorage);
+    expect(secondProfile.sessionStorage).toEqual(firstProfile.sessionStorage);
+  });
+});

--- a/tests/unit/auth-manager-persistence.test.ts
+++ b/tests/unit/auth-manager-persistence.test.ts
@@ -142,4 +142,21 @@ describe('AuthManager secure persistence', () => {
     expect(secondProfile.localStorage).toEqual(firstProfile.localStorage);
     expect(secondProfile.sessionStorage).toEqual(firstProfile.sessionStorage);
   });
+
+  test('save succeeds for long-but-valid site names without ENAMETOOLONG on the temp file', async () => {
+    // Many filesystems cap a single name component at 255 bytes. The atomic temp file lives in
+    // the same directory as the final profile, so its name must stay bounded regardless of site
+    // length — otherwise `<basename>.<pid>.<uuid>.tmp` overflows for legitimately long domains.
+    const longSite = 'a'.repeat(220) + '.example.com';
+
+    const filePath = await authManager.save(longSite, createFakeBackend());
+
+    expect(path.basename(filePath).length).toBeLessThanOrEqual(255);
+    const files = await fs.readdir(authDir);
+    expect(files.every((f) => f.length <= 255)).toBe(true);
+    // No temp residue: only the persisted profile should remain.
+    expect(files).toEqual([path.basename(filePath)]);
+    const profile = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+    expect(profile.site).toBe(longSite);
+  });
 });


### PR DESCRIPTION
## Summary
- Implements #699.
- Persists auth profiles atomically with private POSIX permissions when supported.
- Adds explicit auth-profile persistence docs and unit coverage for cookies/localStorage/sessionStorage/metadata round trips.

## Validation
- git diff --check
- tsc -p tsconfig.json --noEmit --pretty false
- npm test -- --runInBand tests/unit/auth-manager-persistence.test.ts --silent
- npm test -- --runInBand tests/unit/auth-tools-verification.test.ts --silent

Closes #699