### PR TITLE
fix(ax-bridge): report inactive Flutter semantics

### DIFF
--- a/src/native/ax-bridge-recovery.ts
+++ b/src/native/ax-bridge-recovery.ts
@@ -46,6 +46,9 @@ export const NON_RECOVERABLE_ERROR_CODES: ReadonlySet<string> = new Set([
   'AX_PERMISSION_DENIED',
 ]);
 
+/** Typed final error when a Flutter target never rematerialises native semantics. */
+export const FLUTTER_SEMANTICS_INACTIVE = 'FLUTTER_SEMANTICS_INACTIVE';
+
 /** Default backoff schedule used between retries (ms). */
 export const DEFAULT_BACKOFF_MS: readonly number[] = [200, 500, 1200];
 /** Default retry budget. */
@@ -122,6 +125,31 @@ function resolveBackoff(
 ): number {
   const source = schedule && schedule.length > 0 ? schedule : DEFAULT_BACKOFF_MS;
   return source[Math.min(gapIndex, source.length - 1)] ?? 0;
+}
+
+function shouldPromoteFlutterSemanticsInactive(
+  err: AccessibilityBridgeError,
+  options: DumpTreeWithRecoveryOptions,
+  stages: readonly AxBridgeRecoveryStage[],
+): boolean {
+  return Boolean(options.bundleId) &&
+    err.code === 'DEVICE_CONTENT_ROOT_EMPTY' &&
+    stages.some((stage) =>
+      stage.action === 'reactivate' &&
+      stage.outcome === 'error' &&
+      stage.errorCode === 'REACTIVATE_RETURNED_FALSE',
+    );
+}
+
+function promoteFlutterSemanticsInactive(
+  err: AccessibilityBridgeError,
+  options: DumpTreeWithRecoveryOptions,
+): AccessibilityBridgeError {
+  return new AccessibilityBridgeError(
+    `Flutter semantics remained inactive for bundle ${options.bundleId} after ax-bridge recovery; ` +
+      `the native accessibility tree stayed empty after simulator reactivation. Original error: ${err.message}`,
+    FLUTTER_SEMANTICS_INACTIVE,
+  );
 }
 
 /**
@@ -250,13 +278,16 @@ export async function dumpTreeWithRecovery(
     'ax-bridge dump failed with no recoverable error recorded',
     'UNKNOWN',
   );
-  attachRecoveryReport(finalError, {
+  const surfacedError = shouldPromoteFlutterSemanticsInactive(finalError, options, stages)
+    ? promoteFlutterSemanticsInactive(finalError, options)
+    : finalError;
+  attachRecoveryReport(surfacedError, {
     attempts: attempt,
     recovered: false,
     stages,
-    lastErrorCode: finalError.code,
+    lastErrorCode: surfacedError.code,
   });
-  throw finalError;
+  throw surfacedError;
 }
 
 /** Extend the thrown error with the diagnostics report without breaking existing `catch` blocks. */

--- a/tests/unit/ax-bridge-recovery.test.ts
+++ b/tests/unit/ax-bridge-recovery.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_BACKOFF_MS,
   DEFAULT_MAX_ATTEMPTS,
   DEFAULT_REACTIVATE_TIMEOUT_MS,
+  FLUTTER_SEMANTICS_INACTIVE,
   NON_RECOVERABLE_ERROR_CODES,
   RECOVERABLE_ERROR_CODES,
   dumpTreeWithRecovery,
@@ -161,6 +162,56 @@ describe('dumpTreeWithRecovery', () => {
       code: 'DEVICE_CONTENT_ROOT_EMPTY',
       message: 'empty 3',
     });
+  });
+
+  test('persistent empty Flutter tree with failed reactivation surfaces a typed semantics-inactive error', async () => {
+    const errors = [
+      new AccessibilityBridgeError('empty 1', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      new AccessibilityBridgeError('empty 2', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      new AccessibilityBridgeError('empty 3', 'DEVICE_CONTENT_ROOT_EMPTY'),
+    ];
+    const { bridge } = makeBridge(errors);
+
+    let caught: (AccessibilityBridgeError & { recovery?: unknown }) | undefined;
+    try {
+      await dumpTreeWithRecovery(bridge, {
+        deviceId: 'SIM-1',
+        bundleId: 'com.example.flutter',
+        reactivate: async () => false,
+        sleep: async () => {},
+      });
+    } catch (err) {
+      caught = err as AccessibilityBridgeError & { recovery?: unknown };
+    }
+
+    expect(caught).toMatchObject({
+      name: 'AccessibilityBridgeError',
+      code: FLUTTER_SEMANTICS_INACTIVE,
+    });
+    expect(caught?.message).toContain('com.example.flutter');
+    expect(caught?.message).toContain('Original error: empty 3');
+    expect(caught?.recovery).toMatchObject({
+      attempts: 3,
+      recovered: false,
+      lastErrorCode: FLUTTER_SEMANTICS_INACTIVE,
+    });
+  });
+
+  test('persistent empty native tree without bundleId preserves original error code', async () => {
+    const errors = [
+      new AccessibilityBridgeError('empty 1', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      new AccessibilityBridgeError('empty 2', 'DEVICE_CONTENT_ROOT_EMPTY'),
+      new AccessibilityBridgeError('empty 3', 'DEVICE_CONTENT_ROOT_EMPTY'),
+    ];
+    const { bridge } = makeBridge(errors);
+
+    await expect(
+      dumpTreeWithRecovery(bridge, {
+        deviceId: 'SIM-1',
+        reactivate: async () => false,
+        sleep: async () => {},
+      }),
+    ).rejects.toMatchObject({ code: 'DEVICE_CONTENT_ROOT_EMPTY', message: 'empty 3' });
   });
 
   test('non-recoverable error short-circuits without retry', async () => {


### PR DESCRIPTION
## Summary
- Adds `FLUTTER_SEMANTICS_INACTIVE` as a typed final recovery failure for Flutter bundle targets.
- Promotes exhausted `DEVICE_CONTENT_ROOT_EMPTY` recovery only when a bundle-scoped reactivation attempt returned `false`.
- Preserves the original empty-tree error for non-bundle/native-app calls.

## Issue analysis / scope
Issue #693 still contains one unresolved, live-gated slice: release-build Flutter semantics can remain inaccessible after coordinate-space and post-tap improvements. The issue thread explicitly cautions against speculative SpringBoard/Flutter activation changes without live release-build evidence.

This PR therefore implements the deterministic, repo-testable part of that remaining scope: callers now get a stable typed diagnostic (`FLUTTER_SEMANTICS_INACTIVE`) when the wrapper can prove that:
1. the target is bundle-scoped,
2. the native accessibility tree stayed empty through the retry budget, and
3. forced semantics reactivation returned `false`.

This makes downstream handling and telemetry reliable while leaving live activation behavior for a separately evidenced follow-up.

## Validation
- `npx jest --runTestsByPath tests/unit/ax-bridge-recovery.test.ts --runInBand`
- `npx eslint --max-warnings=0 src/native/ax-bridge-recovery.ts tests/unit/ax-bridge-recovery.test.ts`
- `npx tsc --noEmit --pretty false`

Refs #693
