### PR TITLE
Avoid busy-spin waits in zombie cleanup lock

### DIFF
--- a/src/reliability/zombie-cleanup.ts
+++ b/src/reliability/zombie-cleanup.ts
@@ -12,6 +12,14 @@ const LOCK_STALE_MS = 10000;
 const LOCK_RETRY_MS = 50;
 const LOCK_TIMEOUT_MS = 5000;
 
+export function sleepWithoutBusySpin(ms: number): void {
+  const duration = Math.max(0, Math.floor(ms));
+  if (duration === 0) return;
+  const buffer = new SharedArrayBuffer(4);
+  const view = new Int32Array(buffer);
+  Atomics.wait(view, 0, 0, duration);
+}
+
 function acquireLock(): boolean {
   const deadline = Date.now() + LOCK_TIMEOUT_MS;
   while (Date.now() < deadline) {
@@ -34,8 +42,7 @@ function acquireLock(): boolean {
           releaseLock();
           continue;
         }
-        const waitUntil = Date.now() + LOCK_RETRY_MS;
-        while (Date.now() < waitUntil) { /* spin */ }
+        sleepWithoutBusySpin(LOCK_RETRY_MS);
         continue;
       }
       return false;

--- a/tests/unit/zombie-cleanup-lock.test.ts
+++ b/tests/unit/zombie-cleanup-lock.test.ts
@@ -1,0 +1,16 @@
+import { sleepWithoutBusySpin } from '../../src/reliability/zombie-cleanup';
+
+describe('zombie cleanup registry lock wait helper', () => {
+  it('returns immediately for non-positive durations', () => {
+    const start = Date.now();
+    sleepWithoutBusySpin(0);
+    sleepWithoutBusySpin(-10);
+    expect(Date.now() - start).toBeLessThan(25);
+  });
+
+  it('waits for approximately the requested duration without a JavaScript spin loop', () => {
+    const start = Date.now();
+    sleepWithoutBusySpin(15);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(10);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the zombie-cleanup registry lock busy-spin wait with a dependency-free synchronous sleep helper.
- Preserves existing lock retry interval, stale timeout, synchronous registry APIs, and failure behavior.
- Adds targeted unit coverage for the wait helper and keeps cross-session zombie cleanup tests green.

Closes #754.

## Direction/scope review
- Aligned with OpenSafari simulator lifecycle reliability and CI stability.
- Low risk: no behavior or timeout changes, only removes CPU-burning spin wait.
- No dependencies or registry redesign.

## Verification
- `npm test -- --runTestsByPath tests/unit/zombie-cleanup-lock.test.ts tests/unit/zombie-cleanup-cross-session.test.ts`
- `npm run lint -- --quiet src/reliability/zombie-cleanup.ts tests/unit/zombie-cleanup-lock.test.ts`
- `npm run build`

## Live validation after merge
- Contend the registry lock from two OpenSafari processes and confirm the waiter does not burn a full CPU core.
- Confirm active registered simulators remain protected from cleanup.
