### PR TITLE
fix(security): harden audit log persistence

### DIFF
--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -192,8 +192,19 @@ function ensurePrivateLogTarget(logPath: string): boolean {
     if (!dirExisted) {
       fs.chmodSync(logDir, AUDIT_DIR_MODE);
     }
+    // Apply file-mode permissions only to regular files. If
+    // OPENSAFARI_AUDIT_LOG_PATH is misconfigured to a directory,
+    // chmod-ing it would strip execute bits and break traversal for
+    // other services. Leave such a target alone — the subsequent
+    // append will fail with EISDIR and the error path will surface it.
     if (fs.existsSync(logPath)) {
-      fs.chmodSync(logPath, AUDIT_FILE_MODE);
+      try {
+        if (fs.statSync(logPath).isFile()) {
+          fs.chmodSync(logPath, AUDIT_FILE_MODE);
+        }
+      } catch {
+        // best-effort: stat failure should not block the append attempt
+      }
     }
     ensuredLogPaths.add(logPath);
     return true;

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -15,11 +15,15 @@ interface AuditEntry {
   args_summary: string;   // brief summary, no sensitive data
 }
 
-let logDirEnsured = false;
+const AUDIT_DIR_MODE = 0o700;
+const AUDIT_FILE_MODE = 0o600;
+export const MAX_AUDIT_LOG_BYTES = 5 * 1024 * 1024;
+const MAX_SUMMARY_STRING_LENGTH = 100;
+const REDACTED = '[REDACTED]';
 
 // Get log file path
 function getLogPath(): string {
-  return path.join(os.homedir(), '.opensafari', 'audit.log');
+  return process.env.OPENSAFARI_AUDIT_LOG_PATH ?? path.join(os.homedir(), '.opensafari', 'audit.log');
 }
 
 // Extract domain from URL safely
@@ -28,27 +32,131 @@ function extractDomain(url?: string): string | null {
   return extractHostname(url) || null;
 }
 
-const SENSITIVE_KEYS = ['password', 'cookie', 'token', 'secret', 'auth', 'credential', 'value', 'text'];
+const SENSITIVE_KEYS = [
+  'password',
+  'cookie',
+  'token',
+  'secret',
+  'auth',
+  'credential',
+  'apikey',
+  'api_key',
+  'accesskey',
+  'access_key',
+  'privatekey',
+  'private_key',
+  'session',
+];
+
+const SENSITIVE_QUERY_PARAMS = [
+  'access_token',
+  'api_key',
+  'apikey',
+  'auth',
+  'authorization',
+  'client_secret',
+  'code',
+  'cookie',
+  'credential',
+  'key',
+  'password',
+  'refresh_token',
+  'secret',
+  'session',
+  'sig',
+  'signature',
+  'token',
+];
 
 function isSensitiveKey(key: string): boolean {
   const lower = key.toLowerCase();
   return SENSITIVE_KEYS.some(s => lower.includes(s));
 }
 
+function isSensitiveQueryParam(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SENSITIVE_QUERY_PARAMS.some(s => lower === s || lower.includes(s));
+}
+
+function redactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    let redacted = false;
+    url.searchParams.forEach((_paramValue, key) => {
+      if (isSensitiveQueryParam(key)) {
+        url.searchParams.set(key, REDACTED);
+        redacted = true;
+      }
+    });
+    return redacted ? url.toString() : value;
+  } catch {
+    return value;
+  }
+}
+
+function summarizeString(value: string): string {
+  const redactedUrl = redactUrl(value);
+  return redactedUrl.length > MAX_SUMMARY_STRING_LENGTH
+    ? `${redactedUrl.slice(0, MAX_SUMMARY_STRING_LENGTH)}...`
+    : redactedUrl;
+}
+
+function redactValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === 'string') {
+    return summarizeString(value);
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+    const redactedArray = value.map(item => redactValue(item, seen));
+    seen.delete(value);
+    return redactedArray;
+  }
+
+  if (value && typeof value === 'object') {
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+    const safe: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      safe[key] = isSensitiveKey(key) ? REDACTED : redactValue(nestedValue, seen);
+    }
+    seen.delete(value);
+    return safe;
+  }
+
+  return value;
+}
+
 // Summarize args (redact sensitive values)
 function summarizeArgs(args: Record<string, unknown>): string {
-  // Include keys like tabId, url, action but redact values of sensitive keys
-  const safe: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(args)) {
-    if (isSensitiveKey(key)) {
-      safe[key] = '[REDACTED]';
-    } else if (typeof value === 'string' && value.length > 100) {
-      safe[key] = value.slice(0, 100) + '...';
-    } else {
-      safe[key] = value;
+  return JSON.stringify(redactValue(args, new WeakSet<object>()));
+}
+
+function ensurePrivateLogTarget(logPath: string): boolean {
+  const logDir = path.dirname(logPath);
+  try {
+    fs.mkdirSync(logDir, { recursive: true, mode: AUDIT_DIR_MODE });
+    fs.chmodSync(logDir, AUDIT_DIR_MODE);
+    if (fs.existsSync(logPath)) {
+      fs.chmodSync(logPath, AUDIT_FILE_MODE);
     }
+    return true;
+  } catch {
+    return false;
   }
-  return JSON.stringify(safe);
+}
+
+function rotateLogIfNeeded(logPath: string, bytesToAppend: number): void {
+  if (!fs.existsSync(logPath)) return;
+
+  const size = fs.statSync(logPath).size;
+  if (size + bytesToAppend <= MAX_AUDIT_LOG_BYTES) return;
+
+  const rotatedPath = `${logPath}.1`;
+  fs.rmSync(rotatedPath, { force: true });
+  fs.renameSync(logPath, rotatedPath);
+  fs.chmodSync(rotatedPath, AUDIT_FILE_MODE);
 }
 
 export function logAuditEntry(tool: string, sessionId: string, args: Record<string, unknown>, pageUrl?: string): void {
@@ -61,19 +169,14 @@ export function logAuditEntry(tool: string, sessionId: string, args: Record<stri
   };
 
   const logPath = getLogPath();
-  const logDir = path.dirname(logPath);
+  if (!ensurePrivateLogTarget(logPath)) return;
 
-  // Ensure directory exists (first time only)
-  if (!logDirEnsured) {
-    try {
-      fs.mkdirSync(logDir, { recursive: true });
-      logDirEnsured = true;
-    } catch {
-      return; // Non-fatal
-    }
-  }
-
-  // Non-blocking append
   const line = JSON.stringify(entry) + '\n';
-  fs.appendFile(logPath, line, (err) => { if (err) console.error('[audit-logger] write failed:', (err as NodeJS.ErrnoException).code); });
+  try {
+    rotateLogIfNeeded(logPath, Buffer.byteLength(line));
+    fs.appendFileSync(logPath, line, { mode: AUDIT_FILE_MODE });
+    fs.chmodSync(logPath, AUDIT_FILE_MODE);
+  } catch (err) {
+    console.error('[audit-logger] write failed:', (err as NodeJS.ErrnoException).code);
+  }
 }

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -168,15 +168,18 @@ function summarizeArgs(args: Record<string, unknown>): string {
   return JSON.stringify(redactValue(args, new WeakSet<object>()));
 }
 
-// Cache the directory-prep result per resolved log path so that we do
+// Remember which log paths have been successfully prepped so that we do
 // not run mkdir/chmod on every audit entry. `getLogPath()` reads from
-// env at call time, so we key the cache by path to stay correct if it
-// changes between calls.
-const ensuredLogPaths = new Map<string, boolean>();
+// env at call time, so we key by path to stay correct if it changes.
+//
+// Only successes are cached — a transient mkdir/chmod failure (e.g. a
+// not-yet-mounted volume at startup) must not permanently disable audit
+// writes for the rest of the process, so we retry setup on subsequent
+// calls until it succeeds.
+const ensuredLogPaths = new Set<string>();
 
 function ensurePrivateLogTarget(logPath: string): boolean {
-  const cached = ensuredLogPaths.get(logPath);
-  if (cached !== undefined) return cached;
+  if (ensuredLogPaths.has(logPath)) return true;
 
   const logDir = path.dirname(logPath);
   try {
@@ -192,10 +195,9 @@ function ensurePrivateLogTarget(logPath: string): boolean {
     if (fs.existsSync(logPath)) {
       fs.chmodSync(logPath, AUDIT_FILE_MODE);
     }
-    ensuredLogPaths.set(logPath, true);
+    ensuredLogPaths.add(logPath);
     return true;
   } catch {
-    ensuredLogPaths.set(logPath, false);
     return false;
   }
 }

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -75,17 +75,24 @@ const SENSITIVE_QUERY_PARAMS = [
   'token',
 ];
 
-// Match either the full lowercased key, or any `_`/`-` separated segment
-// of it (with simple plural `s` stripped), against the provided list.
-// Substring matching is too loose — `monkey` would match `key` and
-// `context` would match `text`.
+// Match either the full lowercased key, or any segment of it against
+// the provided list. Segments are split on `_` / `-` and on camelCase
+// boundaries so `apiKey`, `accessToken`, and `refreshToken` are caught
+// while `monkey` / `keyboard` / `context` are not. Trailing plural `s`
+// on a segment is stripped before comparison.
 function matchesSensitiveTerm(key: string, terms: readonly string[]): boolean {
   const lower = key.toLowerCase();
   if (matchSegment(lower, terms)) return true;
-  for (const segment of lower.split(/[_-]/)) {
-    if (segment && matchSegment(segment, terms)) return true;
+  for (const segment of splitIntoSegments(key)) {
+    if (segment && matchSegment(segment.toLowerCase(), terms)) return true;
   }
   return false;
+}
+
+// Split on `_` / `-` and camelCase boundaries (`apiKey` → `api`, `Key`;
+// `XMLHttp` → `XML`, `Http`).
+function splitIntoSegments(key: string): string[] {
+  return key.split(/[_-]+|(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/);
 }
 
 function matchSegment(segment: string, terms: readonly string[]): boolean {
@@ -173,8 +180,15 @@ function ensurePrivateLogTarget(logPath: string): boolean {
 
   const logDir = path.dirname(logPath);
   try {
+    // Only tighten directory permissions on directories we own (i.e. that
+    // we just created). When OPENSAFARI_AUDIT_LOG_PATH points at a shared
+    // location (e.g. /var/log), unconditionally chmod-ing the parent
+    // could break other services that rely on its existing mode.
+    const dirExisted = fs.existsSync(logDir);
     fs.mkdirSync(logDir, { recursive: true, mode: AUDIT_DIR_MODE });
-    fs.chmodSync(logDir, AUDIT_DIR_MODE);
+    if (!dirExisted) {
+      fs.chmodSync(logDir, AUDIT_DIR_MODE);
+    }
     if (fs.existsSync(logPath)) {
       fs.chmodSync(logPath, AUDIT_FILE_MODE);
     }

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -38,6 +38,7 @@ const SENSITIVE_KEYS = [
   'token',
   'secret',
   'auth',
+  'authorization',
   'credential',
   'apikey',
   'api_key',
@@ -46,6 +47,12 @@ const SENSITIVE_KEYS = [
   'privatekey',
   'private_key',
   'session',
+  // Free-form user input that flows through MCP tool calls (e.g.
+  // `type.text`, `select_option.value`) can carry passwords or OTPs, so
+  // redact these keys defensively even though they are not credentials
+  // by name.
+  'text',
+  'value',
 ];
 
 const SENSITIVE_QUERY_PARAMS = [
@@ -68,20 +75,41 @@ const SENSITIVE_QUERY_PARAMS = [
   'token',
 ];
 
-function isSensitiveKey(key: string): boolean {
+// Match either the full lowercased key, or any `_`/`-` separated segment
+// of it (with simple plural `s` stripped), against the provided list.
+// Substring matching is too loose — `monkey` would match `key` and
+// `context` would match `text`.
+function matchesSensitiveTerm(key: string, terms: readonly string[]): boolean {
   const lower = key.toLowerCase();
-  return SENSITIVE_KEYS.some(s => lower.includes(s));
+  if (matchSegment(lower, terms)) return true;
+  for (const segment of lower.split(/[_-]/)) {
+    if (segment && matchSegment(segment, terms)) return true;
+  }
+  return false;
+}
+
+function matchSegment(segment: string, terms: readonly string[]): boolean {
+  if (terms.includes(segment)) return true;
+  return segment.endsWith('s') && terms.includes(segment.slice(0, -1));
+}
+
+function isSensitiveKey(key: string): boolean {
+  return matchesSensitiveTerm(key, SENSITIVE_KEYS);
 }
 
 function isSensitiveQueryParam(key: string): boolean {
-  const lower = key.toLowerCase();
-  return SENSITIVE_QUERY_PARAMS.some(s => lower === s || lower.includes(s));
+  return matchesSensitiveTerm(key, SENSITIVE_QUERY_PARAMS);
 }
 
 function redactUrl(value: string): string {
   try {
     const url = new URL(value);
     let redacted = false;
+    if (url.username || url.password) {
+      url.username = '';
+      url.password = '';
+      redacted = true;
+    }
     url.searchParams.forEach((_paramValue, key) => {
       if (isSensitiveQueryParam(key)) {
         url.searchParams.set(key, REDACTED);
@@ -133,7 +161,16 @@ function summarizeArgs(args: Record<string, unknown>): string {
   return JSON.stringify(redactValue(args, new WeakSet<object>()));
 }
 
+// Cache the directory-prep result per resolved log path so that we do
+// not run mkdir/chmod on every audit entry. `getLogPath()` reads from
+// env at call time, so we key the cache by path to stay correct if it
+// changes between calls.
+const ensuredLogPaths = new Map<string, boolean>();
+
 function ensurePrivateLogTarget(logPath: string): boolean {
+  const cached = ensuredLogPaths.get(logPath);
+  if (cached !== undefined) return cached;
+
   const logDir = path.dirname(logPath);
   try {
     fs.mkdirSync(logDir, { recursive: true, mode: AUDIT_DIR_MODE });
@@ -141,8 +178,10 @@ function ensurePrivateLogTarget(logPath: string): boolean {
     if (fs.existsSync(logPath)) {
       fs.chmodSync(logPath, AUDIT_FILE_MODE);
     }
+    ensuredLogPaths.set(logPath, true);
     return true;
   } catch {
+    ensuredLogPaths.set(logPath, false);
     return false;
   }
 }
@@ -175,7 +214,6 @@ export function logAuditEntry(tool: string, sessionId: string, args: Record<stri
   try {
     rotateLogIfNeeded(logPath, Buffer.byteLength(line));
     fs.appendFileSync(logPath, line, { mode: AUDIT_FILE_MODE });
-    fs.chmodSync(logPath, AUDIT_FILE_MODE);
   } catch (err) {
     console.error('[audit-logger] write failed:', (err as NodeJS.ErrnoException).code);
   }

--- a/tests/unit/audit-logger.test.ts
+++ b/tests/unit/audit-logger.test.ts
@@ -170,6 +170,34 @@ describe('audit logger', () => {
     }
   });
 
+  it('does not chmod a directory mistakenly configured as the log path', () => {
+    // If OPENSAFARI_AUDIT_LOG_PATH is misconfigured to point at a
+    // directory, the logger must not strip the directory's execute
+    // bits — that would break traversal for other services/users.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-logger-dir-target-'));
+    const dirAsLogPath = path.join(root, 'audit.log'); // we'll mkdir it
+    fs.mkdirSync(dirAsLogPath, { mode: 0o755 });
+    const beforeMode = fs.statSync(dirAsLogPath).mode & 0o777;
+
+    const previous = process.env.OPENSAFARI_AUDIT_LOG_PATH;
+    process.env.OPENSAFARI_AUDIT_LOG_PATH = dirAsLogPath;
+    try {
+      // The append will fail (EISDIR), but ensurePrivateLogTarget must
+      // not chmod the directory to 0o600 along the way.
+      logAuditEntry('navigate', 'session-dir-target', { url: 'https://example.test/' });
+
+      const afterMode = fs.statSync(dirAsLogPath).mode & 0o777;
+      expect(afterMode).toBe(beforeMode);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENSAFARI_AUDIT_LOG_PATH;
+      } else {
+        process.env.OPENSAFARI_AUDIT_LOG_PATH = previous;
+      }
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('does not chmod a pre-existing parent log directory', () => {
     // Pre-create the log directory with a permissive mode (e.g. shared
     // /var/log) and verify the audit logger does NOT tighten it.

--- a/tests/unit/audit-logger.test.ts
+++ b/tests/unit/audit-logger.test.ts
@@ -132,6 +132,44 @@ describe('audit logger', () => {
     });
   });
 
+  it('retries log target setup after a transient initialization error', () => {
+    // Point the logger at a path under a parent that doesn't yet exist and
+    // can't be created (a regular file, so mkdir(recursive) will EEXIST/ENOTDIR).
+    // First call: setup fails, no log is written.
+    // Then we replace the blocker with a real directory and call again — the
+    // second call must retry setup (not return cached failure) and succeed.
+    const blockerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-logger-blocker-'));
+    const blockedParent = path.join(blockerDir, 'parent');
+    fs.writeFileSync(blockedParent, ''); // a *file* where the dir is expected
+    const logPathUnderBlocker = path.join(blockedParent, 'audit.log');
+
+    const previous = process.env.OPENSAFARI_AUDIT_LOG_PATH;
+    process.env.OPENSAFARI_AUDIT_LOG_PATH = logPathUnderBlocker;
+    try {
+      // First attempt — setup must fail because parent is a regular file
+      logAuditEntry('navigate', 'session-init-fail', { url: 'https://example.test/' });
+      expect(fs.existsSync(logPathUnderBlocker)).toBe(false);
+
+      // Remove the blocker; the path is now legitimately constructable
+      fs.unlinkSync(blockedParent);
+
+      // Second attempt — must retry setup and succeed (no permanent disable)
+      logAuditEntry('navigate', 'session-init-recover', { url: 'https://example.test/recover' });
+      expect(fs.existsSync(logPathUnderBlocker)).toBe(true);
+      const recovered = fs.readFileSync(logPathUnderBlocker, 'utf8').trim().split('\n');
+      expect(recovered).toHaveLength(1);
+      const entry = JSON.parse(recovered[0]) as Record<string, unknown>;
+      expect(entry.sessionId).toBe('session-init-recover');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENSAFARI_AUDIT_LOG_PATH;
+      } else {
+        process.env.OPENSAFARI_AUDIT_LOG_PATH = previous;
+      }
+      fs.rmSync(blockerDir, { recursive: true, force: true });
+    }
+  });
+
   it('does not chmod a pre-existing parent log directory', () => {
     // Pre-create the log directory with a permissive mode (e.g. shared
     // /var/log) and verify the audit logger does NOT tighten it.

--- a/tests/unit/audit-logger.test.ts
+++ b/tests/unit/audit-logger.test.ts
@@ -100,6 +100,65 @@ describe('audit logger', () => {
     expect(readAuditEntries(tmpHome)).toHaveLength(1);
   });
 
+  it('redacts camelCase secret keys (apiKey, accessToken, refreshToken)', () => {
+    logAuditEntry('http_request', 'session-camel', {
+      headers: {
+        apiKey: 'fake-api-key-camel',
+        accessToken: 'fake-access-token-camel',
+        refreshToken: 'fake-refresh-token-camel',
+      },
+      // Non-credential look-alike keys must NOT be redacted
+      monkey: 'visible-monkey',
+      keyboard: 'visible-keyboard',
+      context: 'visible-context',
+    });
+
+    const [entry] = readAuditEntries(tmpHome);
+    const summary = parseArgsSummary(entry);
+
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain('fake-api-key-camel');
+    expect(serialized).not.toContain('fake-access-token-camel');
+    expect(serialized).not.toContain('fake-refresh-token-camel');
+    expect(serialized).toContain('visible-monkey');
+    expect(serialized).toContain('visible-keyboard');
+    expect(serialized).toContain('visible-context');
+    expect(summary).toMatchObject({
+      headers: {
+        apiKey: '[REDACTED]',
+        accessToken: '[REDACTED]',
+        refreshToken: '[REDACTED]',
+      },
+    });
+  });
+
+  it('does not chmod a pre-existing parent log directory', () => {
+    // Pre-create the log directory with a permissive mode (e.g. shared
+    // /var/log) and verify the audit logger does NOT tighten it.
+    const sharedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-logger-shared-'));
+    const sharedLogPath = path.join(sharedDir, 'audit.log');
+    fs.chmodSync(sharedDir, 0o755);
+    const beforeMode = fs.statSync(sharedDir).mode & 0o777;
+
+    const previous = process.env.OPENSAFARI_AUDIT_LOG_PATH;
+    process.env.OPENSAFARI_AUDIT_LOG_PATH = sharedLogPath;
+    try {
+      logAuditEntry('navigate', 'session-shared', { url: 'https://example.test/' });
+
+      const afterMode = fs.statSync(sharedDir).mode & 0o777;
+      expect(afterMode).toBe(beforeMode);
+      // The audit file itself must still be created with private mode
+      expect(fs.statSync(sharedLogPath).mode & 0o777).toBe(0o600);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENSAFARI_AUDIT_LOG_PATH;
+      } else {
+        process.env.OPENSAFARI_AUDIT_LOG_PATH = previous;
+      }
+      fs.rmSync(sharedDir, { recursive: true, force: true });
+    }
+  });
+
   it('redacts fake high-risk HTTP secrets emitted through MCP tool-call auditing', async () => {
     const server = new MCPServer();
     server.enableAuditLog();

--- a/tests/unit/audit-logger.test.ts
+++ b/tests/unit/audit-logger.test.ts
@@ -1,0 +1,136 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MCPServer } from '../../src/mcp-server';
+import { MAX_AUDIT_LOG_BYTES, logAuditEntry } from '../../src/security/audit-logger';
+
+function readAuditEntries(home: string): Array<Record<string, unknown>> {
+  const logPath = path.join(home, '.opensafari', 'audit.log');
+  return fs.readFileSync(logPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+function parseArgsSummary(entry: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(entry.args_summary as string) as Record<string, unknown>;
+}
+
+describe('audit logger', () => {
+  let tmpHome: string;
+  let previousAuditLogPath: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-logger-'));
+    previousAuditLogPath = process.env.OPENSAFARI_AUDIT_LOG_PATH;
+    process.env.OPENSAFARI_AUDIT_LOG_PATH = path.join(tmpHome, '.opensafari', 'audit.log');
+  });
+
+  afterEach(() => {
+    if (previousAuditLogPath === undefined) {
+      delete process.env.OPENSAFARI_AUDIT_LOG_PATH;
+    } else {
+      process.env.OPENSAFARI_AUDIT_LOG_PATH = previousAuditLogPath;
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('recursively redacts sensitive nested objects, arrays, and URL query parameters', () => {
+    logAuditEntry('http_request', 'session-1', {
+      url: 'https://example.test/path?token=fake-token&safe=visible&client_secret=fake-secret',
+      headers: {
+        authorization: 'Bearer fake-token',
+        nested: [
+          { refresh_token: 'fake-refresh-token' },
+          'https://example.test/callback?code=fake-code&state=ok',
+        ],
+      },
+      body: {
+        user: 'alice',
+        password: 'fake-password',
+        profile: [{ cookie: 'fake-cookie' }],
+      },
+    });
+
+    const [entry] = readAuditEntries(tmpHome);
+    const summary = parseArgsSummary(entry);
+
+    expect(entry.domain).toBe('example.test');
+    expect(JSON.stringify(summary)).not.toContain('fake-token');
+    expect(JSON.stringify(summary)).not.toContain('fake-secret');
+    expect(JSON.stringify(summary)).not.toContain('fake-refresh-token');
+    expect(JSON.stringify(summary)).not.toContain('fake-code');
+    expect(JSON.stringify(summary)).not.toContain('fake-password');
+    expect(JSON.stringify(summary)).not.toContain('fake-cookie');
+    expect(JSON.stringify(summary)).toContain('safe=visible');
+    expect(JSON.stringify(summary)).toContain('state=ok');
+    expect(summary).toMatchObject({
+      headers: {
+        authorization: '[REDACTED]',
+      },
+      body: {
+        password: '[REDACTED]',
+      },
+    });
+  });
+
+  it('creates the audit directory and file with private POSIX permissions', () => {
+    logAuditEntry('navigate', 'session-1', { url: 'https://example.test/' });
+
+    const logDir = path.join(tmpHome, '.opensafari');
+    const logPath = path.join(logDir, 'audit.log');
+
+    expect(fs.statSync(logDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(logPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('rotates the local audit log before it exceeds the configured byte cap', () => {
+    const logDir = path.join(tmpHome, '.opensafari');
+    const logPath = path.join(logDir, 'audit.log');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(logPath, Buffer.alloc(MAX_AUDIT_LOG_BYTES, 'x'), { mode: 0o600 });
+
+    logAuditEntry('navigate', 'session-1', { url: 'https://example.test/' });
+
+    const rotatedPath = `${logPath}.1`;
+    expect(fs.existsSync(rotatedPath)).toBe(true);
+    expect(fs.statSync(rotatedPath).size).toBe(MAX_AUDIT_LOG_BYTES);
+    expect(fs.statSync(rotatedPath).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(logPath).size).toBeLessThan(MAX_AUDIT_LOG_BYTES);
+    expect(readAuditEntries(tmpHome)).toHaveLength(1);
+  });
+
+  it('redacts fake high-risk HTTP secrets emitted through MCP tool-call auditing', async () => {
+    const server = new MCPServer();
+    server.enableAuditLog();
+    server.registerTool(
+      {
+        name: 'http_request',
+        description: 'test HTTP request',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+    );
+
+    await (server as unknown as {
+      handleMessage(msg: Record<string, unknown>): Promise<unknown>;
+    }).handleMessage({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'http_request',
+        arguments: {
+          url: 'https://api.example.test/data?api_key=fake-api-key',
+          headers: { authorization: 'Bearer fake-token' },
+          payload: [{ token: 'fake-token' }],
+        },
+      },
+    });
+
+    const rawLog = fs.readFileSync(path.join(tmpHome, '.opensafari', 'audit.log'), 'utf8');
+    expect(rawLog).toContain('http_request');
+    expect(rawLog).not.toContain('fake-api-key');
+    expect(rawLog).not.toContain('fake-token');
+  });
+});


### PR DESCRIPTION
## Summary
- Implements #711.
- Adds recursive audit redaction for nested data and sensitive URL query parameters.
- Creates audit log directory/file with private permissions and rotates retained local logs before exceeding the configured cap.
- Adds unit coverage for redaction, permissions, rotation, and MCP tool-call audit logging.

## Validation
- git diff --check
- tsc -p tsconfig.json --noEmit --pretty false
- npm test -- --runInBand tests/unit/audit-logger.test.ts --silent

Closes #711