### PR TITLE
fix(network-intercept): evict session cache on HTTP delete

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17,6 +17,7 @@ import {
   MCPMessageContext,
 } from './types/mcp';
 import { createTransport, MCPTransport, TransportMode } from './transports';
+import { removeNetworkInterceptorForSession } from './tools/network-intercept-cache';
 import { TOOL_TIERS, getToolTier } from './config/tool-tiers';
 import { BrowserBackend } from './types/browser-backend';
 import { logAuditEntry } from './security/audit-logger';
@@ -194,6 +195,10 @@ export class MCPServer {
       authToken: options.authToken,
       insecure: options.httpInsecure,
       allowedOrigins: options.allowedOrigins,
+    });
+
+    this.transport.onSessionDelete?.((sessionId) => {
+      removeNetworkInterceptorForSession(sessionId);
     });
 
     this.transport.onMessage((msg, context) => this.handleMessage(msg, context));

--- a/src/tools/network-intercept-cache.ts
+++ b/src/tools/network-intercept-cache.ts
@@ -1,0 +1,38 @@
+import { NetworkInterceptor } from '../network-interceptor';
+
+const DEFAULT_INTERCEPTOR_SCOPE = '__default__';
+const interceptorsBySession = new Map<string, NetworkInterceptor>();
+
+function resolveInterceptorScope(sessionId?: string): string {
+  return sessionId || DEFAULT_INTERCEPTOR_SCOPE;
+}
+
+export function getNetworkInterceptorForSession(sessionId?: string): NetworkInterceptor {
+  const key = resolveInterceptorScope(sessionId);
+  let interceptor = interceptorsBySession.get(key);
+  if (!interceptor) {
+    interceptor = new NetworkInterceptor();
+    interceptorsBySession.set(key, interceptor);
+  }
+  return interceptor;
+}
+
+export function removeNetworkInterceptorForSession(sessionId: string): number {
+  if (!sessionId) return 0;
+
+  let removed = 0;
+  for (const key of Array.from(interceptorsBySession.keys())) {
+    if (key === sessionId || key.startsWith(`${sessionId}|`)) {
+      interceptorsBySession.delete(key);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+export function resetNetworkInterceptorsForTest(): void {
+  interceptorsBySession.clear();
+}
+
+/** Legacy singleton for callers that are not yet session-aware. */
+export const networkInterceptor = getNetworkInterceptorForSession(DEFAULT_INTERCEPTOR_SCOPE);

--- a/src/tools/network-intercept.ts
+++ b/src/tools/network-intercept.ts
@@ -1,29 +1,21 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
 import {
-  NetworkInterceptor,
   type InterceptorClient,
   type InterceptRule,
 } from '../network-interceptor';
+import {
+  getNetworkInterceptorForSession,
+  networkInterceptor,
+  removeNetworkInterceptorForSession,
+  resetNetworkInterceptorsForTest,
+} from './network-intercept-cache';
 
-const DEFAULT_INTERCEPTOR_SCOPE = '__default__';
-const interceptorsBySession = new Map<string, NetworkInterceptor>();
-
-export function getNetworkInterceptorForSession(sessionId?: string): NetworkInterceptor {
-  const key = sessionId || DEFAULT_INTERCEPTOR_SCOPE;
-  let interceptor = interceptorsBySession.get(key);
-  if (!interceptor) {
-    interceptor = new NetworkInterceptor();
-    interceptorsBySession.set(key, interceptor);
-  }
-  return interceptor;
-}
-
-export function resetNetworkInterceptorsForTest(): void {
-  interceptorsBySession.clear();
-}
-
-/** Legacy singleton for callers that are not yet session-aware. */
-export const networkInterceptor = getNetworkInterceptorForSession(DEFAULT_INTERCEPTOR_SCOPE);
+export {
+  getNetworkInterceptorForSession,
+  networkInterceptor,
+  removeNetworkInterceptorForSession,
+  resetNetworkInterceptorsForTest,
+};
 
 function resolveClient(deviceId: unknown): InterceptorClient | null {
   return getWebKitClient(typeof deviceId === 'string' ? deviceId : undefined);

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -26,6 +26,12 @@ export interface MCPTransport {
    */
   send(response: MCPResponse): void;
 
+  /**
+   * Register cleanup that runs when a stateful transport deletes an MCP session.
+   * Stateless transports can omit this hook.
+   */
+  onSessionDelete?(handler: (sessionId: string) => void): void;
+
   /** Start listening for messages (bind port or attach readline). */
   start(): void | Promise<void>;
 

--- a/tests/unit/mcp-server-session-cleanup.test.ts
+++ b/tests/unit/mcp-server-session-cleanup.test.ts
@@ -1,0 +1,36 @@
+describe('MCPServer HTTP session cleanup', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('registers network interceptor eviction for transport session deletion', async () => {
+    const onSessionDelete = jest.fn();
+    const transport = {
+      onMessage: jest.fn(),
+      onSessionDelete,
+      send: jest.fn(),
+      start: jest.fn(),
+      close: jest.fn(),
+    };
+    const removeNetworkInterceptorForSession = jest.fn();
+
+    jest.doMock('../../src/transports', () => ({
+      createTransport: jest.fn(async () => transport),
+    }));
+    jest.doMock('../../src/tools/network-intercept-cache', () => ({
+      removeNetworkInterceptorForSession,
+    }));
+
+    const { MCPServer } = await import('../../src/mcp-server');
+    const server = new MCPServer();
+
+    await server.start({ transport: 'http' });
+
+    expect(onSessionDelete).toHaveBeenCalledWith(expect.any(Function));
+    const handler = onSessionDelete.mock.calls[0][0] as (sessionId: string) => void;
+    handler('session-a');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(removeNetworkInterceptorForSession).toHaveBeenCalledWith('session-a');
+  });
+});

--- a/tests/unit/network-intercept-tool.test.ts
+++ b/tests/unit/network-intercept-tool.test.ts
@@ -1,4 +1,8 @@
-import { getNetworkInterceptorForSession, resetNetworkInterceptorsForTest } from '../../src/tools/network-intercept';
+import {
+  getNetworkInterceptorForSession,
+  removeNetworkInterceptorForSession,
+  resetNetworkInterceptorsForTest,
+} from '../../src/tools/network-intercept';
 
 describe('network_intercept session scoping', () => {
   beforeEach(() => resetNetworkInterceptorsForTest());
@@ -24,6 +28,29 @@ describe('network_intercept session scoping', () => {
 
     expect(a2.listRules()).toHaveLength(1);
     expect(a2.findMatchingRule('https://example.com/login')?.action).toBe('mock');
+  });
+
+  it('evicts only the selected MCP session cache on session deletion', () => {
+    const a1 = getNetworkInterceptorForSession('session-a');
+    const b = getNetworkInterceptorForSession('session-b');
+
+    a1.addRule({ urlPattern: '/a', action: 'block' });
+    b.addRule({ urlPattern: '/b', action: 'block' });
+
+    expect(removeNetworkInterceptorForSession('session-a')).toBe(1);
+
+    const a2 = getNetworkInterceptorForSession('session-a');
+    expect(a2).not.toBe(a1);
+    expect(a2.listRules()).toHaveLength(0);
+    expect(b.listRules()).toHaveLength(1);
+  });
+
+  it('reports no eviction for unknown or empty session ids', () => {
+    getNetworkInterceptorForSession('session-a').addRule({ urlPattern: '/a', action: 'block' });
+
+    expect(removeNetworkInterceptorForSession('missing')).toBe(0);
+    expect(removeNetworkInterceptorForSession('')).toBe(0);
+    expect(getNetworkInterceptorForSession('session-a').listRules()).toHaveLength(1);
   });
 
   it('clear/disable restores and clears only the selected session', async () => {


### PR DESCRIPTION
## Summary
- Exposes an optional `MCPTransport.onSessionDelete` lifecycle hook through the transport abstraction.
- Wires HTTP session deletion to `removeNetworkInterceptorForSession(sessionId)` so `network_intercept` per-session rule state is evicted when streamable HTTP sessions are deleted.
- Adds unit coverage for direct cache eviction and MCPServer lifecycle wiring.

## Issue analysis / scope
Open issue #763 is still valid: HTTP transport already has a session delete callback, but `MCPServer` did not register cleanup, so the module-level network interceptor map retained per-session `NetworkInterceptor` instances after `DELETE /mcp`.

This PR intentionally keeps the scope narrow:
- It removes stale in-memory interceptor state for the deleted session.
- It preserves stdio behavior by making the transport hook optional.
- It avoids a `mcp-server -> network-intercept` import cycle by moving the cache into a side-effect-light module that both layers can share synchronously.

## Validation
- `npx jest --runTestsByPath tests/unit/network-intercept-tool.test.ts tests/unit/mcp-server-session-cleanup.test.ts --runInBand`
- `npx eslint --max-warnings=0 src/tools/network-intercept.ts src/tools/network-intercept-cache.ts src/transports/index.ts src/mcp-server.ts tests/unit/network-intercept-tool.test.ts tests/unit/mcp-server-session-cleanup.test.ts`
- `npx tsc --noEmit --pretty false`

Closes #763
