### PR TITLE
feat(reliability): crash watcher cleans Flutter state + per-device VM circuit breaker

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b62dba66-abdc-4951-8e70-674549aea677","pid":51989,"procStart":"Wed May 20 15:33:56 2026","acquiredAt":1779333431078}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b62dba66-abdc-4951-8e70-674549aea677","pid":51989,"procStart":"Wed May 20 15:33:56 2026","acquiredAt":1779333431078}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ npm-debug.log*
 # OMC state
 .omc/
 
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock
+
 # Temp files
 /tmp/
 *.tmp

--- a/src/flutter/flutter-circuit-breakers.ts
+++ b/src/flutter/flutter-circuit-breakers.ts
@@ -1,0 +1,25 @@
+/**
+ * Per-device circuit breakers for Flutter VM Service calls.
+ *
+ * Lives separately from `SimulatorPool`'s registry because the failure modes
+ * are different: the pool's breaker trips on simulator-level memory/crash
+ * signals (minute-scale recovery), whereas this one trips on a short burst
+ * of VM Service request failures (e.g. ios-webkit-debug-proxy thrashing).
+ *
+ * Threshold tuned conservatively — 3 consecutive failures within the
+ * cooldown window will fail-fast subsequent `callMethod` invocations for
+ * 10 seconds so a flapping VM Service can't pin up the event loop with
+ * repeated 10-30 s timeouts.
+ */
+
+import { CircuitBreakerRegistry } from '../reliability/circuit-breaker';
+
+const registry = new CircuitBreakerRegistry({
+  failureThreshold: 3,
+  cooldownMs: 10_000,
+  halfOpenMaxAttempts: 1,
+});
+
+export function flutterCircuitBreakers(): CircuitBreakerRegistry {
+  return registry;
+}

--- a/src/flutter/vm-service-client.ts
+++ b/src/flutter/vm-service-client.ts
@@ -23,6 +23,7 @@ import {
   rememberVMServiceUrl,
   forgetVMServiceUrl,
 } from './vm-service-discovery';
+import { flutterCircuitBreakers } from './flutter-circuit-breakers';
 import {
   DEFAULT_FLUTTER_VM_REQUEST_TIMEOUT_MS,
   DEFAULT_FLUTTER_VM_HEAVY_TIMEOUT_MS,
@@ -213,10 +214,12 @@ export class FlutterVMClient {
     }
 
     // Re-apply any user-requested event streams that survived a reconnect.
+    // Bypass the circuit breaker — this is infrastructure for the reconnect
+    // itself; failing here would leave us connected but eventless.
     for (const streamId of this.subscribedStreams) {
       if (streamId === 'Isolate') continue; // handled above
       try {
-        await this.callMethod('streamListen', { streamId });
+        await this.callMethod('streamListen', { streamId }, { bypassCircuitBreaker: true });
       } catch {
         // Best-effort; caller may re-subscribe
       }
@@ -284,10 +287,28 @@ export class FlutterVMClient {
   async callMethod(
     method: string,
     params?: Record<string, unknown>,
-    options?: { timeoutMs?: number },
+    options?: { timeoutMs?: number; bypassCircuitBreaker?: boolean },
   ): Promise<Record<string, unknown>> {
     if (!this.isConnected()) {
       throw new FlutterVMError('Not connected to VM Service', 'NOT_CONNECTED');
+    }
+
+    // Per-device circuit breaker: short-circuit when a recent burst of
+    // failures tripped the breaker open, so we don't pile another 10-30 s
+    // request timeout on top of an already failing VM Service. The
+    // heartbeat ping and internal lifecycle calls bypass the breaker to
+    // avoid a feedback loop and to allow the breaker's half-open probe
+    // path to succeed via the lighter `getVersion` heartbeat.
+    const deviceId = this.state?.deviceId;
+    const useBreaker = !options?.bypassCircuitBreaker && deviceId;
+    if (useBreaker) {
+      const breaker = flutterCircuitBreakers().get(deviceId);
+      if (!breaker.isAvailable()) {
+        throw new FlutterVMError(
+          `Circuit breaker open for device ${deviceId}; backing off ${method}`,
+          'CIRCUIT_OPEN',
+        );
+      }
     }
 
     const timeoutMs = options?.timeoutMs
@@ -301,7 +322,7 @@ export class FlutterVMClient {
       params,
     };
 
-    return new Promise((resolve, reject) => {
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
         reject(new FlutterVMError(
@@ -312,7 +333,20 @@ export class FlutterVMClient {
 
       this.pending.set(id, { resolve, reject, timer, method });
       this.ws!.send(JSON.stringify(request));
-    });
+    }).then(
+      (value) => {
+        if (useBreaker) flutterCircuitBreakers().get(deviceId).recordSuccess();
+        return value;
+      },
+      (err) => {
+        if (useBreaker) {
+          flutterCircuitBreakers()
+            .get(deviceId)
+            .recordFailure(err instanceof Error ? err : new Error(String(err)));
+        }
+        throw err;
+      },
+    );
   }
 
   /**
@@ -786,7 +820,7 @@ export class FlutterVMClient {
       // returns ~50 bytes). Failure here means the socket is half-open or
       // the proxy died — trigger the reconnect path the same way `close`
       // would.
-      this.callMethod('getVersion', undefined, { timeoutMs: 5000 }).catch(() => {
+      this.callMethod('getVersion', undefined, { timeoutMs: 5000, bypassCircuitBreaker: true }).catch(() => {
         if (this.wantOpen && !this.reconnecting && this.lastConnectOptions) {
           forgetVMServiceUrl(this.lastConnectOptions.deviceId);
           try {
@@ -870,9 +904,10 @@ export class FlutterVMClient {
 
   private async subscribeIsolateLifecycle(): Promise<void> {
     // Idempotent: VM Service rejects duplicate `streamListen` with a
-    // 103 error which we can safely ignore.
+    // 103 error which we can safely ignore. Bypass the breaker — this is
+    // an infrastructure subscription, not a user-visible op.
     try {
-      await this.callMethod('streamListen', { streamId: 'Isolate' });
+      await this.callMethod('streamListen', { streamId: 'Isolate' }, { bypassCircuitBreaker: true });
       this.subscribedStreams.add('Isolate');
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/reliability/crash-watcher.ts
+++ b/src/reliability/crash-watcher.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from 'events';
 import { SimulatorPool } from '../simulator/pool';
 import { CircuitBreakerRegistry } from './circuit-breaker';
+import { removeFlutterVMClient } from '../flutter';
+import { forgetVMServiceUrl } from '../flutter/vm-service-discovery';
+import { flutterCircuitBreakers } from '../flutter/flutter-circuit-breakers';
 
 export class SimulatorCrashWatcher extends EventEmitter {
   private interval: ReturnType<typeof setInterval> | null = null;
@@ -41,6 +44,10 @@ export class SimulatorCrashWatcher extends EventEmitter {
           if (previousState === 'Booted') {
             console.error(`[CrashWatcher] Simulator ${deviceId} crashed (was Booted, now ${device?.state ?? 'gone'})`);
             this.circuitBreakers?.get(deviceId).trip();
+            // Trip the Flutter-side breaker too so any in-flight
+            // `flutter_*` tool calls fail fast instead of hanging on a
+            // dead simulator.
+            flutterCircuitBreakers().get(deviceId).trip();
             this.emit('crash', { deviceId });
             await this.recover(deviceId);
           }
@@ -60,30 +67,61 @@ export class SimulatorCrashWatcher extends EventEmitter {
 
       console.error(`[CrashWatcher] Recovering ${sim.preset}...`);
 
+      // Tear down any Flutter VM Service state for this device. The
+      // simulator is being re-booted; the singleton FlutterVMClient is
+      // pointing at a now-dead WebSocket and a stale isolate id. Without
+      // this, the next `flutter_connect` against the same UDID would
+      // inherit and surface confusing NO_ISOLATE / NOT_CONNECTED errors.
+      try {
+        removeFlutterVMClient(deviceId);
+        forgetVMServiceUrl(deviceId);
+      } catch (err) {
+        console.error(`[CrashWatcher] Flutter cleanup failed for ${deviceId}: ${err}`);
+      }
+
       // Re-boot
       await manager.boot(sim.preset);
 
-      // Reconnect WebKit
+      // Reconnect WebKit (track outcome so 'recovered' isn't claimed when
+      // the WebKit reconnect actually failed — caller may want to retry
+      // or open the circuit again instead of pretending we healed).
+      let webkitOk = false;
       try {
         await sim.client.connect();
+        webkitOk = true;
       } catch {
         console.error(`[CrashWatcher] WebKit reconnect failed for ${sim.preset}`);
       }
 
       // Restore auth if available
+      let authOk = true;
       if (this.authProfile) {
         try {
           await this.pool.injectAuth(this.authProfile);
         } catch {
           console.error(`[CrashWatcher] Auth restore failed for ${sim.preset}`);
+          authOk = false;
         }
       }
 
       this.knownStates.set(deviceId, 'Booted');
-      this.circuitBreakers?.get(deviceId).reset();
-      const duration = Date.now() - startTime;
-      console.error(`[CrashWatcher] Recovered ${sim.preset} in ${duration}ms`);
-      this.emit('recovered', { deviceId, duration });
+
+      if (webkitOk && authOk) {
+        this.circuitBreakers?.get(deviceId).reset();
+        // Reset the Flutter-side breaker too so the next flutter_connect
+        // against this device isn't blocked by the pre-crash failure
+        // accounting carried in the registry.
+        flutterCircuitBreakers().get(deviceId).reset();
+        const duration = Date.now() - startTime;
+        console.error(`[CrashWatcher] Recovered ${sim.preset} in ${duration}ms`);
+        this.emit('recovered', { deviceId, duration });
+      } else {
+        const duration = Date.now() - startTime;
+        console.error(
+          `[CrashWatcher] Partial recovery for ${sim.preset} (webkit=${webkitOk}, auth=${authOk})`,
+        );
+        this.emit('recovery-partial', { deviceId, duration, webkitOk, authOk });
+      }
     } catch (err) {
       console.error(`[CrashWatcher] Recovery failed for ${deviceId}: ${err}`);
       this.emit('recovery-failed', { deviceId, error: err });

--- a/tests/unit/flutter-circuit-breaker.test.ts
+++ b/tests/unit/flutter-circuit-breaker.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for PR2 — Flutter VM circuit breaker integration.
+ *
+ * The actual breaker registry lives in `flutter-circuit-breakers.ts`. The
+ * client-side wiring (callMethod consults & records into the breaker) is
+ * the surface under test.
+ */
+
+import { FlutterVMClient, FlutterVMError } from '../../src/flutter/vm-service-client';
+import { flutterCircuitBreakers } from '../../src/flutter/flutter-circuit-breakers';
+
+const TEST_DEVICE = 'CB-TEST-DEVICE';
+
+function makeClientWithFakeWs(): FlutterVMClient {
+  const client = new FlutterVMClient({ heartbeatIntervalMs: 0 });
+  (client as unknown as { ws: unknown }).ws = {
+    readyState: 1, // OPEN
+    send: () => {/* discard */},
+  };
+  (client as unknown as { state: Record<string, unknown> }).state = {
+    httpUrl: 'http://127.0.0.1:1/x=/',
+    wsUrl: 'ws://127.0.0.1:1/x=/ws',
+    connected: true,
+    deviceId: TEST_DEVICE,
+  };
+  return client;
+}
+
+afterEach(() => {
+  flutterCircuitBreakers().get(TEST_DEVICE).reset();
+  flutterCircuitBreakers().remove(TEST_DEVICE);
+});
+
+describe('FlutterVMClient circuit breaker', () => {
+  it('fails fast with CIRCUIT_OPEN when the per-device breaker is open', async () => {
+    flutterCircuitBreakers().get(TEST_DEVICE).trip();
+    const client = makeClientWithFakeWs();
+
+    await expect(client.callMethod('getVM')).rejects.toMatchObject({
+      name: 'FlutterVMError',
+      code: 'CIRCUIT_OPEN',
+    });
+  });
+
+  it('bypasses the breaker when bypassCircuitBreaker: true is set', async () => {
+    flutterCircuitBreakers().get(TEST_DEVICE).trip();
+    const client = makeClientWithFakeWs();
+
+    // We expect this to NOT throw CIRCUIT_OPEN. It will eventually fail
+    // with a timeout because the fake WS never responds — but the timeout
+    // proves we got past the breaker gate.
+    const pending = client
+      .callMethod('getVersion', undefined, { timeoutMs: 50, bypassCircuitBreaker: true })
+      .catch((e: Error) => e);
+
+    const err = (await pending) as FlutterVMError;
+    expect(err.code).toBe('REQUEST_TIMEOUT');
+  });
+
+  it('records failures into the breaker and trips after 3 timeouts', async () => {
+    const client = makeClientWithFakeWs();
+    const breaker = flutterCircuitBreakers().get(TEST_DEVICE);
+    expect(breaker.getState()).toBe('closed');
+
+    for (let i = 0; i < 3; i++) {
+      await expect(
+        client.callMethod('someMethod', undefined, { timeoutMs: 25 }),
+      ).rejects.toThrow();
+    }
+
+    expect(breaker.getState()).toBe('open');
+  });
+});


### PR DESCRIPTION
> **Stacked on** #767 (Flutter VM Service lifecycle). Diff against `feature/flutter-vm-lifecycle`; re-target to `develop` after #767 lands.

## Summary
Wires Flutter VM Service stability into the same reliability primitives the WebKit side already enjoys. A flapping VM Service or a simulator crash now fails fast instead of pinning the event loop with repeated 10-30 s timeouts, and a recovered simulator starts the next Flutter session from a clean slate.

### `flutter-circuit-breakers.ts` (new)
Process-singleton `CircuitBreakerRegistry` tuned for VM Service characteristics (`failureThreshold: 3`, `cooldownMs: 10000`, `halfOpenMaxAttempts: 1`). Lives separately from `SimulatorPool`'s registry — the pool's breaker tracks simulator-level health, this one tracks short-burst VM Service failures.

### `vm-service-client.ts`
`callMethod` now consults the per-device breaker keyed by `state.deviceId`:
- Open breaker rejects immediately with `FlutterVMError(CIRCUIT_OPEN)` so callers learn within milliseconds instead of waiting for the full timeout.
- Success / failure outcomes are recorded into the breaker. 3 consecutive failures trip; a successful half-open probe closes.
- Infrastructure calls (heartbeat `getVersion`, `streamListen` for the Isolate stream + replayed subscriptions during reconnect) pass `bypassCircuitBreaker: true` so the breaker can't deadlock the reconnect path or feed back on its own probe.

### `crash-watcher.ts`
Recovery now:
- Calls `removeFlutterVMClient(deviceId)` + `forgetVMServiceUrl(deviceId)` **before** re-booting, so the next `flutter_connect` against the recovered UDID doesn't inherit a stale singleton pointing at a dead WebSocket and an exited isolate.
- Tracks WebKit reconnect and auth restore outcomes individually — emits `recovered` only when both succeed, otherwise emits a new `recovery-partial` event with `{ webkitOk, authOk }` instead of pretending we healed.
- On the crash trip path, also trips `flutterCircuitBreakers().get(deviceId)` so any in-flight `flutter_*` tool call fails fast against the dead simulator.
- On full recovery, resets the Flutter-side breaker so the next `flutter_connect` isn't blocked by pre-crash failure accounting.

## Background
Pre-PR2 the `crash-watcher` only knew about WebKit. After a recovered simulator, the next `flutter_connect` inherited stale `mainIsolateId` / `connected=false` and surfaced confusing `NO_ISOLATE` / `NOT_CONNECTED` errors. Audit recommendation S-6 + S-7.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`flutter-circuit-breaker.test.ts\` (3 tests): CIRCUIT_OPEN fail-fast, bypass flag actually bypasses (verified via timeout instead of CIRCUIT_OPEN), 3-failure trip into open state.
- [x] Full unit suite: 181 suites / 2687 tests / 0 failures (was 180/2684).
- [ ] Manual: kill SpringBoard on a Flutter-running simulator, confirm \`flutter_widget_tree\` fails fast with \`CIRCUIT_OPEN\` instead of hanging until the breaker's cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)