### PR TITLE
Coalesce parallel Flutter VM resolver probes

### DIFF
--- a/src/input/flutter-resolver.ts
+++ b/src/input/flutter-resolver.ts
@@ -140,6 +140,7 @@ async function defaultFlutterVMResolver(
  */
 export class FlutterVMResolverInstance {
   private cache = new Map<string, FlutterClientCacheEntry>();
+  private pendingResolutions = new Map<string, Promise<FlutterVMClient | null>>();
   private resolver: FlutterVMResolver;
 
   constructor() {
@@ -153,10 +154,22 @@ export class FlutterVMResolverInstance {
    * working for native iOS apps.
    */
   async resolve(deviceId: string): Promise<FlutterVMClient | null> {
+    const pending = this.pendingResolutions.get(deviceId);
+    if (pending) return pending;
+
+    const resolution = (async () => {
+      try {
+        return await this.resolver(deviceId);
+      } catch {
+        return null;
+      }
+    })();
+
+    this.pendingResolutions.set(deviceId, resolution);
     try {
-      return await this.resolver(deviceId);
-    } catch {
-      return null;
+      return await resolution;
+    } finally {
+      this.pendingResolutions.delete(deviceId);
     }
   }
 
@@ -180,6 +193,7 @@ export class FlutterVMResolverInstance {
   /** Clear all cached entries and reset the resolver to default. */
   reset(): void {
     this.cache.clear();
+    this.pendingResolutions.clear();
     this.resolver = (deviceId) => defaultFlutterVMResolver(deviceId, this.cache);
   }
 }

--- a/tests/unit/input-backend-resolver.test.ts
+++ b/tests/unit/input-backend-resolver.test.ts
@@ -86,6 +86,60 @@ describe('InputBackendResolver — instance isolation', () => {
     expect(backendB).toBeInstanceOf(SimctlInputBackend);
   });
 
+
+  test('coalesces concurrent Flutter VM resolution for the same device', async () => {
+    const resolver = new InputBackendResolver();
+    const fakeClient = { isConnected: () => true, evaluate: jest.fn() } as any;
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    resolver.setFlutterVMResolver(async () => {
+      calls++;
+      await gate;
+      return fakeClient;
+    });
+
+    const first = resolver.getInputBackend(DEVICE);
+    const second = resolver.getInputBackend(DEVICE);
+
+    await Promise.resolve();
+    release();
+
+    const [backendA, backendB] = await Promise.all([first, second]);
+
+    expect(backendA).toBeInstanceOf(FlutterVMInputBackend);
+    expect(backendB).toBeInstanceOf(FlutterVMInputBackend);
+    expect(calls).toBe(1);
+  });
+
+  test('clears failed Flutter VM pending resolution so retry can probe again', async () => {
+    const resolver = new InputBackendResolver();
+    let calls = 0;
+    resolver.setFlutterVMResolver(async () => {
+      calls++;
+      throw new Error('transient vm discovery failure');
+    });
+
+    execMock.mockResolvedValue('');
+    await Promise.all([
+      resolver.getInputBackend(DEVICE),
+      resolver.getInputBackend(DEVICE),
+    ]);
+
+    expect(calls).toBe(1);
+
+    resolver.setFlutterVMResolver(async () => {
+      calls++;
+      return null;
+    });
+    await resolver.getInputBackend(DEVICE);
+
+    expect(calls).toBe(2);
+  });
+
   test('Flutter cache size is per-instance', async () => {
     const resolverA = new InputBackendResolver();
     const resolverB = new InputBackendResolver();


### PR DESCRIPTION
## Summary\n- Add per-device single-flight handling around Flutter VM resolution\n- Clear pending resolution on success/failure so retries still probe normally\n- Add regression coverage for concurrent Flutter Tier-0 resolution and failed pending retry\n\n## Why\nParallel native app tools can all enter Tier 0 before the Flutter VM cache is populated. Without coalescing, the shared FlutterVMClient can receive overlapping discovery/connect calls, which is unsafe for debug/profile Flutter app automation.\n\n## Validation\n- npx eslint src/input/flutter-resolver.ts tests/unit/input-backend-resolver.test.ts (warnings only: existing test any/no-var warnings)\n- npm test -- --runTestsByPath tests/unit/input-backend-resolver.test.ts