### PR TITLE
Recover device_boot when WebKit registration is late

### DIFF
--- a/src/tools/device-boot.ts
+++ b/src/tools/device-boot.ts
@@ -1,7 +1,7 @@
 import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { SimctlExecutor } from '../simulator/simctl';
-import { getProxyForDevice } from '../simulator/proxy-manager';
+import { getProxyForDevice, stopProxyForDevice } from '../simulator/proxy-manager';
 import { WebKitClient } from '../webkit/client';
 import { addManagedDevice } from '../reliability/zombie-cleanup';
 import { getSessionManager } from '../session-manager';
@@ -60,6 +60,21 @@ export function registerDeviceBootTool(server: MCPServer): void {
         console.error(`[device_boot] Post-boot optimization failed (non-fatal): ${err}`);
       }
 
+      const sm = getSessionManager();
+      const preset = Object.entries(DEVICE_PRESETS).find(([, p]) => p.name === device.name);
+
+      // Register the simulator even if WebKit target discovery fails. Native
+      // tools and diagnostics can still operate on a successfully booted
+      // simulator; only Safari/WebKit tools should remain unavailable.
+      sm.addSimulator(device.udid, {
+        deviceId: device.udid,
+        deviceType: device.name,
+        state: 'booted',
+        viewport: { width: preset?.[1]?.w ?? 390, height: preset?.[1]?.h ?? 844 },
+        bootedAt: Date.now(),
+        lastActivity: Date.now(),
+      });
+
       // Auto-start a per-device WebInspector proxy so parallel sessions
       // each get their own isolated proxy bound to their simulator's socket.
       let proxyStatus: { running: boolean; pid: number | null; port: number | null } = {
@@ -67,61 +82,61 @@ export function registerDeviceBootTool(server: MCPServer): void {
         pid: null,
         port: null,
       };
+
+      const openSafariWithRetry = async (): Promise<void> => {
+        // Retry openUrl — the simulator may report "Booted" before app
+        // launch services are fully ready (LSApplicationWorkspaceErrorDomain 115).
+        let openRetries = 5;
+        while (openRetries > 0) {
+          try {
+            await manager.openUrl(device.udid, 'https://example.com');
+            return;
+          } catch (openErr) {
+            openRetries--;
+            if (openRetries === 0) throw openErr;
+            await new Promise(r => setTimeout(r, 2000));
+          }
+        }
+      };
+
+      const connectWebKit = async (port: number): Promise<WebKitClient> => {
+        // Disconnect any existing client for THIS device to avoid leaking WebSocket connections.
+        const existingClient = sm.getConnection(device.udid);
+        if (existingClient) {
+          try { await existingClient.disconnect(); } catch { /* best-effort */ }
+          sm.removeConnection(device.udid);
+        }
+
+        await openSafariWithRetry();
+        const client = new WebKitClient({ host: 'localhost', port });
+        await client.connect({ retries: 5, retryDelay: 2000 });
+        sm.setConnection(device.udid, client);
+        return client;
+      };
+
       try {
-        const proxy = await getProxyForDevice(device.udid);
+        let proxy = await getProxyForDevice(device.udid);
         proxyStatus = { running: proxy.running, pid: proxy.pid, port: proxy.port };
 
-        // Open Safari so it registers with WebInspector, then connect WebKitClient
         try {
-          const sm = getSessionManager();
-
-          // Disconnect any existing client for THIS device to avoid leaking WebSocket connections
-          if (sm.hasConnection(device.udid)) {
-            const existingClient = sm.getConnection(device.udid);
-            if (existingClient) {
-              try { await existingClient.disconnect(); } catch { /* best-effort */ }
-            }
-            sm.removeConnection(device.udid);
-          }
-
-          // Retry openUrl — the simulator may report "Booted" before app
-          // launch services are fully ready (LSApplicationWorkspaceErrorDomain 115).
-          let openRetries = 5;
-          while (openRetries > 0) {
-            try {
-              await manager.openUrl(device.udid, 'https://example.com');
-              break;
-            } catch (openErr) {
-              openRetries--;
-              if (openRetries === 0) throw openErr;
-              await new Promise(r => setTimeout(r, 2000));
-            }
-          }
-
           // Give slow Safari registrations a short window to appear before the first
           // connect attempt. Falls through tolerantly so fast paths stay fast.
           await proxy.waitForTarget({ timeout: 3000 }).catch(() => { /* tolerated */ });
-
-          // Connect to WebKit with retries — Safari may need time to register with WebInspector
-          const client = new WebKitClient({ host: 'localhost', port: proxy.port });
-          await client.connect({ retries: 5, retryDelay: 2000 });
-
-          // Register in SessionManager — tracks the connection by deviceId
-          const preset = Object.entries(DEVICE_PRESETS).find(([, p]) => p.name === device.name);
-          sm.addSimulator(device.udid, {
-            deviceId: device.udid,
-            deviceType: device.name,
-            state: 'booted',
-            viewport: { width: preset?.[1]?.w ?? 390, height: preset?.[1]?.h ?? 844 },
-            bootedAt: Date.now(),
-            lastActivity: Date.now(),
-          });
-          sm.setConnection(device.udid, client);
+          await connectWebKit(proxy.port);
         } catch (err) {
-          console.error(`[device_boot] WebKit connection failed (proxy running, tools may not work): ${err}`);
+          console.error(`[device_boot] WebKit connection failed; restarting device proxy once: ${err}`);
+          await stopProxyForDevice(device.udid).catch((stopErr) => {
+            console.error(`[device_boot] Failed to stop stale WebInspector proxy: ${stopErr}`);
+          });
+          proxy = await getProxyForDevice(device.udid);
+          proxyStatus = { running: proxy.running, pid: proxy.pid, port: proxy.port };
+          await proxy.waitForTarget({ timeout: 3000 }).catch(() => { /* tolerated */ });
+          await connectWebKit(proxy.port);
         }
       } catch (err) {
-        console.error(`[device_boot] Failed to start WebInspector proxy: ${err}`);
+        // Keep the booted simulator registered for native-tool fallback, but
+        // make the missing WebKit connection visible through diagnose/QA tools.
+        console.error(`[device_boot] WebKit connection failed (proxy unavailable, Safari tools may not work): ${err}`);
       }
 
       return {

--- a/tests/unit/device-boot-webkit-retry.test.ts
+++ b/tests/unit/device-boot-webkit-retry.test.ts
@@ -1,0 +1,123 @@
+import { MCPServer } from '../../src/mcp-server';
+import { getSessionManager } from '../../src/session-manager';
+import { registerDeviceBootTool } from '../../src/tools/device-boot';
+
+const listBooted = jest.fn();
+const boot = jest.fn();
+const openUrl = jest.fn();
+const getProxyForDevice = jest.fn();
+const stopProxyForDevice = jest.fn();
+const addManagedDevice = jest.fn();
+const disableBackgroundServices = jest.fn();
+const connect = jest.fn();
+const disconnect = jest.fn();
+
+jest.mock('../../src/simulator', () => ({
+  SimulatorManager: jest.fn().mockImplementation(() => ({
+    listBooted,
+    boot,
+    openUrl,
+  })),
+}));
+
+jest.mock('../../src/simulator/simctl', () => ({
+  SimctlExecutor: jest.fn(),
+}));
+
+jest.mock('../../src/simulator/proxy-manager', () => ({
+  getProxyForDevice: (...args: unknown[]) => getProxyForDevice(...args),
+  stopProxyForDevice: (...args: unknown[]) => stopProxyForDevice(...args),
+}));
+
+jest.mock('../../src/reliability/zombie-cleanup', () => ({
+  addManagedDevice: (...args: unknown[]) => addManagedDevice(...args),
+}));
+
+jest.mock('../../src/simulator/post-boot-optimize', () => ({
+  disableBackgroundServices: (...args: unknown[]) => disableBackgroundServices(...args),
+}));
+
+jest.mock('../../src/webkit/client', () => ({
+  WebKitClient: jest.fn().mockImplementation(() => ({
+    connect,
+    disconnect,
+    backendType: 'safari',
+  })),
+}));
+
+function parseToolText(result: unknown): Record<string, unknown> {
+  const content = (result as { content?: Array<{ text: string }> }).content;
+  if (!content?.[0]?.text) throw new Error('missing tool text content');
+  return JSON.parse(content[0].text);
+}
+
+describe('device_boot WebKit recovery', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await getSessionManager().shutdown();
+    listBooted.mockResolvedValue([]);
+    boot.mockResolvedValue({
+      udid: 'DEVICE-1',
+      name: 'iPhone 16',
+      state: 'Booted',
+      isAvailable: true,
+      runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-26-4',
+      runtimeVersion: '26.4',
+    });
+    openUrl.mockResolvedValue(undefined);
+    disableBackgroundServices.mockResolvedValue(undefined);
+    stopProxyForDevice.mockResolvedValue(undefined);
+  });
+
+  it('keeps the booted simulator registered when WebKit never connects', async () => {
+    getProxyForDevice.mockRejectedValue(new Error('socket unavailable'));
+
+    const server = new MCPServer();
+    registerDeviceBootTool(server);
+    const handler = server.getToolHandler('device_boot');
+    expect(handler).toBeDefined();
+
+    const result = await handler!('session-1', { device: 'iPhone 16' });
+    const body = parseToolText(result);
+
+    expect(body.proxy).toEqual({ running: false, pid: null, port: null });
+    expect(getSessionManager().getSimulator('DEVICE-1')).toMatchObject({
+      deviceId: 'DEVICE-1',
+      deviceType: 'iPhone 16',
+      state: 'booted',
+    });
+    expect(getSessionManager().hasConnection('DEVICE-1')).toBe(false);
+  });
+
+  it('restarts the device proxy once after a WebKit connect failure', async () => {
+    const firstProxy = {
+      running: true,
+      pid: 101,
+      port: 9347,
+      waitForTarget: jest.fn().mockResolvedValue(undefined),
+    };
+    const secondProxy = {
+      running: true,
+      pid: 202,
+      port: 9447,
+      waitForTarget: jest.fn().mockResolvedValue(undefined),
+    };
+    getProxyForDevice.mockResolvedValueOnce(firstProxy).mockResolvedValueOnce(secondProxy);
+    connect.mockRejectedValueOnce(new Error('No Safari targets found')).mockResolvedValueOnce(undefined);
+
+    const server = new MCPServer();
+    registerDeviceBootTool(server);
+    const handler = server.getToolHandler('device_boot');
+    expect(handler).toBeDefined();
+
+    const result = await handler!('session-1', { device: 'iPhone 16' });
+    const body = parseToolText(result);
+
+    expect(stopProxyForDevice).toHaveBeenCalledWith('DEVICE-1');
+    expect(getProxyForDevice).toHaveBeenCalledTimes(2);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(openUrl).toHaveBeenCalledTimes(2);
+    expect(body.proxy).toEqual({ running: true, pid: 202, port: 9447 });
+    expect(getSessionManager().hasConnection('DEVICE-1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Registers a successfully booted simulator in `SessionManager` before WebKit target discovery, so diagnostics/native tools still see the device when Safari is late or unavailable.
- Retries WebKit setup once by stopping the per-device proxy and creating a fresh proxy after an initial connect failure.
- Adds unit coverage for the live-validation failure mode observed while validating #752.

Fixes #756.

## Validation

- `npm test -- --runInBand tests/unit/device-boot-webkit-retry.test.ts`
- `npm run lint -- --quiet`
- `npm run build:src`

## Live validation context

OpenSafari live validation on iPhone 16 (`3BEF4E9A-069A-4419-AC62-AB889348EF12`) found `device_boot` returning a proxy, followed by `qa_session_create` -> `NO_WEBKIT_CLIENT` and `diagnose.device=null`. This PR keeps the booted device diagnosable and retries a stale/late WebKit proxy once.
