### PR TITLE
Fix proxy manager concurrent start race

### DIFF
--- a/src/simulator/proxy-manager.ts
+++ b/src/simulator/proxy-manager.ts
@@ -38,6 +38,8 @@ interface ManagedProxy {
 }
 
 const managed: Map<string, ManagedProxy> = new Map();
+/** In-flight proxy starts keyed by device so concurrent callers share one spawn. */
+const pendingStarts: Map<string, Promise<WebInspectorProxy>> = new Map();
 /** Ports reserved (in-use) by this manager across devices. */
 const reservedPorts: Set<number> = new Set();
 
@@ -95,17 +97,29 @@ export async function getProxyForDevice(deviceId: string): Promise<WebInspectorP
   const existing = managed.get(deviceId);
   if (existing) return existing.proxy;
 
-  const port = allocatePort(deviceId);
-  const proxy = new WebInspectorProxy({ port });
-  try {
-    await proxy.start({ targetUdid: deviceId });
-  } catch (err) {
-    reservedPorts.delete(port);
-    throw err;
-  }
+  const pending = pendingStarts.get(deviceId);
+  if (pending) return pending;
 
-  managed.set(deviceId, { proxy, deviceId, port });
-  return proxy;
+  const startPromise = (async () => {
+    const port = allocatePort(deviceId);
+    const proxy = new WebInspectorProxy({ port });
+    try {
+      await proxy.start({ targetUdid: deviceId });
+    } catch (err) {
+      reservedPorts.delete(port);
+      throw err;
+    }
+
+    managed.set(deviceId, { proxy, deviceId, port });
+    return proxy;
+  })();
+
+  pendingStarts.set(deviceId, startPromise);
+  try {
+    return await startPromise;
+  } finally {
+    pendingStarts.delete(deviceId);
+  }
 }
 
 /** Return the proxy for a device without starting a new one. */
@@ -144,5 +158,6 @@ export function listManagedProxies(): Array<{ deviceId: string; port: number }> 
 /** Reset state. Test-only — does NOT stop running proxies. */
 export function resetProxyManagerState(): void {
   managed.clear();
+  pendingStarts.clear();
   reservedPorts.clear();
 }

--- a/src/simulator/proxy-manager.ts
+++ b/src/simulator/proxy-manager.ts
@@ -129,6 +129,14 @@ export function peekProxyForDevice(deviceId: string): WebInspectorProxy | null {
 
 /** Stop and forget a device's proxy. No-op if none exists. */
 export async function stopProxyForDevice(deviceId: string): Promise<void> {
+  const pending = pendingStarts.get(deviceId);
+  if (pending) {
+    // Teardown may race with startup during parallel boot/retry flows. Wait for
+    // the in-flight start to settle so a proxy cannot register itself after a
+    // caller has already requested stop for this device.
+    await pending.catch(() => null);
+  }
+
   const entry = managed.get(deviceId);
   if (!entry) return;
   try {
@@ -142,7 +150,7 @@ export async function stopProxyForDevice(deviceId: string): Promise<void> {
 
 /** Stop every managed proxy. Used on process shutdown / from tests. */
 export async function stopAll(): Promise<void> {
-  const devices = Array.from(managed.keys());
+  const devices = Array.from(new Set([...managed.keys(), ...pendingStarts.keys()]));
   for (const id of devices) {
     await stopProxyForDevice(id);
   }

--- a/tests/unit/proxy-manager.test.ts
+++ b/tests/unit/proxy-manager.test.ts
@@ -183,6 +183,29 @@ describe('ProxyManager', () => {
   });
 
   describe('stopProxyForDevice', () => {
+
+    test('waits for an in-flight start before stopping the target device', async () => {
+      let releaseStart!: () => void;
+      const startGate = new Promise<void>((resolve) => {
+        releaseStart = resolve;
+      });
+      mockStart.mockImplementationOnce(async () => {
+        await startGate;
+      });
+
+      const starting = getProxyForDevice(UDID_A);
+      await Promise.resolve();
+
+      const stopping = stopProxyForDevice(UDID_A);
+      releaseStart();
+
+      await Promise.all([starting, stopping]);
+
+      expect(mockStop).toHaveBeenCalledTimes(1);
+      expect(peekProxyForDevice(UDID_A)).toBeNull();
+      expect(listManagedProxies()).toHaveLength(0);
+    });
+
     test('stops only the target device proxy', async () => {
       await getProxyForDevice(UDID_A);
       await getProxyForDevice(UDID_B);
@@ -209,6 +232,28 @@ describe('ProxyManager', () => {
   });
 
   describe('stopAll', () => {
+
+    test('includes in-flight starts when stopping all proxies', async () => {
+      let releaseStart!: () => void;
+      const startGate = new Promise<void>((resolve) => {
+        releaseStart = resolve;
+      });
+      mockStart.mockImplementationOnce(async () => {
+        await startGate;
+      });
+
+      const starting = getProxyForDevice(UDID_A);
+      await Promise.resolve();
+
+      const stoppingAll = stopAll();
+      releaseStart();
+
+      await Promise.all([starting, stoppingAll]);
+
+      expect(mockStop).toHaveBeenCalledTimes(1);
+      expect(listManagedProxies()).toHaveLength(0);
+    });
+
     test('stops every managed proxy', async () => {
       await getProxyForDevice(UDID_A);
       await getProxyForDevice(UDID_B);

--- a/tests/unit/proxy-manager.test.ts
+++ b/tests/unit/proxy-manager.test.ts
@@ -17,8 +17,8 @@ jest.mock('../../src/simulator/proxy', () => ({
     this.pid = 12345;
     this.running = false;
     this.start = async (_startOptions?: { targetUdid?: string }) => {
+      await mockStart(_startOptions);
       this.running = true;
-      mockStart(_startOptions);
     };
     this.stop = async () => {
       this.running = false;
@@ -120,6 +120,50 @@ describe('ProxyManager', () => {
       expect(a).not.toBe(b);
       expect(a.port).not.toBe(b.port);
       expect(constructorCalls).toHaveLength(2);
+    });
+
+
+    test('coalesces concurrent starts for the same device', async () => {
+      let releaseStart!: () => void;
+      const startGate = new Promise<void>((resolve) => {
+        releaseStart = resolve;
+      });
+      mockStart.mockImplementationOnce(async () => {
+        await startGate;
+      });
+
+      const firstPromise = getProxyForDevice(UDID_A);
+      const secondPromise = getProxyForDevice(UDID_A);
+
+      // Let both calls reach the pending-start path before unblocking start().
+      await Promise.resolve();
+      releaseStart();
+
+      const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+      expect(first).toBe(second);
+      expect(constructorCalls).toHaveLength(1);
+      expect(mockStart).toHaveBeenCalledTimes(1);
+      expect(listManagedProxies()).toHaveLength(1);
+    });
+
+    test('clears failed pending starts so a concurrent retry can create a fresh proxy', async () => {
+      mockStart.mockImplementationOnce(async () => {
+        throw new Error('proxy spawn failed');
+      });
+
+      await expect(Promise.all([
+        getProxyForDevice(UDID_A),
+        getProxyForDevice(UDID_A),
+      ])).rejects.toThrow('proxy spawn failed');
+
+      expect(peekProxyForDevice(UDID_A)).toBeNull();
+      const retry = await getProxyForDevice(UDID_A);
+
+      expect(retry).toBeDefined();
+      expect(constructorCalls).toHaveLength(2);
+      expect(mockStart).toHaveBeenCalledTimes(2);
+      expect(listManagedProxies()).toHaveLength(1);
     });
 
     test('releases the reserved port when start() throws', async () => {


### PR DESCRIPTION
## Summary\n- Coalesce concurrent getProxyForDevice() calls per device while a WebInspectorProxy is starting\n- Clear pending starts on success/failure so retries remain safe\n- Add regression coverage for same-UDID concurrent start and failed pending retry\n\n## Why\nOpenSafari advertises parallel simulator sessions. Concurrent device boot or WebKit retry paths can call getProxyForDevice for the same UDID before the first proxy is registered, creating duplicate proxy processes and reserved ports.\n\n## Validation\n- npx eslint src/simulator/proxy-manager.ts tests/unit/proxy-manager.test.ts (warnings only: pre-existing test any annotations)\n- npm test -- --runTestsByPath tests/unit/proxy-manager.test.ts