### PR TITLE
feat(tap): scale AX frame coords from macOS-pt to iOS-pt (#693 WU3)

### DIFF
--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -530,28 +530,36 @@ function sleep(ms: number): Promise<void> {
 const iosPtSizeCache = new Map<string, Size2D | null>();
 
 async function getIosPtSizeForDevice(deviceId: string): Promise<Size2D | null> {
-  const cached = iosPtSizeCache.get(deviceId);
-  if (cached !== undefined) {
-    return cached;
+  if (iosPtSizeCache.has(deviceId)) {
+    return iosPtSizeCache.get(deviceId) ?? null;
   }
-  let result: Size2D | null = null;
   try {
     const manager = new SimulatorManager();
     const device = await manager.getDevice(deviceId);
-    if (device) {
-      const deviceNameLower = device.name.toLowerCase();
-      const preset = Object.values(DEVICE_PRESETS).find(
-        (p) => p.name.toLowerCase() === deviceNameLower,
-      );
-      if (preset) {
-        result = { width: preset.w, height: preset.h };
-      }
+    if (!device) {
+      // Transient: simctl could not see the device on this call. A later
+      // dispatch after simctl recovers should retry, so do NOT memoize
+      // this failure (otherwise one transient error permanently disables
+      // coordinate conversion for the UDID until process restart).
+      return null;
     }
+    const deviceNameLower = device.name.toLowerCase();
+    const preset = Object.values(DEVICE_PRESETS).find(
+      (p) => p.name.toLowerCase() === deviceNameLower,
+    );
+    const result: Size2D | null = preset
+      ? { width: preset.w, height: preset.h }
+      : null;
+    // simctl returned a stable device descriptor — caching the preset
+    // hit-or-miss is safe (the device's name and the preset table are
+    // both static for this process). Transient simctl failures handled
+    // by the early return above remain un-cached.
+    iosPtSizeCache.set(deviceId, result);
+    return result;
   } catch {
-    result = null;
+    // Same rationale as the !device branch — never cache a thrown error.
+    return null;
   }
-  iosPtSizeCache.set(deviceId, result);
-  return result;
 }
 
 /** @internal — test-only hook to reset the per-process iOS-pt size cache. */

--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -13,7 +13,7 @@ import {
   countNodes,
   isLikelyChromeOnlyTree,
 } from '../native';
-import type { AXNode, AXPressResponse } from '../native';
+import type { AXNode, AXPressResponse, AXQueryResult } from '../native';
 import type { AccessibilityBridge } from '../native/accessibility-bridge';
 import { walkTree, fingerprintTree } from '../native/ax-verification';
 import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
@@ -24,6 +24,9 @@ import {
   NativeContextMeta,
 } from './native-app-context';
 import { SimulatorManager } from '../simulator';
+import { DEVICE_PRESETS } from '../simulator/presets';
+import { convertMacOSPtToIOSPt } from '../utils/coordinate-space';
+import type { Size2D } from '../utils/coordinate-space';
 
 type AXPressVerification = {
   verified: boolean;
@@ -150,6 +153,9 @@ export function registerAppTapElementTool(server: MCPServer): void {
         let match: AXNode | undefined;
         let totalMatches = 0;
         let ambiguous = false;
+        // Capture deviceContentMacOSPt from the last successful query result.
+        // Present only when the bridge is a recent build (#693 WU3-prep).
+        let queryResult: AXQueryResult | undefined;
         if (timeout > 0) {
           const deadline = Date.now() + timeout;
           while (Date.now() < deadline) {
@@ -158,6 +164,7 @@ export function registerAppTapElementTool(server: MCPServer): void {
             ambiguous = result.ambiguous;
             if (result.matches.length > index) {
               match = result.matches[index];
+              queryResult = result;
               break;
             }
             await sleep(300);
@@ -168,6 +175,7 @@ export function registerAppTapElementTool(server: MCPServer): void {
           ambiguous = result.ambiguous;
           if (result.matches.length > index) {
             match = result.matches[index];
+            queryResult = result;
           }
         }
 
@@ -207,9 +215,38 @@ export function registerAppTapElementTool(server: MCPServer): void {
           };
         }
 
-        // Calculate center of element
-        const rawCenterX = match.frame.x + match.frame.width / 2;
-        const rawCenterY = match.frame.y + match.frame.height / 2;
+        // Calculate center of element in AX-frame space (macOS-screen-points).
+        const axCenterX = match.frame.x + match.frame.width / 2;
+        const axCenterY = match.frame.y + match.frame.height / 2;
+
+        // Convert from macOS-screen-points to iOS-points when the bridge
+        // emits `deviceContentMacOSPt` (#693 WU3). The conversion requires
+        // the iOS-point size of the device under test, which is looked up from
+        // the preset table by matching the simulator device name. When either
+        // size is unavailable (legacy bridge, unknown device, simctl failure)
+        // the coordinates are forwarded unchanged — same behavior as before.
+        let rawCenterX = axCenterX;
+        let rawCenterY = axCenterY;
+        const macOSPtSize = queryResult?.deviceContentMacOSPt;
+        if (macOSPtSize) {
+          const iosPtSize = await getIosPtSizeForDevice(deviceId);
+          if (iosPtSize) {
+            const converted = convertMacOSPtToIOSPt(
+              { x: axCenterX, y: axCenterY },
+              macOSPtSize,
+              iosPtSize,
+            );
+            rawCenterX = converted.x;
+            rawCenterY = converted.y;
+            console.error(
+              `[app_tap_element] macOS-pt→iOS-pt conversion applied: ` +
+                `macOSPt(${axCenterX.toFixed(2)}, ${axCenterY.toFixed(2)}) → ` +
+                `iOSPt(${rawCenterX.toFixed(2)}, ${rawCenterY.toFixed(2)}) ` +
+                `scale=(${(iosPtSize.width / macOSPtSize.width).toFixed(4)}, ` +
+                `${(iosPtSize.height / macOSPtSize.height).toFixed(4)})`,
+            );
+          }
+        }
 
         // Sanitize the tap target. An accessibility tree that reports a
         // `visible: true` element with a frame whose center lands outside
@@ -470,6 +507,29 @@ export function registerAppTapElementTool(server: MCPServer): void {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Look up the iOS-point screen size for a booted simulator by its UDID.
+ *
+ * Resolves: device UDID → device name (from simctl list) → preset entry
+ * (matched by name) → `{ width: w, height: h }`.
+ *
+ * Returns `null` when the device cannot be found, no name matches a preset,
+ * or the simctl call fails — callers treat `null` as "no conversion available"
+ * and fall back to using raw AX-frame coordinates.
+ */
+async function getIosPtSizeForDevice(deviceId: string): Promise<Size2D | null> {
+  try {
+    const manager = new SimulatorManager();
+    const device = await manager.getDevice(deviceId);
+    if (!device) return null;
+    const preset = Object.values(DEVICE_PRESETS).find((p) => p.name === device.name);
+    if (!preset) return null;
+    return { width: preset.w, height: preset.h };
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -219,34 +219,15 @@ export function registerAppTapElementTool(server: MCPServer): void {
         const axCenterX = match.frame.x + match.frame.width / 2;
         const axCenterY = match.frame.y + match.frame.height / 2;
 
-        // Convert from macOS-screen-points to iOS-points when the bridge
-        // emits `deviceContentMacOSPt` (#693 WU3). The conversion requires
-        // the iOS-point size of the device under test, which is looked up from
-        // the preset table by matching the simulator device name. When either
-        // size is unavailable (legacy bridge, unknown device, simctl failure)
-        // the coordinates are forwarded unchanged — same behavior as before.
-        let rawCenterX = axCenterX;
-        let rawCenterY = axCenterY;
-        const macOSPtSize = queryResult?.deviceContentMacOSPt;
-        if (macOSPtSize) {
-          const iosPtSize = await getIosPtSizeForDevice(deviceId);
-          if (iosPtSize) {
-            const converted = convertMacOSPtToIOSPt(
-              { x: axCenterX, y: axCenterY },
-              macOSPtSize,
-              iosPtSize,
-            );
-            rawCenterX = converted.x;
-            rawCenterY = converted.y;
-            console.error(
-              `[app_tap_element] macOS-pt→iOS-pt conversion applied: ` +
-                `macOSPt(${axCenterX.toFixed(2)}, ${axCenterY.toFixed(2)}) → ` +
-                `iOSPt(${rawCenterX.toFixed(2)}, ${rawCenterY.toFixed(2)}) ` +
-                `scale=(${(iosPtSize.width / macOSPtSize.width).toFixed(4)}, ` +
-                `${(iosPtSize.height / macOSPtSize.height).toFixed(4)})`,
-            );
-          }
-        }
+        // The macOS-pt → iOS-pt conversion (#693 WU3) is deferred until the
+        // coordinate-dispatch path below. AXPress (the fast path) drives the
+        // tap through the macOS AX API by element path and never consumes
+        // coordinates, so paying for a `simctl list` round-trip on every
+        // successful AXPress tap is pure waste. The lookup also has its
+        // own module-level cache, so repeated dispatches on the same UDID
+        // do not re-pay the simctl cost.
+        const rawCenterX = axCenterX;
+        const rawCenterY = axCenterY;
 
         // Sanitize the tap target. An accessibility tree that reports a
         // `visible: true` element with a frame whose center lands outside
@@ -389,6 +370,33 @@ export function registerAppTapElementTool(server: MCPServer): void {
           }
         }
 
+        // Convert from macOS-screen-points to iOS-points before dispatching
+        // through the coordinate input backend (#693 WU3). The AX bridge
+        // reports element frames in macOS-pt, but `sim-hid` / `simctl`
+        // consume iOS-pt. When `deviceContentMacOSPt` is missing (legacy
+        // bridge) or the device's iOS-pt size cannot be resolved (unknown
+        // device, simctl failure), the coordinates are forwarded unchanged
+        // — same behavior as before. The lookup is deferred to here (rather
+        // than running before AXPress) so successful AXPress taps avoid the
+        // `simctl list` round-trip entirely.
+        const macOSPtSize = queryResult?.deviceContentMacOSPt;
+        if (macOSPtSize) {
+          const iosPtSize = await getIosPtSizeForDevice(deviceId);
+          if (iosPtSize) {
+            const before = { x: centerX, y: centerY };
+            const converted = convertMacOSPtToIOSPt(before, macOSPtSize, iosPtSize);
+            centerX = converted.x;
+            centerY = converted.y;
+            console.error(
+              `[app_tap_element] macOS-pt→iOS-pt conversion applied: ` +
+                `macOSPt(${before.x.toFixed(2)}, ${before.y.toFixed(2)}) → ` +
+                `iOSPt(${centerX.toFixed(2)}, ${centerY.toFixed(2)}) ` +
+                `scale=(${(iosPtSize.width / macOSPtSize.width).toFixed(4)}, ` +
+                `${(iosPtSize.height / macOSPtSize.height).toFixed(4)})`,
+            );
+          }
+        }
+
         // Tap via input backend
         const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
         const { meta } = await runInputOp(backend, deviceId, () =>
@@ -519,17 +527,36 @@ function sleep(ms: number): Promise<void> {
  * or the simctl call fails — callers treat `null` as "no conversion available"
  * and fall back to using raw AX-frame coordinates.
  */
+const iosPtSizeCache = new Map<string, Size2D | null>();
+
 async function getIosPtSizeForDevice(deviceId: string): Promise<Size2D | null> {
+  const cached = iosPtSizeCache.get(deviceId);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let result: Size2D | null = null;
   try {
     const manager = new SimulatorManager();
     const device = await manager.getDevice(deviceId);
-    if (!device) return null;
-    const preset = Object.values(DEVICE_PRESETS).find((p) => p.name === device.name);
-    if (!preset) return null;
-    return { width: preset.w, height: preset.h };
+    if (device) {
+      const deviceNameLower = device.name.toLowerCase();
+      const preset = Object.values(DEVICE_PRESETS).find(
+        (p) => p.name.toLowerCase() === deviceNameLower,
+      );
+      if (preset) {
+        result = { width: preset.w, height: preset.h };
+      }
+    }
   } catch {
-    return null;
+    result = null;
   }
+  iosPtSizeCache.set(deviceId, result);
+  return result;
+}
+
+/** @internal — test-only hook to reset the per-process iOS-pt size cache. */
+export function __resetIosPtSizeCacheForTests(): void {
+  iosPtSizeCache.clear();
 }
 
 /**

--- a/src/utils/coordinate-space.ts
+++ b/src/utils/coordinate-space.ts
@@ -1,0 +1,64 @@
+/**
+ * coordinate-space — helpers for converting AX-frame coordinates between
+ * macOS-screen-points and iOS-points.
+ *
+ * Background (#693 WU3):
+ *   ax-bridge-native reports element frames in macOS-screen-points relative to
+ *   the device-content-root. sim-hid-bridge and simctl both consume
+ *   iOS-points (the logical point space of the device under test, e.g. 402×874
+ *   for iPhone 17 Pro). The ratio is ~1.733×, so a tap dispatched at the raw
+ *   AX-frame center lands ~73% of the way across the device instead of at the
+ *   intended target.
+ *
+ *   PR #695 (already merged) emits `deviceContentMacOSPt: { width, height }`
+ *   on the AX dump root / query result. This module converts coordinates using
+ *   that size paired with the known iOS-point size of the device.
+ */
+
+/** A 2-D size in a given coordinate space. */
+export interface Size2D {
+  width: number;
+  height: number;
+}
+
+/** A 2-D point. */
+export interface Point2D {
+  x: number;
+  y: number;
+}
+
+/**
+ * Convert a point from macOS-screen-points (AX frame space) to iOS-points
+ * (sim-hid / simctl input space).
+ *
+ * Scale factor per axis = iosPtSize / macOSPtSize.
+ *
+ * Fallback: when either size argument is falsy, or when either dimension is
+ * zero or non-finite, the input point is returned unchanged so callers that
+ * lack the necessary metadata transparently preserve the previous behavior.
+ */
+export function convertMacOSPtToIOSPt(
+  point: Point2D,
+  macOSPtSize: Size2D | undefined | null,
+  iosPtSize: Size2D | undefined | null,
+): Point2D {
+  if (
+    !macOSPtSize ||
+    !iosPtSize ||
+    !Number.isFinite(macOSPtSize.width) ||
+    !Number.isFinite(macOSPtSize.height) ||
+    macOSPtSize.width === 0 ||
+    macOSPtSize.height === 0 ||
+    !Number.isFinite(iosPtSize.width) ||
+    !Number.isFinite(iosPtSize.height) ||
+    iosPtSize.width === 0 ||
+    iosPtSize.height === 0
+  ) {
+    return point;
+  }
+
+  return {
+    x: point.x * (iosPtSize.width / macOSPtSize.width),
+    y: point.y * (iosPtSize.height / macOSPtSize.height),
+  };
+}

--- a/tests/unit/app-tap-element.test.ts
+++ b/tests/unit/app-tap-element.test.ts
@@ -11,7 +11,11 @@ jest.mock('../../src/mcp-server', () => {
 });
 
 import { MCPServer } from '../../src/mcp-server';
-import { registerAppTapElementTool, sanitizeTapTarget } from '../../src/tools/app-tap-element';
+import {
+  registerAppTapElementTool,
+  sanitizeTapTarget,
+  __resetIosPtSizeCacheForTests,
+} from '../../src/tools/app-tap-element';
 import type { AXNode, AXQueryResult } from '../../src/native/ax-types';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
@@ -131,6 +135,10 @@ beforeAll(() => {
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useRealTimers();
+  // The iOS-pt size cache is module-level so a previous test's resolved
+  // size would otherwise leak into subsequent tests that change the
+  // `mockGetDevice` return value (e.g. preset hit → preset miss).
+  __resetIosPtSizeCacheForTests();
   // Reset the press mock entirely — `clearAllMocks` does not drain the
   // `mockResolvedValueOnce` / `mockRejectedValueOnce` queue, so an
   // overridden once-value from a previous test would otherwise be

--- a/tests/unit/app-tap-element.test.ts
+++ b/tests/unit/app-tap-element.test.ts
@@ -63,6 +63,16 @@ jest.mock('../../src/session-manager', () => ({
   }),
 }));
 
+// SimulatorManager is used to look up the iOS-pt size for coordinate conversion.
+// Default: return null (device not in preset table) so pre-existing tests are
+// unaffected. Individual tests override this via mockGetDevice.
+const mockGetDevice = jest.fn().mockResolvedValue(null);
+jest.mock('../../src/simulator', () => ({
+  SimulatorManager: jest.fn().mockImplementation(() => ({
+    getDevice: mockGetDevice,
+  })),
+}));
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function makeNode(overrides: Partial<AXNode> = {}): AXNode {
@@ -141,6 +151,8 @@ beforeEach(() => {
     axErrorCode: null,
   });
   mockDumpTree.mockResolvedValue(makeNodeTree(makeNode()));
+  // Default: device not found in preset table → no coordinate conversion.
+  mockGetDevice.mockResolvedValue(null);
 });
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -927,6 +939,92 @@ describe('app_tap_element — Tier 1.5 AX press', () => {
     );
 
     warnSpy.mockRestore();
+  });
+});
+
+describe('app_tap_element — macOS-pt → iOS-pt coordinate conversion (#693 WU3)', () => {
+  it('scales tap coordinates when query result carries deviceContentMacOSPt and device is in preset table', async () => {
+    // iPhone 17 Pro: macOS content area 697×1515, iOS pts 402×874.
+    // AX frame: x=500, y=1000, w=100, h=50 → raw center (550, 1025) in macOS-pts.
+    // Expected after conversion: x ≈ 550*(402/697) ≈ 317.07, y ≈ 1025*(874/1515) ≈ 591.53
+    const node = makeNode({ frame: { x: 500, y: 1000, width: 100, height: 50 } });
+    const queryResultWithMacOSPt = {
+      ...makeQueryResult([node]),
+      deviceContentMacOSPt: { width: 697, height: 1515 },
+    };
+    mockQuery.mockResolvedValue(queryResultWithMacOSPt);
+    // Device lookup returns iPhone 17 Pro — name matches preset 'iphone-17-pro'.
+    mockGetDevice.mockResolvedValue({ name: 'iPhone 17 Pro', udid: 'test-device-id', state: 'Booted', isAvailable: true, runtime: '', runtimeVersion: '' });
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await handler('session', { label: 'Login', timeout: 0 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('tapped');
+    // Converted coordinates must differ from the raw center (550, 1025).
+    expect(body.coordinates.x).toBeCloseTo(317.07, 0);
+    expect(body.coordinates.y).toBeCloseTo(591.53, 0);
+    // The tap backend must receive the converted coordinates.
+    const tapCall = mockTap.mock.calls[0];
+    expect(tapCall[1]).toBeCloseTo(317.07, 0);
+    expect(tapCall[2]).toBeCloseTo(591.53, 0);
+    // Log entry should mention the conversion.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/macOS-pt→iOS-pt conversion applied/),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to raw AX coordinates when deviceContentMacOSPt is absent (legacy bridge)', async () => {
+    const node = makeNode({ frame: { x: 100, y: 200, width: 200, height: 44 } });
+    // No deviceContentMacOSPt on query result.
+    mockQuery.mockResolvedValue(makeQueryResult([node]));
+    mockGetDevice.mockResolvedValue({ name: 'iPhone 17 Pro', udid: 'test-device-id', state: 'Booted', isAvailable: true, runtime: '', runtimeVersion: '' });
+
+    const result = await handler('session', { label: 'Login', timeout: 0 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('tapped');
+    // Raw center: 100+200/2=200, 200+44/2=222
+    expect(body.coordinates).toEqual({ x: 200, y: 222 });
+    expect(mockTap).toHaveBeenCalledWith('test-device-id', 200, 222, undefined);
+  });
+
+  it('falls back to raw AX coordinates when device is not in the preset table', async () => {
+    const node = makeNode({ frame: { x: 100, y: 200, width: 200, height: 44 } });
+    const queryResultWithMacOSPt = {
+      ...makeQueryResult([node]),
+      deviceContentMacOSPt: { width: 697, height: 1515 },
+    };
+    mockQuery.mockResolvedValue(queryResultWithMacOSPt);
+    // Device name does not match any preset.
+    mockGetDevice.mockResolvedValue({ name: 'iPhone Unknown Model', udid: 'test-device-id', state: 'Booted', isAvailable: true, runtime: '', runtimeVersion: '' });
+
+    const result = await handler('session', { label: 'Login', timeout: 0 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('tapped');
+    // Raw center unchanged: 200, 222
+    expect(body.coordinates).toEqual({ x: 200, y: 222 });
+  });
+
+  it('falls back to raw AX coordinates when getDevice returns null (simctl failure)', async () => {
+    const node = makeNode({ frame: { x: 100, y: 200, width: 200, height: 44 } });
+    const queryResultWithMacOSPt = {
+      ...makeQueryResult([node]),
+      deviceContentMacOSPt: { width: 697, height: 1515 },
+    };
+    mockQuery.mockResolvedValue(queryResultWithMacOSPt);
+    // getDevice returns null — simctl failure simulated.
+    mockGetDevice.mockResolvedValue(null);
+
+    const result = await handler('session', { label: 'Login', timeout: 0 });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.status).toBe('tapped');
+    // Raw center unchanged.
+    expect(body.coordinates).toEqual({ x: 200, y: 222 });
   });
 });
 

--- a/tests/unit/coordinate-space.test.ts
+++ b/tests/unit/coordinate-space.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for src/utils/coordinate-space.ts
+ *
+ * Verifies macOS-screen-pt → iOS-pt coordinate conversion (#693 WU3).
+ */
+
+import { convertMacOSPtToIOSPt } from '../../src/utils/coordinate-space';
+import type { Size2D, Point2D } from '../../src/utils/coordinate-space';
+
+// iPhone 17 Pro reference sizes
+const IPHONE_17_PRO_MACOS_PT: Size2D = { width: 697, height: 1515 };
+const IPHONE_17_PRO_IOS_PT: Size2D = { width: 402, height: 874 };
+
+describe('convertMacOSPtToIOSPt', () => {
+  it('scales correctly for iPhone 17 Pro ~1.733× ratio', () => {
+    // macOS-pt center from AX frame: (609.875, 1386.73)
+    // Expected iOS-pt: x = 609.875 * (402/697) ≈ 351.75
+    //                  y = 1386.73 * (874/1515) ≈ 800.00
+    const input: Point2D = { x: 609.875, y: 1386.73 };
+    const result = convertMacOSPtToIOSPt(input, IPHONE_17_PRO_MACOS_PT, IPHONE_17_PRO_IOS_PT);
+
+    expect(result.x).toBeCloseTo(351.75, 1);
+    expect(result.y).toBeCloseTo(800.00, 1);
+  });
+
+  it('returns identity when scale is 1.0 (macOS size equals iOS size)', () => {
+    const size: Size2D = { width: 390, height: 844 };
+    const input: Point2D = { x: 195, y: 422 };
+    const result = convertMacOSPtToIOSPt(input, size, size);
+
+    expect(result.x).toBeCloseTo(195, 5);
+    expect(result.y).toBeCloseTo(422, 5);
+  });
+
+  it('applies asymmetric scale independently on each axis', () => {
+    // x scale = 2.0, y scale = 0.5
+    const macOS: Size2D = { width: 100, height: 200 };
+    const ios: Size2D = { width: 200, height: 100 };
+    const input: Point2D = { x: 50, y: 80 };
+    const result = convertMacOSPtToIOSPt(input, macOS, ios);
+
+    // x: 50 * (200/100) = 100
+    // y: 80 * (100/200) = 40
+    expect(result.x).toBeCloseTo(100, 5);
+    expect(result.y).toBeCloseTo(40, 5);
+  });
+
+  it('returns input unchanged when deviceContentMacOSPt is undefined', () => {
+    const input: Point2D = { x: 200, y: 300 };
+    const ios: Size2D = { width: 402, height: 874 };
+    const result = convertMacOSPtToIOSPt(input, undefined, ios);
+
+    expect(result).toEqual(input);
+  });
+
+  it('returns input unchanged when deviceContentMacOSPt is null', () => {
+    const input: Point2D = { x: 200, y: 300 };
+    const ios: Size2D = { width: 402, height: 874 };
+    const result = convertMacOSPtToIOSPt(input, null, ios);
+
+    expect(result).toEqual(input);
+  });
+
+  it('returns input unchanged when iosPtSize is undefined', () => {
+    const input: Point2D = { x: 200, y: 300 };
+    const macOS: Size2D = { width: 697, height: 1515 };
+    const result = convertMacOSPtToIOSPt(input, macOS, undefined);
+
+    expect(result).toEqual(input);
+  });
+
+  it('returns input unchanged when iosPtSize is null', () => {
+    const input: Point2D = { x: 200, y: 300 };
+    const macOS: Size2D = { width: 697, height: 1515 };
+    const result = convertMacOSPtToIOSPt(input, macOS, null);
+
+    expect(result).toEqual(input);
+  });
+
+  it('returns input unchanged when macOSPtSize width is zero (avoids division by zero)', () => {
+    const input: Point2D = { x: 200, y: 300 };
+    const macOS: Size2D = { width: 0, height: 1515 };
+    const ios: Size2D = { width: 402, height: 874 };
+    const result = convertMacOSPtToIOSPt(input, macOS, ios);
+
+    expect(result).toEqual(input);
+  });
+
+  it('returns input unchanged when macOSPtSize height is zero (avoids division by zero)', () => {
+    const input: Point2D = { x: 200, y: 300 };
+    const macOS: Size2D = { width: 697, height: 0 };
+    const ios: Size2D = { width: 402, height: 874 };
+    const result = convertMacOSPtToIOSPt(input, macOS, ios);
+
+    expect(result).toEqual(input);
+  });
+
+  it('returns input unchanged when a dimension is NaN', () => {
+    const input: Point2D = { x: 200, y: 300 };
+    const macOS: Size2D = { width: NaN, height: 1515 };
+    const ios: Size2D = { width: 402, height: 874 };
+    const result = convertMacOSPtToIOSPt(input, macOS, ios);
+
+    expect(result).toEqual(input);
+  });
+
+  it('preserves zero-valued input coordinates (origin tap)', () => {
+    const input: Point2D = { x: 0, y: 0 };
+    const result = convertMacOSPtToIOSPt(input, IPHONE_17_PRO_MACOS_PT, IPHONE_17_PRO_IOS_PT);
+
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/utils/coordinate-space.ts` with `convertMacOSPtToIOSPt()` that scales a point by `iosPtSize / macOSPtSize` per axis
- In `app-tap-element.ts`, captures `deviceContentMacOSPt` from the AX query result and looks up the iOS-pt size from the simulator preset table; applies the scale before dispatching the tap
- Fallback to raw AX coords when either size is unavailable (legacy bridge, unknown device, simctl failure) — zero behavior change for existing callers
- Adds 10 unit tests for the converter and 4 integration cases proving the conversion path is invoked / bypassed correctly

Implements #693 WU3 (does not Close — WU2/WU4/WU5 still pending)

## Scale derivation

```
scaleX = iosPtSize.width  / deviceContentMacOSPt.width
scaleY = iosPtSize.height / deviceContentMacOSPt.height
```

For iPhone 17 Pro (macOS content 697×1515, iOS pts 402×874):
- scaleX ≈ 0.577, scaleY ≈ 0.577 (~1.733× inverse ratio)
- A tap at macOS-pt center (550, 1025) → iOS-pt (317, 591) — lands on target instead of ~73% across the device

## Files changed

| File | Change |
|------|--------|
| `src/utils/coordinate-space.ts` | New — `convertMacOSPtToIOSPt()` + `Size2D` / `Point2D` types |
| `src/tools/app-tap-element.ts` | Capture `queryResult`, call `getIosPtSizeForDevice()`, apply conversion |
| `tests/unit/coordinate-space.test.ts` | New — 10 cases: 1.733× scale, identity, asymmetric, all falsy fallbacks |
| `tests/unit/app-tap-element.test.ts` | 4 new cases + `SimulatorManager` mock + `mockGetDevice` reset |

## Test plan

- [x] `npx tsc --noEmit --pretty false` — zero errors
- [x] `npx jest --runInBand tests/unit/coordinate-space.test.ts tests/unit/app-tap-element.test.ts` — 58 passed, 0 failed
- [x] `git diff --check` — no whitespace issues
- [ ] `npm run build` — deferred (Swift bridge compilation requires Xcode; not available in CI for this worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)