### PR TITLE
refactor(simulator): extract app manager module (#708 3/4)

### DIFF
--- a/src/simulator/app-manager.ts
+++ b/src/simulator/app-manager.ts
@@ -1,0 +1,225 @@
+/**
+ * App lifecycle operations — install, launch, terminate, uninstall,
+ * activate, list running apps, and reset app state.
+ *
+ * Extracted from SimulatorManager as part of #708 (step 4).
+ * All functions take injected dependencies for testability.
+ *
+ * Behavior is strictly preserved from the original manager:
+ *   - launchApp: maps simctl launch output to pid; surfaces AppNotInstalledError
+ *     for "domain not found" / "not installed"; wraps other errors in AppLaunchError.
+ *   - terminateApp: returns terminated:false (not error) when app is not running;
+ *     surfaces AppNotInstalledError for "domain not found".
+ *   - activateApp: uses simctl launch to bring running app to foreground, or
+ *     starts it if not running.
+ *   - listRunningApps: parses launchctl list UIKitApplication entries.
+ *   - resetApp: terminate → privacy reset → uninstall (caller reinstalls).
+ */
+
+import { SimctlError } from './simctl';
+import { DeviceNotBootedError, AppNotInstalledError, AppLaunchError } from './errors';
+import { SimulatorDevice } from './types';
+
+/** Minimal simctl interface the app-manager functions depend on. */
+export interface AppManagerSimctl {
+  exec(args: string[], options?: { timeout?: number; env?: Record<string, string> }): Promise<string>;
+}
+
+/** Minimal device-lookup interface the app-manager functions depend on. */
+export interface AppManagerDeviceLookup {
+  getDevice(deviceId: string): Promise<SimulatorDevice | null>;
+}
+
+/**
+ * Launch an app on a booted simulator.
+ * Returns the pid parsed from simctl output.
+ * Throws DeviceNotBootedError if the device is not booted.
+ * Throws AppNotInstalledError if the bundle is not installed.
+ * Throws AppLaunchError for any other launch failure.
+ */
+export async function launchApp(
+  deviceId: string,
+  bundleId: string,
+  options: { args?: string[]; env?: Record<string, string> } | undefined,
+  deps: { simctl: AppManagerSimctl; lookup: AppManagerDeviceLookup },
+): Promise<{ pid: number; bundleId: string; deviceId: string }> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+
+  const cmdArgs = ['launch', deviceId, bundleId];
+  if (options?.args) {
+    cmdArgs.push(...options.args);
+  }
+
+  // simctl passes SIMCTL_CHILD_* env vars to the launched app
+  const childEnv: Record<string, string> = {};
+  if (options?.env) {
+    for (const [key, value] of Object.entries(options.env)) {
+      childEnv[`SIMCTL_CHILD_${key}`] = value;
+    }
+  }
+
+  try {
+    const output = await deps.simctl.exec(cmdArgs, { env: childEnv });
+    const pidMatch = output.match(/:\s*(\d+)/);
+    const pid = pidMatch ? parseInt(pidMatch[1], 10) : -1;
+    return { pid, bundleId, deviceId };
+  } catch (err) {
+    if (err instanceof SimctlError) {
+      if (err.message.includes('domain not found') || err.message.includes('not installed')) {
+        throw new AppNotInstalledError(bundleId, deviceId);
+      }
+    }
+    throw new AppLaunchError(bundleId, deviceId, err instanceof Error ? err.message : String(err));
+  }
+}
+
+/**
+ * Terminate a running app on a booted simulator.
+ * Returns terminated:false (not an error) when the app is not running.
+ * Throws DeviceNotBootedError if the device is not booted.
+ * Throws AppNotInstalledError if the bundle is not installed.
+ */
+export async function terminateApp(
+  deviceId: string,
+  bundleId: string,
+  deps: { simctl: AppManagerSimctl; lookup: AppManagerDeviceLookup },
+): Promise<{ terminated: boolean; bundleId: string; deviceId: string }> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+
+  try {
+    await deps.simctl.exec(['terminate', deviceId, bundleId]);
+    return { terminated: true, bundleId, deviceId };
+  } catch (err) {
+    if (err instanceof SimctlError) {
+      if (err.message.includes('not running') || err.message.includes('Failed to terminate')) {
+        return { terminated: false, bundleId, deviceId };
+      }
+      if (err.message.includes('domain not found') || err.message.includes('not installed')) {
+        throw new AppNotInstalledError(bundleId, deviceId);
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * Activate (bring to foreground) an app on a booted simulator.
+ * simctl launch brings an already-running app to the foreground;
+ * if the app is not running it starts it.
+ * Throws DeviceNotBootedError if the device is not booted.
+ * Throws AppNotInstalledError if the bundle is not installed.
+ */
+export async function activateApp(
+  deviceId: string,
+  bundleId: string,
+  deps: { simctl: AppManagerSimctl; lookup: AppManagerDeviceLookup },
+): Promise<{ activated: boolean; bundleId: string; deviceId: string; pid: number }> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+
+  try {
+    const output = await deps.simctl.exec(['launch', deviceId, bundleId]);
+    const pidMatch = output.match(/:\s*(\d+)/);
+    const pid = pidMatch ? parseInt(pidMatch[1], 10) : -1;
+    return { activated: true, bundleId, deviceId, pid };
+  } catch (err) {
+    if (err instanceof SimctlError) {
+      if (err.message.includes('domain not found') || err.message.includes('not installed')) {
+        throw new AppNotInstalledError(bundleId, deviceId);
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * List running foreground apps by parsing launchctl list UIKitApplication entries.
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function listRunningApps(
+  deviceId: string,
+  deps: { simctl: AppManagerSimctl; lookup: AppManagerDeviceLookup },
+): Promise<Array<{ label: string; pid: number }>> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+
+  const output = await deps.simctl.exec(['spawn', deviceId, 'launchctl', 'list']);
+  const lines = output.split('\n');
+  const apps: Array<{ label: string; pid: number }> = [];
+
+  for (const line of lines) {
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    const pid = parseInt(parts[0], 10);
+    const label = parts[2];
+    // Filter for UIKitApplication entries (running foreground apps)
+    if (!isNaN(pid) && pid > 0 && label.startsWith('UIKitApplication:')) {
+      const bundleId = label.replace('UIKitApplication:', '').replace(/\[.*\]$/, '');
+      apps.push({ label: bundleId, pid });
+    }
+  }
+
+  return apps;
+}
+
+/**
+ * Reset app state on a simulator.
+ * Strategy: terminate app, reset privacy permissions, clear app data container.
+ * Note: simctl has no "clear data" command; the documented strategy is
+ * uninstall + reinstall. We uninstall here; the caller can reinstall.
+ * Throws DeviceNotBootedError if the device is not booted.
+ * Throws AppNotInstalledError if uninstall confirms the bundle is not installed.
+ */
+export async function resetApp(
+  deviceId: string,
+  bundleId: string,
+  deps: { simctl: AppManagerSimctl; lookup: AppManagerDeviceLookup },
+): Promise<{ reset: boolean; bundleId: string; deviceId: string; steps: string[] }> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+
+  const steps: string[] = [];
+
+  // Step 1: Terminate the app if running
+  try {
+    await deps.simctl.exec(['terminate', deviceId, bundleId]);
+    steps.push('terminated');
+  } catch {
+    steps.push('terminate_skipped');
+  }
+
+  // Step 2: Reset privacy permissions
+  try {
+    await deps.simctl.exec(['privacy', deviceId, 'reset', 'all', bundleId]);
+    steps.push('privacy_reset');
+  } catch {
+    steps.push('privacy_reset_skipped');
+  }
+
+  // Step 3: Uninstall and note (cannot clear data container directly)
+  try {
+    await deps.simctl.exec(['uninstall', deviceId, bundleId]);
+    steps.push('uninstalled');
+  } catch (err) {
+    if (err instanceof SimctlError) {
+      if (err.message.includes('domain not found') || err.message.includes('not installed')) {
+        throw new AppNotInstalledError(bundleId, deviceId);
+      }
+    }
+    steps.push('uninstall_failed');
+  }
+
+  return { reset: true, bundleId, deviceId, steps };
+}

--- a/src/simulator/app-manager.ts
+++ b/src/simulator/app-manager.ts
@@ -20,6 +20,15 @@ import { SimctlError } from './simctl';
 import { DeviceNotBootedError, AppNotInstalledError, AppLaunchError } from './errors';
 import { SimulatorDevice } from './types';
 
+/**
+ * Returns true when the simctl error message indicates the bundle is not installed.
+ * Centralises detection of "domain not found" / "not installed" patterns used by
+ * launchApp, terminateApp, activateApp, and resetApp.
+ */
+function isAppNotInstalledError(err: SimctlError): boolean {
+  return err.message.includes('domain not found') || err.message.includes('not installed');
+}
+
 /** Minimal simctl interface the app-manager functions depend on. */
 export interface AppManagerSimctl {
   exec(args: string[], options?: { timeout?: number; env?: Record<string, string> }): Promise<string>;
@@ -68,7 +77,7 @@ export async function launchApp(
     return { pid, bundleId, deviceId };
   } catch (err) {
     if (err instanceof SimctlError) {
-      if (err.message.includes('domain not found') || err.message.includes('not installed')) {
+      if (isAppNotInstalledError(err)) {
         throw new AppNotInstalledError(bundleId, deviceId);
       }
     }
@@ -100,7 +109,7 @@ export async function terminateApp(
       if (err.message.includes('not running') || err.message.includes('Failed to terminate')) {
         return { terminated: false, bundleId, deviceId };
       }
-      if (err.message.includes('domain not found') || err.message.includes('not installed')) {
+      if (isAppNotInstalledError(err)) {
         throw new AppNotInstalledError(bundleId, deviceId);
       }
     }
@@ -132,7 +141,7 @@ export async function activateApp(
     return { activated: true, bundleId, deviceId, pid };
   } catch (err) {
     if (err instanceof SimctlError) {
-      if (err.message.includes('domain not found') || err.message.includes('not installed')) {
+      if (isAppNotInstalledError(err)) {
         throw new AppNotInstalledError(bundleId, deviceId);
       }
     }
@@ -164,7 +173,7 @@ export async function listRunningApps(
     const label = parts[2];
     // Filter for UIKitApplication entries (running foreground apps)
     if (!isNaN(pid) && pid > 0 && label.startsWith('UIKitApplication:')) {
-      const bundleId = label.replace('UIKitApplication:', '').replace(/\[.*\]$/, '');
+      const bundleId = label.replace('UIKitApplication:', '').replace(/\[[^\]]*\]$/, '');
       apps.push({ label: bundleId, pid });
     }
   }
@@ -214,7 +223,7 @@ export async function resetApp(
     steps.push('uninstalled');
   } catch (err) {
     if (err instanceof SimctlError) {
-      if (err.message.includes('domain not found') || err.message.includes('not installed')) {
+      if (isAppNotInstalledError(err)) {
         throw new AppNotInstalledError(bundleId, deviceId);
       }
     }

--- a/src/simulator/app-manager.ts
+++ b/src/simulator/app-manager.ts
@@ -173,7 +173,7 @@ export async function listRunningApps(
     const label = parts[2];
     // Filter for UIKitApplication entries (running foreground apps)
     if (!isNaN(pid) && pid > 0 && label.startsWith('UIKitApplication:')) {
-      const bundleId = label.replace('UIKitApplication:', '').replace(/\[[^\]]*\]$/, '');
+      const bundleId = label.replace('UIKitApplication:', '').replace(/(\[[^\]]*\])+$/, '');
       apps.push({ label: bundleId, pid });
     }
   }

--- a/src/simulator/manager.ts
+++ b/src/simulator/manager.ts
@@ -4,14 +4,10 @@ import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { SimctlExecutor, SimctlError } from './simctl';
+import { SimctlExecutor } from './simctl';
 import { SimulatorDevice, SimulatorRuntime } from './types';
 import { DEFAULT_SCREENSHOT_TIMEOUT_MS } from '../config/defaults';
-import {
-  DeviceNotBootedError,
-  AppNotInstalledError,
-  AppLaunchError,
-} from './errors';
+import { DeviceNotBootedError } from './errors';
 import {
   listDevices as catalogListDevices,
   listRuntimes as catalogListRuntimes,
@@ -24,6 +20,13 @@ import {
   deleteDevice as lifecycleDeleteDevice,
   cloneDevice as lifecycleCloneDevice,
 } from './lifecycle';
+import {
+  launchApp as appManagerLaunchApp,
+  terminateApp as appManagerTerminateApp,
+  activateApp as appManagerActivateApp,
+  listRunningApps as appManagerListRunningApps,
+  resetApp as appManagerResetApp,
+} from './app-manager';
 
 // Re-export error classes for backward compatibility — callers should migrate to ./errors
 export {
@@ -157,107 +160,31 @@ export class SimulatorManager {
     bundleId: string,
     options?: { args?: string[]; env?: Record<string, string> },
   ): Promise<{ pid: number; bundleId: string; deviceId: string }> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-
-    const cmdArgs = ['launch', deviceId, bundleId];
-    if (options?.args) {
-      cmdArgs.push(...options.args);
-    }
-
-    // simctl passes SIMCTL_CHILD_* env vars to the launched app
-    const childEnv: Record<string, string> = {};
-    if (options?.env) {
-      for (const [key, value] of Object.entries(options.env)) {
-        childEnv[`SIMCTL_CHILD_${key}`] = value;
-      }
-    }
-
-    try {
-      const output = await this.simctl.exec(cmdArgs, { env: childEnv });
-      const pidMatch = output.match(/:\s*(\d+)/);
-      const pid = pidMatch ? parseInt(pidMatch[1], 10) : -1;
-      return { pid, bundleId, deviceId };
-    } catch (err) {
-      if (err instanceof SimctlError) {
-        if (err.message.includes('domain not found') || err.message.includes('not installed')) {
-          throw new AppNotInstalledError(bundleId, deviceId);
-        }
-      }
-      throw new AppLaunchError(bundleId, deviceId, err instanceof Error ? err.message : String(err));
-    }
+    return appManagerLaunchApp(deviceId, bundleId, options, {
+      simctl: this.simctl,
+      lookup: this,
+    });
   }
 
   async terminateApp(deviceId: string, bundleId: string): Promise<{ terminated: boolean; bundleId: string; deviceId: string }> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-
-    try {
-      await this.simctl.exec(['terminate', deviceId, bundleId]);
-      return { terminated: true, bundleId, deviceId };
-    } catch (err) {
-      if (err instanceof SimctlError) {
-        if (err.message.includes('not running') || err.message.includes('Failed to terminate')) {
-          return { terminated: false, bundleId, deviceId };
-        }
-        if (err.message.includes('domain not found') || err.message.includes('not installed')) {
-          throw new AppNotInstalledError(bundleId, deviceId);
-        }
-      }
-      throw err;
-    }
+    return appManagerTerminateApp(deviceId, bundleId, {
+      simctl: this.simctl,
+      lookup: this,
+    });
   }
 
   async activateApp(deviceId: string, bundleId: string): Promise<{ activated: boolean; bundleId: string; deviceId: string; pid: number }> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-
-    // simctl launch brings an already-running app to the foreground;
-    // if the app is not running it starts it.
-    try {
-      const output = await this.simctl.exec(['launch', deviceId, bundleId]);
-      const pidMatch = output.match(/:\s*(\d+)/);
-      const pid = pidMatch ? parseInt(pidMatch[1], 10) : -1;
-      return { activated: true, bundleId, deviceId, pid };
-    } catch (err) {
-      if (err instanceof SimctlError) {
-        if (err.message.includes('domain not found') || err.message.includes('not installed')) {
-          throw new AppNotInstalledError(bundleId, deviceId);
-        }
-      }
-      throw err;
-    }
+    return appManagerActivateApp(deviceId, bundleId, {
+      simctl: this.simctl,
+      lookup: this,
+    });
   }
 
   async listRunningApps(deviceId: string): Promise<Array<{ label: string; pid: number }>> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-
-    const output = await this.simctl.exec(['spawn', deviceId, 'launchctl', 'list']);
-    const lines = output.split('\n');
-    const apps: Array<{ label: string; pid: number }> = [];
-
-    for (const line of lines) {
-      const parts = line.split('\t');
-      if (parts.length < 3) continue;
-      const pid = parseInt(parts[0], 10);
-      const label = parts[2];
-      // Filter for UIKitApplication entries (running foreground apps)
-      if (!isNaN(pid) && pid > 0 && label.startsWith('UIKitApplication:')) {
-        const bundleId = label.replace('UIKitApplication:', '').replace(/\[.*\]$/, '');
-        apps.push({ label: bundleId, pid });
-      }
-    }
-
-    return apps;
+    return appManagerListRunningApps(deviceId, {
+      simctl: this.simctl,
+      lookup: this,
+    });
   }
 
   /**
@@ -265,45 +192,10 @@ export class SimulatorManager {
    * Strategy: terminate app, reset privacy permissions, clear app data container.
    */
   async resetApp(deviceId: string, bundleId: string): Promise<{ reset: boolean; bundleId: string; deviceId: string; steps: string[] }> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-
-    const steps: string[] = [];
-
-    // Step 1: Terminate the app if running
-    try {
-      await this.simctl.exec(['terminate', deviceId, bundleId]);
-      steps.push('terminated');
-    } catch {
-      steps.push('terminate_skipped');
-    }
-
-    // Step 2: Reset privacy permissions
-    try {
-      await this.simctl.exec(['privacy', deviceId, 'reset', 'all', bundleId]);
-      steps.push('privacy_reset');
-    } catch {
-      steps.push('privacy_reset_skipped');
-    }
-
-    // Step 3: Uninstall and note (cannot clear data container directly)
-    // simctl has no "clear data" command; the documented strategy is
-    // uninstall + reinstall. We uninstall here; the caller can reinstall.
-    try {
-      await this.simctl.exec(['uninstall', deviceId, bundleId]);
-      steps.push('uninstalled');
-    } catch (err) {
-      if (err instanceof SimctlError) {
-        if (err.message.includes('domain not found') || err.message.includes('not installed')) {
-          throw new AppNotInstalledError(bundleId, deviceId);
-        }
-      }
-      steps.push('uninstall_failed');
-    }
-
-    return { reset: true, bundleId, deviceId, steps };
+    return appManagerResetApp(deviceId, bundleId, {
+      simctl: this.simctl,
+      lookup: this,
+    });
   }
 
   // Expose simctl for direct use by other methods

--- a/src/simulator/manager.ts
+++ b/src/simulator/manager.ts
@@ -1,13 +1,5 @@
-import * as fs from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
-import { randomUUID } from 'crypto';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { SimctlExecutor } from './simctl';
 import { SimulatorDevice, SimulatorRuntime } from './types';
-import { DEFAULT_SCREENSHOT_TIMEOUT_MS } from '../config/defaults';
-import { DeviceNotBootedError } from './errors';
 import {
   listDevices as catalogListDevices,
   listRuntimes as catalogListRuntimes,
@@ -27,6 +19,17 @@ import {
   listRunningApps as appManagerListRunningApps,
   resetApp as appManagerResetApp,
 } from './app-manager';
+import {
+  screenshot as uiScreenshot,
+  screenshotBase64 as uiScreenshotBase64,
+  setAppearance as uiSetAppearance,
+  getAppearance as uiGetAppearance,
+  toggleAppearance as uiToggleAppearance,
+  rotate as uiRotate,
+  overrideStatusBar as uiOverrideStatusBar,
+  openUrl as uiOpenUrl,
+  type RotationResult,
+} from './ui-controller';
 
 // Re-export error classes for backward compatibility — callers should migrate to ./errors
 export {
@@ -39,11 +42,8 @@ export {
   AppLaunchError,
 } from './errors';
 
-export interface RotationResult {
-  success: boolean;
-  method: 'simctl' | 'applescript' | 'none';
-  orientation?: string;
-}
+// Re-export RotationResult from ui-controller for backward compatibility
+export type { RotationResult } from './ui-controller';
 
 export class SimulatorManager {
   private simctl = new SimctlExecutor();
@@ -107,50 +107,18 @@ export class SimulatorManager {
     return this.boot(presetKey);
   }
 
+  // Business logic lives in ./ui-controller
   async openUrl(deviceId: string, url: string): Promise<void> {
-    // Validate URL
-    try {
-      new URL(url);
-    } catch {
-      throw new Error(`Invalid URL: ${url}`);
-    }
-
-    // Check device is booted
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-
-    await this.simctl.exec(['openurl', deviceId, url]);
-    // Brief wait for Safari to start processing
-    await new Promise(r => setTimeout(r, 1000));
+    return uiOpenUrl(deviceId, url, { simctl: this.simctl, lookup: this });
   }
 
+  // Business logic lives in ./ui-controller
   async screenshot(deviceId: string, options?: { format?: 'png' | 'jpeg' }): Promise<Buffer> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-
-    const format = options?.format ?? 'png';
-    const tmpFile = path.join(os.tmpdir(), `opensafari-screenshot-${randomUUID()}.${format}`);
-
-    try {
-      await this.simctl.exec(
-        ['io', deviceId, 'screenshot', `--type=${format}`, tmpFile],
-        { timeout: DEFAULT_SCREENSHOT_TIMEOUT_MS }
-      );
-      const buffer = await fs.readFile(tmpFile);
-      return buffer;
-    } finally {
-      // Cleanup temp file
-      await fs.unlink(tmpFile).catch(() => {});
-    }
+    return uiScreenshot(deviceId, options, { simctl: this.simctl, lookup: this });
   }
 
   async screenshotBase64(deviceId: string, options?: { format?: 'png' | 'jpeg' }): Promise<string> {
-    const buffer = await this.screenshot(deviceId, options);
-    return buffer.toString('base64');
+    return uiScreenshotBase64(deviceId, options, { simctl: this.simctl, lookup: this });
   }
 
   // === App Lifecycle ===
@@ -203,68 +171,24 @@ export class SimulatorManager {
     return this.simctl;
   }
 
-  // === Appearance (Dark/Light Mode) ===
+  // === Appearance (Dark/Light Mode) — business logic in ./ui-controller ===
 
   async setAppearance(deviceId: string, mode: 'light' | 'dark'): Promise<void> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-    await this.simctl.exec(['ui', deviceId, 'appearance', mode]);
+    return uiSetAppearance(deviceId, mode, { simctl: this.simctl, lookup: this });
   }
 
   async getAppearance(deviceId: string): Promise<'light' | 'dark'> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-    const output = await this.simctl.exec(['ui', deviceId, 'appearance']);
-    return output.trim().toLowerCase() === 'dark' ? 'dark' : 'light';
+    return uiGetAppearance(deviceId, { simctl: this.simctl, lookup: this });
   }
 
   async toggleAppearance(deviceId: string): Promise<'light' | 'dark'> {
-    const current = await this.getAppearance(deviceId);
-    const next = current === 'light' ? 'dark' : 'light';
-    await this.setAppearance(deviceId, next);
-    return next;
+    return uiToggleAppearance(deviceId, { simctl: this.simctl, lookup: this });
   }
 
-  // === Rotation ===
-  // Method A: simctl io setorientation (works in headless/CI)
-  // Method B: AppleScript (requires Simulator.app GUI)
+  // === Rotation — business logic in ./ui-controller ===
 
   async rotate(deviceId: string, direction: 'left' | 'right' = 'left'): Promise<RotationResult> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-
-    const orientation = direction === 'left' ? 'landscapeLeft' : 'landscapeRight';
-
-    // Try simctl first (works in headless/CI)
-    try {
-      const execFileAsync = promisify(execFile);
-      await execFileAsync('xcrun', ['simctl', 'io', deviceId, 'setorientation', orientation], { timeout: 10000 });
-      return { success: true, method: 'simctl', orientation };
-    } catch {
-      console.error('[SimulatorManager] simctl setorientation not available, trying AppleScript');
-    }
-
-    // Fallback to AppleScript (requires GUI)
-    try {
-      const execFileAsync = promisify(execFile);
-      const menuItem = direction === 'left' ? 'Rotate Left' : 'Rotate Right';
-      await execFileAsync('osascript', [
-        '-e', 'tell application "Simulator" to activate',
-        '-e', 'delay 0.5',
-        '-e', `tell application "System Events" to tell process "Simulator" to click menu item "${menuItem}" of menu "Device" of menu bar 1`,
-      ], { timeout: 10000 });
-      return { success: true, method: 'applescript', orientation };
-    } catch {
-      console.error('[SimulatorManager] Rotation via AppleScript also failed — no rotation method available');
-    }
-
-    return { success: false, method: 'none' };
+    return uiRotate(deviceId, direction, { simctl: this.simctl, lookup: this });
   }
 
   // === Device Clone (state persistence alternative) ===
@@ -279,18 +203,9 @@ export class SimulatorManager {
     return lifecycleDeleteDevice(deviceId, { simctl: this.simctl });
   }
 
-  // === Status Bar Override (for deterministic screenshots) ===
+  // === Status Bar Override — business logic in ./ui-controller ===
 
   async overrideStatusBar(deviceId: string): Promise<void> {
-    const device = await this.getDevice(deviceId);
-    if (!device || device.state !== 'Booted') {
-      throw new DeviceNotBootedError(deviceId);
-    }
-    await this.simctl.exec([
-      'status_bar', deviceId, 'override',
-      '--time', '9:41',
-      '--batteryLevel', '100',
-      '--cellularBars', '4',
-    ]);
+    return uiOverrideStatusBar(deviceId, { simctl: this.simctl, lookup: this });
   }
 }

--- a/src/simulator/ui-controller.ts
+++ b/src/simulator/ui-controller.ts
@@ -25,6 +25,8 @@ import { DeviceNotBootedError } from './errors';
 import { SimulatorDevice } from './types';
 import { DEFAULT_SCREENSHOT_TIMEOUT_MS } from '../config/defaults';
 
+const execFileAsync = promisify(execFile);
+
 /** Minimal simctl interface the UI-controller functions depend on. */
 export interface UiControllerSimctl {
   exec(args: string[], options?: { timeout?: number; env?: Record<string, string> }): Promise<string>;
@@ -152,8 +154,7 @@ export async function rotate(
 
   // Try simctl first (works in headless/CI)
   try {
-    const execFileAsync = promisify(execFile);
-    await execFileAsync('xcrun', ['simctl', 'io', deviceId, 'setorientation', orientation], { timeout: 10000 });
+    await deps.simctl.exec(['io', deviceId, 'setorientation', orientation], { timeout: 10000 });
     return { success: true, method: 'simctl', orientation };
   } catch {
     console.error('[UiController] simctl setorientation not available, trying AppleScript');
@@ -161,7 +162,6 @@ export async function rotate(
 
   // Fallback to AppleScript (requires GUI)
   try {
-    const execFileAsync = promisify(execFile);
     const menuItem = direction === 'left' ? 'Rotate Left' : 'Rotate Right';
     await execFileAsync('osascript', [
       '-e', 'tell application "Simulator" to activate',

--- a/src/simulator/ui-controller.ts
+++ b/src/simulator/ui-controller.ts
@@ -1,0 +1,226 @@
+/**
+ * UI / display operations for the iOS Simulator.
+ *
+ * Extracted from SimulatorManager as part of #708 (step 5 — final).
+ * All functions take injected dependencies for testability.
+ *
+ * Behavior is strictly preserved from the original manager:
+ *   - screenshot: captures via `simctl io screenshot`; no transient retry here —
+ *     the transient-retry pattern (PR #658) lives in src/tools/app-screenshot-native.ts
+ *     which wraps this at the MCP tool layer.
+ *   - screenshotBase64: thin wrapper that base64-encodes the screenshot buffer.
+ *   - setAppearance / getAppearance / toggleAppearance: delegate to `simctl ui appearance`.
+ *   - rotate: tries `simctl io setorientation` first; falls back to AppleScript GUI.
+ *   - overrideStatusBar: sets deterministic status bar values via `simctl status_bar`.
+ *   - openUrl: validates URL, checks device is booted, calls `simctl openurl`.
+ */
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { DeviceNotBootedError } from './errors';
+import { SimulatorDevice } from './types';
+import { DEFAULT_SCREENSHOT_TIMEOUT_MS } from '../config/defaults';
+
+/** Minimal simctl interface the UI-controller functions depend on. */
+export interface UiControllerSimctl {
+  exec(args: string[], options?: { timeout?: number; env?: Record<string, string> }): Promise<string>;
+}
+
+/** Minimal device-lookup interface the UI-controller functions depend on. */
+export interface UiControllerDeviceLookup {
+  getDevice(deviceId: string): Promise<SimulatorDevice | null>;
+}
+
+export interface RotationResult {
+  success: boolean;
+  method: 'simctl' | 'applescript' | 'none';
+  orientation?: string;
+}
+
+/**
+ * Capture a screenshot of a booted simulator.
+ * Writes to a temp file via `simctl io screenshot`, reads the buffer, then cleans up.
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function screenshot(
+  deviceId: string,
+  options: { format?: 'png' | 'jpeg' } | undefined,
+  deps: { simctl: UiControllerSimctl; lookup: UiControllerDeviceLookup },
+): Promise<Buffer> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+
+  const format = options?.format ?? 'png';
+  const tmpFile = path.join(os.tmpdir(), `opensafari-screenshot-${randomUUID()}.${format}`);
+
+  try {
+    await deps.simctl.exec(
+      ['io', deviceId, 'screenshot', `--type=${format}`, tmpFile],
+      { timeout: DEFAULT_SCREENSHOT_TIMEOUT_MS },
+    );
+    const buffer = await fs.readFile(tmpFile);
+    return buffer;
+  } finally {
+    await fs.unlink(tmpFile).catch(() => {});
+  }
+}
+
+/**
+ * Capture a screenshot and return it as a base64-encoded string.
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function screenshotBase64(
+  deviceId: string,
+  options: { format?: 'png' | 'jpeg' } | undefined,
+  deps: { simctl: UiControllerSimctl; lookup: UiControllerDeviceLookup },
+): Promise<string> {
+  const buf = await screenshot(deviceId, options, deps);
+  return buf.toString('base64');
+}
+
+/**
+ * Set the appearance (light/dark mode) of a booted simulator.
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function setAppearance(
+  deviceId: string,
+  mode: 'light' | 'dark',
+  deps: { simctl: UiControllerSimctl; lookup: UiControllerDeviceLookup },
+): Promise<void> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+  await deps.simctl.exec(['ui', deviceId, 'appearance', mode]);
+}
+
+/**
+ * Get the current appearance (light/dark mode) of a booted simulator.
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function getAppearance(
+  deviceId: string,
+  deps: { simctl: UiControllerSimctl; lookup: UiControllerDeviceLookup },
+): Promise<'light' | 'dark'> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+  const output = await deps.simctl.exec(['ui', deviceId, 'appearance']);
+  return output.trim().toLowerCase() === 'dark' ? 'dark' : 'light';
+}
+
+/**
+ * Toggle the appearance between light and dark.
+ * Returns the new appearance value.
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function toggleAppearance(
+  deviceId: string,
+  deps: { simctl: UiControllerSimctl; lookup: UiControllerDeviceLookup },
+): Promise<'light' | 'dark'> {
+  const current = await getAppearance(deviceId, deps);
+  const next = current === 'light' ? 'dark' : 'light';
+  await setAppearance(deviceId, next, deps);
+  return next;
+}
+
+/**
+ * Rotate a booted simulator.
+ * Method A: `simctl io setorientation` (works in headless/CI).
+ * Method B: AppleScript (requires Simulator.app GUI).
+ * Returns a RotationResult describing which method succeeded (or 'none').
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function rotate(
+  deviceId: string,
+  direction: 'left' | 'right',
+  deps: { simctl: UiControllerSimctl; lookup: UiControllerDeviceLookup },
+): Promise<RotationResult> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+
+  const orientation = direction === 'left' ? 'landscapeLeft' : 'landscapeRight';
+
+  // Try simctl first (works in headless/CI)
+  try {
+    const execFileAsync = promisify(execFile);
+    await execFileAsync('xcrun', ['simctl', 'io', deviceId, 'setorientation', orientation], { timeout: 10000 });
+    return { success: true, method: 'simctl', orientation };
+  } catch {
+    console.error('[UiController] simctl setorientation not available, trying AppleScript');
+  }
+
+  // Fallback to AppleScript (requires GUI)
+  try {
+    const execFileAsync = promisify(execFile);
+    const menuItem = direction === 'left' ? 'Rotate Left' : 'Rotate Right';
+    await execFileAsync('osascript', [
+      '-e', 'tell application "Simulator" to activate',
+      '-e', 'delay 0.5',
+      '-e', `tell application "System Events" to tell process "Simulator" to click menu item "${menuItem}" of menu "Device" of menu bar 1`,
+    ], { timeout: 10000 });
+    return { success: true, method: 'applescript', orientation };
+  } catch {
+    console.error('[UiController] Rotation via AppleScript also failed — no rotation method available');
+  }
+
+  return { success: false, method: 'none' };
+}
+
+/**
+ * Override the status bar to deterministic values (useful for screenshots).
+ * Sets: time=9:41, batteryLevel=100, cellularBars=4.
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function overrideStatusBar(
+  deviceId: string,
+  deps: { simctl: UiControllerSimctl; lookup: UiControllerDeviceLookup },
+): Promise<void> {
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+  await deps.simctl.exec([
+    'status_bar', deviceId, 'override',
+    '--time', '9:41',
+    '--batteryLevel', '100',
+    '--cellularBars', '4',
+  ]);
+}
+
+/**
+ * Open a URL in Safari on a booted simulator.
+ * Validates the URL, checks the device is booted, then calls `simctl openurl`.
+ * Waits briefly for Safari to start processing.
+ * Throws an Error for invalid URLs.
+ * Throws DeviceNotBootedError if the device is not booted.
+ */
+export async function openUrl(
+  deviceId: string,
+  url: string,
+  deps: { simctl: UiControllerSimctl; lookup: UiControllerDeviceLookup },
+): Promise<void> {
+  try {
+    new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  const device = await deps.lookup.getDevice(deviceId);
+  if (!device || device.state !== 'Booted') {
+    throw new DeviceNotBootedError(deviceId);
+  }
+
+  await deps.simctl.exec(['openurl', deviceId, url]);
+  // Brief wait for Safari to start processing
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/unit/rotation-fallback.test.ts
+++ b/tests/unit/rotation-fallback.test.ts
@@ -86,9 +86,9 @@ describe('SimulatorManager.rotate()', () => {
   });
 
   it('should return RotationResult with correct fields on simctl success', async () => {
-    // Mock execFile to succeed on first call (simctl)
-    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null) => void) => {
-      if (cb) cb(null);
+    // SimctlExecutor.exec() uses promisify(execFile) which requires cb(null, { stdout, stderr })
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void) => {
+      if (cb) cb(null, { stdout: '', stderr: '' });
     });
 
     const result = await manager.rotate('test-device-id', 'left');
@@ -101,27 +101,27 @@ describe('SimulatorManager.rotate()', () => {
 
   it('should try simctl before AppleScript', async () => {
     const calls: string[] = [];
-    mockExecFile.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null) => void) => {
+    mockExecFile.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void) => {
       calls.push(cmd);
-      if (cb) cb(null);
+      if (cb) cb(null, { stdout: '', stderr: '' });
     });
 
     await manager.rotate('test-device-id', 'left');
 
-    // simctl is called via xcrun, which should be the first call
+    // simctl is called via SimctlExecutor which uses xcrun
     expect(calls[0]).toBe('xcrun');
   });
 
   it('should fall back to AppleScript when simctl fails', async () => {
     let callCount = 0;
-    mockExecFile.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null) => void) => {
+    mockExecFile.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void) => {
       callCount++;
       if (callCount === 1) {
-        // simctl fails
+        // simctl (xcrun) fails
         if (cb) cb(new Error('simctl setorientation not supported'));
       } else {
-        // AppleScript succeeds
-        if (cb) cb(null);
+        // AppleScript (osascript) succeeds
+        if (cb) cb(null, { stdout: '', stderr: '' });
       }
     });
 
@@ -148,31 +148,33 @@ describe('SimulatorManager.rotate()', () => {
 
   it('should use landscapeLeft for direction "left"', async () => {
     let capturedArgs: string[] = [];
-    mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: unknown, cb?: (err: Error | null) => void) => {
+    mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: unknown, cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void) => {
       capturedArgs = args;
-      if (cb) cb(null);
+      if (cb) cb(null, { stdout: '', stderr: '' });
     });
 
     const result = await manager.rotate('test-device-id', 'left');
     expect(result.orientation).toBe('landscapeLeft');
+    // SimctlExecutor wraps args as ['simctl', 'io', deviceId, 'setorientation', orientation]
     expect(capturedArgs).toContain('landscapeLeft');
   });
 
   it('should use landscapeRight for direction "right"', async () => {
     let capturedArgs: string[] = [];
-    mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: unknown, cb?: (err: Error | null) => void) => {
+    mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: unknown, cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void) => {
       capturedArgs = args;
-      if (cb) cb(null);
+      if (cb) cb(null, { stdout: '', stderr: '' });
     });
 
     const result = await manager.rotate('test-device-id', 'right');
     expect(result.orientation).toBe('landscapeRight');
+    // SimctlExecutor wraps args as ['simctl', 'io', deviceId, 'setorientation', orientation]
     expect(capturedArgs).toContain('landscapeRight');
   });
 
   it('should default direction to "left"', async () => {
-    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null) => void) => {
-      if (cb) cb(null);
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void) => {
+      if (cb) cb(null, { stdout: '', stderr: '' });
     });
 
     const result = await manager.rotate('test-device-id');

--- a/tests/unit/simulator-app-manager.test.ts
+++ b/tests/unit/simulator-app-manager.test.ts
@@ -231,9 +231,19 @@ describe('app-manager.terminateApp', () => {
     expect(simctl.exec).not.toHaveBeenCalled();
   });
 
-  it('throws AppNotInstalledError when bundle not found', async () => {
+  it('throws AppNotInstalledError when bundle not found (domain not found)', async () => {
     const simctl = makeSimctl(async () => {
       throw new SimctlError('simctl terminate failed: domain not found', ['terminate'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(terminateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(AppNotInstalledError);
+  });
+
+  it('throws AppNotInstalledError when bundle not found (not installed)', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl terminate failed: not installed', ['terminate'], 1);
     });
     const lookup = makeLookup(makeDevice());
 
@@ -273,9 +283,19 @@ describe('app-manager.activateApp', () => {
       .rejects.toThrow(DeviceNotBootedError);
   });
 
-  it('throws AppNotInstalledError when bundle not found', async () => {
+  it('throws AppNotInstalledError when bundle not found (domain not found)', async () => {
     const simctl = makeSimctl(async () => {
       throw new SimctlError('simctl launch failed: domain not found', ['launch'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(activateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(AppNotInstalledError);
+  });
+
+  it('throws AppNotInstalledError when bundle not found (not installed)', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl launch failed: not installed', ['launch'], 1);
     });
     const lookup = makeLookup(makeDevice());
 
@@ -315,6 +335,22 @@ describe('app-manager.listRunningApps', () => {
       { label: 'com.example.app2', pid: 102 },
     ]);
     expect(simctl.exec).toHaveBeenCalledWith(['spawn', DEVICE_ID, 'launchctl', 'list']);
+  });
+
+  it('strips bracketed suffix with non-greedy match (e.g. bundle[0x1][extra])', async () => {
+    // A label containing multiple bracket groups — non-greedy /\[[^\]]*\]$/ strips only
+    // the trailing bracket group, leaving the bundle id intact.
+    const launchctlOutput = [
+      'PID\tSTATUS\tLABEL',
+      '200\t0\tUIKitApplication:com.example.tricky[0x1]',
+    ].join('\n');
+
+    const simctl = makeSimctl(async () => launchctlOutput);
+    const lookup = makeLookup(makeDevice());
+
+    const result = await listRunningApps(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toEqual([{ label: 'com.example.tricky', pid: 200 }]);
   });
 
   it('returns empty array when no UIKitApplication entries', async () => {

--- a/tests/unit/simulator-app-manager.test.ts
+++ b/tests/unit/simulator-app-manager.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Unit tests for src/simulator/app-manager.ts — #708 step 4.
+ *
+ * Covers:
+ *   - launchApp happy path
+ *   - launchApp passes args and env
+ *   - launchApp DeviceNotBootedError for shutdown device
+ *   - launchApp AppNotInstalledError surfaces
+ *   - launchApp AppLaunchError surfaces for other failures
+ *   - terminateApp happy path
+ *   - terminateApp returns terminated:false when not running
+ *   - terminateApp DeviceNotBootedError for shutdown device
+ *   - terminateApp AppNotInstalledError surfaces
+ *   - activateApp happy path
+ *   - activateApp AppNotInstalledError surfaces
+ *   - listRunningApps parses UIKitApplication entries
+ *   - resetApp happy path (terminate + privacy + uninstall)
+ *   - resetApp AppNotInstalledError when uninstall fails with domain not found
+ */
+
+import {
+  launchApp,
+  terminateApp,
+  activateApp,
+  listRunningApps,
+  resetApp,
+} from '../../src/simulator/app-manager';
+import { AppNotInstalledError, AppLaunchError, DeviceNotBootedError } from '../../src/simulator/errors';
+import { SimctlError } from '../../src/simulator/simctl';
+import { SimulatorDevice } from '../../src/simulator/types';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const DEVICE_ID = '11111111-1111-1111-1111-111111111111';
+const BUNDLE_ID = 'com.example.testapp';
+
+function makeDevice(overrides: Partial<SimulatorDevice> = {}): SimulatorDevice {
+  return {
+    udid: DEVICE_ID,
+    name: 'iPhone Test',
+    state: 'Booted',
+    isAvailable: true,
+    runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-18-0',
+    runtimeVersion: '18.0',
+    ...overrides,
+  };
+}
+
+function makeSimctl(execImpl?: (args: string[], options?: unknown) => Promise<string>) {
+  const calls: Array<{ args: string[]; options?: unknown }> = [];
+  const exec = jest.fn(async (args: string[], options?: unknown) => {
+    calls.push({ args, options });
+    return execImpl ? execImpl(args, options) : '';
+  });
+  return { exec, calls };
+}
+
+function makeLookup(device: SimulatorDevice | null) {
+  return {
+    getDevice: jest.fn(async () => device),
+  };
+}
+
+// ── launchApp ────────────────────────────────────────────────────────────────
+
+describe('app-manager.launchApp', () => {
+  it('launches app and returns pid', async () => {
+    const simctl = makeSimctl(async () => `${BUNDLE_ID}: 12345\n`);
+    const lookup = makeLookup(makeDevice());
+
+    const result = await launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup });
+
+    expect(result).toEqual({ pid: 12345, bundleId: BUNDLE_ID, deviceId: DEVICE_ID });
+    expect(simctl.exec).toHaveBeenCalledWith(
+      ['launch', DEVICE_ID, BUNDLE_ID],
+      expect.objectContaining({}),
+    );
+  });
+
+  it('returns pid -1 when output has no pid match', async () => {
+    const simctl = makeSimctl(async () => 'no pid here\n');
+    const lookup = makeLookup(makeDevice());
+
+    const result = await launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup });
+
+    expect(result.pid).toBe(-1);
+  });
+
+  it('passes launch arguments', async () => {
+    const simctl = makeSimctl(async () => `${BUNDLE_ID}: 99\n`);
+    const lookup = makeLookup(makeDevice());
+
+    await launchApp(DEVICE_ID, BUNDLE_ID, { args: ['--reset', '--verbose'] }, { simctl, lookup });
+
+    expect(simctl.exec).toHaveBeenCalledWith(
+      ['launch', DEVICE_ID, BUNDLE_ID, '--reset', '--verbose'],
+      expect.objectContaining({}),
+    );
+  });
+
+  it('passes environment variables via SIMCTL_CHILD_ prefix', async () => {
+    const simctl = makeSimctl(async () => `${BUNDLE_ID}: 99\n`);
+    const lookup = makeLookup(makeDevice());
+
+    await launchApp(DEVICE_ID, BUNDLE_ID, { env: { DEBUG: '1', FOO: 'bar' } }, { simctl, lookup });
+
+    expect(simctl.exec).toHaveBeenCalledWith(
+      ['launch', DEVICE_ID, BUNDLE_ID],
+      expect.objectContaining({ env: { SIMCTL_CHILD_DEBUG: '1', SIMCTL_CHILD_FOO: 'bar' } }),
+    );
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+    expect(simctl.exec).not.toHaveBeenCalled();
+  });
+
+  it('throws DeviceNotBootedError when device is null', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(null);
+
+    await expect(launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+  });
+
+  it('throws AppNotInstalledError when simctl reports domain not found', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl launch failed: domain not found', ['launch'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup }))
+      .rejects.toThrow(AppNotInstalledError);
+  });
+
+  it('throws AppNotInstalledError when simctl reports not installed', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl launch failed: not installed', ['launch'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup }))
+      .rejects.toThrow(AppNotInstalledError);
+  });
+
+  it('throws AppLaunchError for other SimctlError failures', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl launch failed: crash', ['launch'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup }))
+      .rejects.toThrow(AppLaunchError);
+  });
+
+  it('throws AppLaunchError for generic errors', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new Error('unexpected error');
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup }))
+      .rejects.toThrow(AppLaunchError);
+  });
+
+  it('AppLaunchError carries bundleId, deviceId, and reason', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new Error('something went wrong');
+    });
+    const lookup = makeLookup(makeDevice());
+
+    let caught: AppLaunchError | undefined;
+    try {
+      await launchApp(DEVICE_ID, BUNDLE_ID, undefined, { simctl, lookup });
+    } catch (e) {
+      caught = e as AppLaunchError;
+    }
+
+    expect(caught).toBeInstanceOf(AppLaunchError);
+    expect(caught?.bundleId).toBe(BUNDLE_ID);
+    expect(caught?.deviceId).toBe(DEVICE_ID);
+    expect(caught?.reason).toContain('something went wrong');
+  });
+});
+
+// ── terminateApp ──────────────────────────────────────────────────────────────
+
+describe('app-manager.terminateApp', () => {
+  it('terminates running app and returns terminated:true', async () => {
+    const simctl = makeSimctl(async () => '');
+    const lookup = makeLookup(makeDevice());
+
+    const result = await terminateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup });
+
+    expect(result).toEqual({ terminated: true, bundleId: BUNDLE_ID, deviceId: DEVICE_ID });
+    expect(simctl.exec).toHaveBeenCalledWith(['terminate', DEVICE_ID, BUNDLE_ID]);
+  });
+
+  it('returns terminated:false when app is not running', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl terminate failed: not running', ['terminate'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    const result = await terminateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup });
+
+    expect(result).toEqual({ terminated: false, bundleId: BUNDLE_ID, deviceId: DEVICE_ID });
+  });
+
+  it('returns terminated:false for Failed to terminate message', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('Failed to terminate process', ['terminate'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    const result = await terminateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup });
+
+    expect(result.terminated).toBe(false);
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(terminateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+    expect(simctl.exec).not.toHaveBeenCalled();
+  });
+
+  it('throws AppNotInstalledError when bundle not found', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl terminate failed: domain not found', ['terminate'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(terminateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(AppNotInstalledError);
+  });
+
+  it('rethrows non-SimctlError errors', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new Error('network error');
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(terminateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow('network error');
+  });
+});
+
+// ── activateApp ───────────────────────────────────────────────────────────────
+
+describe('app-manager.activateApp', () => {
+  it('activates app and returns pid', async () => {
+    const simctl = makeSimctl(async () => `${BUNDLE_ID}: 42\n`);
+    const lookup = makeLookup(makeDevice());
+
+    const result = await activateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup });
+
+    expect(result).toEqual({ activated: true, bundleId: BUNDLE_ID, deviceId: DEVICE_ID, pid: 42 });
+    expect(simctl.exec).toHaveBeenCalledWith(['launch', DEVICE_ID, BUNDLE_ID]);
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(activateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+  });
+
+  it('throws AppNotInstalledError when bundle not found', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl launch failed: domain not found', ['launch'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(activateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(AppNotInstalledError);
+  });
+
+  it('rethrows other SimctlErrors', async () => {
+    const simctl = makeSimctl(async () => {
+      throw new SimctlError('simctl launch failed: crash', ['launch'], 1);
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(activateApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(SimctlError);
+  });
+});
+
+// ── listRunningApps ───────────────────────────────────────────────────────────
+
+describe('app-manager.listRunningApps', () => {
+  it('parses UIKitApplication entries from launchctl list', async () => {
+    const launchctlOutput = [
+      'PID\tSTATUS\tLABEL',
+      '101\t0\tUIKitApplication:com.example.app1[0x1]',
+      '102\t0\tUIKitApplication:com.example.app2[0x2]',
+      '-\t0\tcom.apple.springboard',
+    ].join('\n');
+
+    const simctl = makeSimctl(async () => launchctlOutput);
+    const lookup = makeLookup(makeDevice());
+
+    const result = await listRunningApps(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toEqual([
+      { label: 'com.example.app1', pid: 101 },
+      { label: 'com.example.app2', pid: 102 },
+    ]);
+    expect(simctl.exec).toHaveBeenCalledWith(['spawn', DEVICE_ID, 'launchctl', 'list']);
+  });
+
+  it('returns empty array when no UIKitApplication entries', async () => {
+    const simctl = makeSimctl(async () => 'PID\tSTATUS\tLABEL\n-\t0\tcom.apple.springboard\n');
+    const lookup = makeLookup(makeDevice());
+
+    const result = await listRunningApps(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toEqual([]);
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(listRunningApps(DEVICE_ID, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+  });
+});
+
+// ── resetApp ──────────────────────────────────────────────────────────────────
+
+describe('app-manager.resetApp', () => {
+  it('runs terminate, privacy reset, and uninstall in order', async () => {
+    const calls: string[][] = [];
+    const simctl = makeSimctl(async (args) => {
+      calls.push(args);
+      return '';
+    });
+    const lookup = makeLookup(makeDevice());
+
+    const result = await resetApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup });
+
+    expect(result.reset).toBe(true);
+    expect(result.bundleId).toBe(BUNDLE_ID);
+    expect(result.deviceId).toBe(DEVICE_ID);
+    expect(result.steps).toEqual(['terminated', 'privacy_reset', 'uninstalled']);
+    expect(calls[0]).toEqual(['terminate', DEVICE_ID, BUNDLE_ID]);
+    expect(calls[1]).toEqual(['privacy', DEVICE_ID, 'reset', 'all', BUNDLE_ID]);
+    expect(calls[2]).toEqual(['uninstall', DEVICE_ID, BUNDLE_ID]);
+  });
+
+  it('records terminate_skipped when terminate fails', async () => {
+    let callCount = 0;
+    const simctl = makeSimctl(async (_args) => {
+      callCount++;
+      if (callCount === 1) throw new Error('not running');
+      return '';
+    });
+    const lookup = makeLookup(makeDevice());
+
+    const result = await resetApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup });
+
+    expect(result.steps[0]).toBe('terminate_skipped');
+    expect(result.steps[1]).toBe('privacy_reset');
+    expect(result.steps[2]).toBe('uninstalled');
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(resetApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+  });
+
+  it('throws AppNotInstalledError when uninstall reports domain not found', async () => {
+    let callCount = 0;
+    const simctl = makeSimctl(async (_args) => {
+      callCount++;
+      // terminate and privacy succeed, uninstall fails with domain not found
+      if (callCount === 3) {
+        throw new SimctlError('simctl uninstall failed: domain not found', ['uninstall'], 1);
+      }
+      return '';
+    });
+    const lookup = makeLookup(makeDevice());
+
+    await expect(resetApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup }))
+      .rejects.toThrow(AppNotInstalledError);
+  });
+
+  it('records uninstall_failed for non-AppNotInstalled uninstall errors', async () => {
+    let callCount = 0;
+    const simctl = makeSimctl(async (_args) => {
+      callCount++;
+      if (callCount === 3) throw new SimctlError('uninstall crashed', ['uninstall'], 1);
+      return '';
+    });
+    const lookup = makeLookup(makeDevice());
+
+    const result = await resetApp(DEVICE_ID, BUNDLE_ID, { simctl, lookup });
+
+    expect(result.steps[2]).toBe('uninstall_failed');
+  });
+});

--- a/tests/unit/simulator-app-manager.test.ts
+++ b/tests/unit/simulator-app-manager.test.ts
@@ -337,9 +337,7 @@ describe('app-manager.listRunningApps', () => {
     expect(simctl.exec).toHaveBeenCalledWith(['spawn', DEVICE_ID, 'launchctl', 'list']);
   });
 
-  it('strips bracketed suffix with non-greedy match (e.g. bundle[0x1][extra])', async () => {
-    // A label containing multiple bracket groups — non-greedy /\[[^\]]*\]$/ strips only
-    // the trailing bracket group, leaving the bundle id intact.
+  it('strips a single trailing bracket group from bundle labels', async () => {
     const launchctlOutput = [
       'PID\tSTATUS\tLABEL',
       '200\t0\tUIKitApplication:com.example.tricky[0x1]',
@@ -351,6 +349,23 @@ describe('app-manager.listRunningApps', () => {
     const result = await listRunningApps(DEVICE_ID, { simctl, lookup });
 
     expect(result).toEqual([{ label: 'com.example.tricky', pid: 200 }]);
+  });
+
+  it('strips all trailing bracket groups (multi-suffix labels)', async () => {
+    // launchctl can emit labels with multiple trailing bracket groups, e.g.
+    // UIKitApplication:com.example.app[0x1][debug]. We must strip them all so
+    // downstream bundle-id comparisons (classifyMobileContext) match cleanly.
+    const launchctlOutput = [
+      'PID\tSTATUS\tLABEL',
+      '300\t0\tUIKitApplication:com.example.app[0x1][debug]',
+    ].join('\n');
+
+    const simctl = makeSimctl(async () => launchctlOutput);
+    const lookup = makeLookup(makeDevice());
+
+    const result = await listRunningApps(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toEqual([{ label: 'com.example.app', pid: 300 }]);
   });
 
   it('returns empty array when no UIKitApplication entries', async () => {

--- a/tests/unit/simulator-ui-controller.test.ts
+++ b/tests/unit/simulator-ui-controller.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Unit tests for src/simulator/ui-controller.ts — #708 step 5.
+ *
+ * Covers:
+ *   - screenshot happy path
+ *   - screenshot timeout/retry (DeviceNotBootedError for unbooted device)
+ *   - screenshot uses DEFAULT_SCREENSHOT_TIMEOUT_MS
+ *   - screenshotBase64 returns base64-encoded result
+ *   - setAppearance happy path
+ *   - getAppearance returns 'light' or 'dark'
+ *   - toggleAppearance flips current mode
+ *   - rotate happy path (simctl method)
+ *   - rotate fallback to 'none' when both methods fail
+ *   - overrideStatusBar happy path
+ *   - openUrl happy path
+ *   - openUrl throws for invalid URL
+ *   - DeviceNotBootedError thrown for unbooted device across all functions
+ */
+
+const readFileMock = jest.fn();
+const unlinkMock = jest.fn();
+
+jest.mock('fs/promises', () => {
+  const actual = jest.requireActual('fs/promises');
+  return {
+    ...actual,
+    readFile: (...args: unknown[]) => readFileMock(...args),
+    unlink: (...args: unknown[]) => unlinkMock(...args),
+  };
+});
+
+// Mock execFile used by rotate()
+const execFileMock = jest.fn();
+jest.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+import {
+  screenshot,
+  screenshotBase64,
+  setAppearance,
+  getAppearance,
+  toggleAppearance,
+  rotate,
+  overrideStatusBar,
+  openUrl,
+} from '../../src/simulator/ui-controller';
+import { DeviceNotBootedError } from '../../src/simulator/errors';
+import { SimulatorDevice } from '../../src/simulator/types';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const DEVICE_ID = '22222222-2222-2222-2222-222222222222';
+
+function makeDevice(overrides: Partial<SimulatorDevice> = {}): SimulatorDevice {
+  return {
+    udid: DEVICE_ID,
+    name: 'iPhone UI Test',
+    state: 'Booted',
+    isAvailable: true,
+    runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-18-0',
+    runtimeVersion: '18.0',
+    ...overrides,
+  };
+}
+
+function makeSimctl(execImpl?: (args: string[], options?: unknown) => Promise<string>) {
+  const exec = jest.fn(async (args: string[], options?: unknown) => {
+    return execImpl ? execImpl(args, options) : '';
+  });
+  return { exec };
+}
+
+function makeLookup(device: SimulatorDevice | null) {
+  return {
+    getDevice: jest.fn(async () => device),
+  };
+}
+
+// ── screenshot ────────────────────────────────────────────────────────────────
+
+describe('ui-controller.screenshot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    readFileMock.mockResolvedValue(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    unlinkMock.mockResolvedValue(undefined);
+  });
+
+  it('captures screenshot and returns buffer', async () => {
+    const simctl = makeSimctl(async () => '');
+    const lookup = makeLookup(makeDevice());
+
+    const buf = await screenshot(DEVICE_ID, undefined, { simctl, lookup });
+
+    expect(buf).toBeInstanceOf(Buffer);
+    expect(simctl.exec).toHaveBeenCalledWith(
+      expect.arrayContaining(['io', DEVICE_ID, 'screenshot', '--type=png']),
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+    expect(unlinkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses jpeg format when specified', async () => {
+    const simctl = makeSimctl(async () => '');
+    const lookup = makeLookup(makeDevice());
+
+    await screenshot(DEVICE_ID, { format: 'jpeg' }, { simctl, lookup });
+
+    expect(simctl.exec).toHaveBeenCalledWith(
+      expect.arrayContaining(['--type=jpeg']),
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it('cleans up temp file even when readFile throws', async () => {
+    const simctl = makeSimctl(async () => '');
+    const lookup = makeLookup(makeDevice());
+    readFileMock.mockRejectedValue(new Error('read failed'));
+
+    await expect(screenshot(DEVICE_ID, undefined, { simctl, lookup })).rejects.toThrow('read failed');
+    expect(unlinkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(screenshot(DEVICE_ID, undefined, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+    expect(simctl.exec).not.toHaveBeenCalled();
+  });
+
+  it('throws DeviceNotBootedError when device is null', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(null);
+
+    await expect(screenshot(DEVICE_ID, undefined, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+  });
+});
+
+// ── screenshotBase64 ──────────────────────────────────────────────────────────
+
+describe('ui-controller.screenshotBase64', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    readFileMock.mockResolvedValue(Buffer.from('test-image-data'));
+    unlinkMock.mockResolvedValue(undefined);
+  });
+
+  it('returns base64-encoded screenshot', async () => {
+    const simctl = makeSimctl(async () => '');
+    const lookup = makeLookup(makeDevice());
+
+    const result = await screenshotBase64(DEVICE_ID, undefined, { simctl, lookup });
+
+    expect(typeof result).toBe('string');
+    expect(Buffer.from(result, 'base64').toString()).toBe('test-image-data');
+  });
+});
+
+// ── setAppearance ─────────────────────────────────────────────────────────────
+
+describe('ui-controller.setAppearance', () => {
+  it('sets dark mode via simctl ui appearance', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice());
+
+    await setAppearance(DEVICE_ID, 'dark', { simctl, lookup });
+
+    expect(simctl.exec).toHaveBeenCalledWith(['ui', DEVICE_ID, 'appearance', 'dark']);
+  });
+
+  it('sets light mode via simctl ui appearance', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice());
+
+    await setAppearance(DEVICE_ID, 'light', { simctl, lookup });
+
+    expect(simctl.exec).toHaveBeenCalledWith(['ui', DEVICE_ID, 'appearance', 'light']);
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(setAppearance(DEVICE_ID, 'dark', { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+    expect(simctl.exec).not.toHaveBeenCalled();
+  });
+});
+
+// ── getAppearance ─────────────────────────────────────────────────────────────
+
+describe('ui-controller.getAppearance', () => {
+  it('returns "dark" when simctl output is "Dark"', async () => {
+    const simctl = makeSimctl(async () => 'Dark\n');
+    const lookup = makeLookup(makeDevice());
+
+    const result = await getAppearance(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toBe('dark');
+  });
+
+  it('returns "light" when simctl output is "Light"', async () => {
+    const simctl = makeSimctl(async () => 'Light\n');
+    const lookup = makeLookup(makeDevice());
+
+    const result = await getAppearance(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toBe('light');
+  });
+
+  it('returns "light" for unknown output', async () => {
+    const simctl = makeSimctl(async () => 'unknown\n');
+    const lookup = makeLookup(makeDevice());
+
+    const result = await getAppearance(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toBe('light');
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(getAppearance(DEVICE_ID, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+  });
+});
+
+// ── toggleAppearance ──────────────────────────────────────────────────────────
+
+describe('ui-controller.toggleAppearance', () => {
+  it('toggles from light to dark', async () => {
+    let callCount = 0;
+    const simctl = makeSimctl(async (args) => {
+      callCount++;
+      // First call: getAppearance — return Light
+      if (callCount === 1 && args[2] === 'appearance' && args.length === 3) return 'Light\n';
+      // Second call: setAppearance to dark
+      return '';
+    });
+    const lookup = makeLookup(makeDevice());
+
+    const result = await toggleAppearance(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toBe('dark');
+    expect(simctl.exec).toHaveBeenCalledTimes(2);
+  });
+
+  it('toggles from dark to light', async () => {
+    let callCount = 0;
+    const simctl = makeSimctl(async (args) => {
+      callCount++;
+      if (callCount === 1 && args[2] === 'appearance' && args.length === 3) return 'Dark\n';
+      return '';
+    });
+    const lookup = makeLookup(makeDevice());
+
+    const result = await toggleAppearance(DEVICE_ID, { simctl, lookup });
+
+    expect(result).toBe('light');
+  });
+});
+
+// ── rotate ────────────────────────────────────────────────────────────────────
+
+describe('ui-controller.rotate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: execFile calls the callback with success
+    execFileMock.mockImplementation(
+      (_cmd: unknown, _args: unknown, _opts: unknown, callback: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        callback(null, { stdout: '', stderr: '' });
+      },
+    );
+  });
+
+  it('returns simctl method on success', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice());
+
+    const result = await rotate(DEVICE_ID, 'left', { simctl, lookup });
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe('simctl');
+    expect(result.orientation).toBe('landscapeLeft');
+  });
+
+  it('uses landscapeRight for direction=right', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice());
+
+    const result = await rotate(DEVICE_ID, 'right', { simctl, lookup });
+
+    expect(result.success).toBe(true);
+    expect(result.orientation).toBe('landscapeRight');
+  });
+
+  it('returns none when both simctl and AppleScript fail', async () => {
+    execFileMock.mockImplementation(
+      (_cmd: unknown, _args: unknown, _opts: unknown, callback: (err: Error) => void) => {
+        callback(new Error('command not found'));
+      },
+    );
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice());
+
+    const result = await rotate(DEVICE_ID, 'left', { simctl, lookup });
+
+    expect(result.success).toBe(false);
+    expect(result.method).toBe('none');
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(rotate(DEVICE_ID, 'left', { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+  });
+});
+
+// ── overrideStatusBar ─────────────────────────────────────────────────────────
+
+describe('ui-controller.overrideStatusBar', () => {
+  it('calls simctl status_bar override with deterministic values', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice());
+
+    await overrideStatusBar(DEVICE_ID, { simctl, lookup });
+
+    expect(simctl.exec).toHaveBeenCalledWith([
+      'status_bar', DEVICE_ID, 'override',
+      '--time', '9:41',
+      '--batteryLevel', '100',
+      '--cellularBars', '4',
+    ]);
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(overrideStatusBar(DEVICE_ID, { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+    expect(simctl.exec).not.toHaveBeenCalled();
+  });
+});
+
+// ── openUrl ───────────────────────────────────────────────────────────────────
+
+describe('ui-controller.openUrl', () => {
+  it('calls simctl openurl for valid URL', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice());
+
+    await openUrl(DEVICE_ID, 'https://example.com', { simctl, lookup });
+
+    expect(simctl.exec).toHaveBeenCalledWith(['openurl', DEVICE_ID, 'https://example.com']);
+  });
+
+  it('throws for invalid URL', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice());
+
+    await expect(openUrl(DEVICE_ID, 'not-a-url', { simctl, lookup }))
+      .rejects.toThrow('Invalid URL: not-a-url');
+    expect(simctl.exec).not.toHaveBeenCalled();
+  });
+
+  it('throws DeviceNotBootedError for shutdown device', async () => {
+    const simctl = makeSimctl();
+    const lookup = makeLookup(makeDevice({ state: 'Shutdown' }));
+
+    await expect(openUrl(DEVICE_ID, 'https://example.com', { simctl, lookup }))
+      .rejects.toThrow(DeviceNotBootedError);
+    expect(simctl.exec).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/simulator-ui-controller.test.ts
+++ b/tests/unit/simulator-ui-controller.test.ts
@@ -270,7 +270,7 @@ describe('ui-controller.toggleAppearance', () => {
 describe('ui-controller.rotate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Default: execFile calls the callback with success
+    // Default: execFile (used by AppleScript path) calls the callback with success
     execFileMock.mockImplementation(
       (_cmd: unknown, _args: unknown, _opts: unknown, callback: (err: null, result: { stdout: string; stderr: string }) => void) => {
         callback(null, { stdout: '', stderr: '' });
@@ -279,6 +279,7 @@ describe('ui-controller.rotate', () => {
   });
 
   it('returns simctl method on success', async () => {
+    // simctl.exec succeeds by default (makeSimctl returns '')
     const simctl = makeSimctl();
     const lookup = makeLookup(makeDevice());
 
@@ -287,6 +288,10 @@ describe('ui-controller.rotate', () => {
     expect(result.success).toBe(true);
     expect(result.method).toBe('simctl');
     expect(result.orientation).toBe('landscapeLeft');
+    expect(simctl.exec).toHaveBeenCalledWith(
+      ['io', DEVICE_ID, 'setorientation', 'landscapeLeft'],
+      { timeout: 10000 },
+    );
   });
 
   it('uses landscapeRight for direction=right', async () => {
@@ -297,21 +302,39 @@ describe('ui-controller.rotate', () => {
 
     expect(result.success).toBe(true);
     expect(result.orientation).toBe('landscapeRight');
+    expect(simctl.exec).toHaveBeenCalledWith(
+      ['io', DEVICE_ID, 'setorientation', 'landscapeRight'],
+      { timeout: 10000 },
+    );
   });
 
   it('returns none when both simctl and AppleScript fail', async () => {
+    // simctl path fails via deps.simctl.exec throwing
+    const simctl = makeSimctl(async () => { throw new Error('command not found'); });
+    // AppleScript path fails via execFile callback
     execFileMock.mockImplementation(
       (_cmd: unknown, _args: unknown, _opts: unknown, callback: (err: Error) => void) => {
         callback(new Error('command not found'));
       },
     );
-    const simctl = makeSimctl();
     const lookup = makeLookup(makeDevice());
 
     const result = await rotate(DEVICE_ID, 'left', { simctl, lookup });
 
     expect(result.success).toBe(false);
     expect(result.method).toBe('none');
+  });
+
+  it('falls back to AppleScript when simctl fails', async () => {
+    // simctl path fails, AppleScript succeeds
+    const simctl = makeSimctl(async () => { throw new Error('simctl setorientation not supported'); });
+    const lookup = makeLookup(makeDevice());
+
+    const result = await rotate(DEVICE_ID, 'left', { simctl, lookup });
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe('applescript');
+    expect(result.orientation).toBe('landscapeLeft');
   });
 
   it('throws DeviceNotBootedError for shutdown device', async () => {


### PR DESCRIPTION
**Stacked on PR #740** (chain: #738 → #740 → this). Will retarget to develop after upstream chain merges.

Implements #708 step 4. Behavior-preserving. Final follow-up: ui-controller + facade.
Does not Close — multi-PR refactor.