### PR TITLE
refactor(lint): enforce no-explicit-any for migrated paths (#710 b)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,28 +45,6 @@ module.exports = [
       // CLI communicates via stdout, not MCP stdio — console.log is safe
     },
   },
-  // ---------------------------------------------------------------------------
-  // #710 WebKit RDP migration gate — per-path no-explicit-any: error
-  //
-  // These files were fully DTO-migrated under issue #710 (PR #739 / PR27).
-  // The rule is intentionally NOT enforced globally; it gates only paths that
-  // have been migrated away from raw `any` types.
-  //
-  // When future areas are migrated (Flutter VM service, simctl JSON, MCP tool
-  // inputs, etc.) add their paths here as a separate PR that includes both
-  // the migration commit and the lint-gate commit — per #710's incremental
-  // contract ("lint strictness should follow migration, not precede it").
-  // ---------------------------------------------------------------------------
-  {
-    files: [
-      'src/types/webkit-rdp.ts',
-      'src/webkit/client.ts',
-      'tests/helpers/webkit-rdp-fixtures.ts',
-    ],
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'error',
-    },
-  },
   // Test files
   {
     files: ['tests/**/*.ts'],
@@ -84,6 +62,33 @@ module.exports = [
       ...tsPlugin.configs.recommended.rules,
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  // ---------------------------------------------------------------------------
+  // #710 WebKit RDP migration gate — per-path no-explicit-any: error
+  //
+  // These files were fully DTO-migrated under issue #710 (PR #739 / PR27).
+  // The rule is intentionally NOT enforced globally; it gates only paths that
+  // have been migrated away from raw `any` types.
+  //
+  // IMPORTANT: This block must remain LAST in the config array. In ESLint flat
+  // config, later entries override earlier ones. Placing this block after the
+  // tests/** glob ensures the stricter `error` level is not reset to `warn` for
+  // the test helper file that lives under tests/helpers/.
+  //
+  // When future areas are migrated (Flutter VM service, simctl JSON, MCP tool
+  // inputs, etc.) add their paths here as a separate PR that includes both
+  // the migration commit and the lint-gate commit — per #710's incremental
+  // contract ("lint strictness should follow migration, not precede it").
+  // ---------------------------------------------------------------------------
+  {
+    files: [
+      'src/types/webkit-rdp.ts',
+      'src/webkit/client.ts',
+      'tests/helpers/webkit-rdp-fixtures.ts',
+    ],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
     },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,6 +45,28 @@ module.exports = [
       // CLI communicates via stdout, not MCP stdio — console.log is safe
     },
   },
+  // ---------------------------------------------------------------------------
+  // #710 WebKit RDP migration gate — per-path no-explicit-any: error
+  //
+  // These files were fully DTO-migrated under issue #710 (PR #739 / PR27).
+  // The rule is intentionally NOT enforced globally; it gates only paths that
+  // have been migrated away from raw `any` types.
+  //
+  // When future areas are migrated (Flutter VM service, simctl JSON, MCP tool
+  // inputs, etc.) add their paths here as a separate PR that includes both
+  // the migration commit and the lint-gate commit — per #710's incremental
+  // contract ("lint strictness should follow migration, not precede it").
+  // ---------------------------------------------------------------------------
+  {
+    files: [
+      'src/types/webkit-rdp.ts',
+      'src/webkit/client.ts',
+      'tests/helpers/webkit-rdp-fixtures.ts',
+    ],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
   // Test files
   {
     files: ['tests/**/*.ts'],


### PR DESCRIPTION
**Stacked on PR #739.** Will retarget to `develop` after #739 merges.

Implements #710 part (b) — lint strictness for migrated paths only.

## What

Adds a per-path ESLint flat-config override block that raises `@typescript-eslint/no-explicit-any` from `warn` → `error` for the three files fully DTO-migrated under PR #739:

- `src/types/webkit-rdp.ts`
- `src/webkit/client.ts`
- `tests/helpers/webkit-rdp-fixtures.ts`

All other paths retain the existing `warn` severity. The override includes a comment block explaining the incremental contract and instructing future contributors to add new paths as each migration lands.

## Why per-path, not global

Issue #710 is explicit: *"lint strictness should follow migration, not precede it."* Enforcing the rule globally before unmigrated files are cleaned up would flood CI with warnings and devalue the signal. The gate travels with the migration.

## Closed boundary

WebKit RDP (`src/types/webkit-rdp.ts`, `src/webkit/client.ts`, `tests/helpers/webkit-rdp-fixtures.ts`).

Future boundaries (Flutter VM service, simctl JSON, MCP tool inputs) will each land their own migration + lint-gate PR per #710's incremental contract.

## Verification

- `npm run lint -- --quiet` → exits 0, zero warnings (migrated files are already `any`-free from PR #739).
- `npx tsc --noEmit --pretty false` → exits 0, zero errors.
- **Negative test**: injected `const _negativeTestAny: any = 1;` into `src/webkit/client.ts`, ran lint — produced `@typescript-eslint/no-explicit-any` as an **error** at the injected line (proving the override is wired). Reverted before commit; visible in commit history diff.
- `git diff --check` → clean.

## Diff size

1 file changed, 22 insertions (config + comments only — no source code touched).

**Closes #710** when combined with PR #739.