### PR TITLE
feat(tools): app_launch authProfile pre-seed hook

### DIFF
--- a/src/tools/app-launch.ts
+++ b/src/tools/app-launch.ts
@@ -1,12 +1,16 @@
 import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { getSessionManager } from '../session-manager';
+import { NativeAuthManager } from '../auth/native-manager';
 
 export function registerAppLaunchTool(server: MCPServer): void {
+  const nativeAuth = new NativeAuthManager();
+
   server.registerTool(
     {
       name: 'app_launch',
-      description: 'Launch an app by bundle identifier on a booted iOS Simulator',
+      description:
+        'Launch an app by bundle identifier on a booted iOS Simulator. Optionally pre-seeds a saved native auth profile (data container + Keychain) before launching so the app starts already logged in.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -28,6 +32,11 @@ export function registerAppLaunchTool(server: MCPServer): void {
             additionalProperties: { type: 'string' },
             description: 'Optional environment variables set in the launched app',
           },
+          authProfile: {
+            type: 'string',
+            description:
+              'Name of a previously saved native auth profile (see auth_save_native) to restore before launching. Restores the data container (and Keychain if the profile included it) so the app starts in its captured signed-in state.',
+          },
         },
         required: ['bundleId'],
       },
@@ -40,7 +49,13 @@ export function registerAppLaunchTool(server: MCPServer): void {
 
       if (!deviceId) {
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'DEVICE_NOT_BOOTED', message: 'No booted simulator found. Call device_boot first.' }) }],
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'DEVICE_NOT_BOOTED',
+              message: 'No booted simulator found. Call device_boot first.',
+            }),
+          }],
           isError: true,
         };
       }
@@ -48,13 +63,37 @@ export function registerAppLaunchTool(server: MCPServer): void {
       const bundleId = params.bundleId as string;
       const args = params.args as string[] | undefined;
       const env = params.env as Record<string, string> | undefined;
+      const authProfile = params.authProfile as string | undefined;
+
+      let authRestored: false | { profile: string; keychain: boolean; warning?: string } = false;
+      if (authProfile) {
+        // Restore first — the call internally terminates the app before
+        // wiping the data container, so by the time `launchApp` runs the
+        // process is in a clean post-restore state.
+        try {
+          const data = await nativeAuth.restore(deviceId, bundleId, authProfile);
+          authRestored = {
+            profile: data.profile,
+            keychain: Boolean(data.keychainArchive),
+          };
+        } catch (err) {
+          // Don't fail the whole launch — surface the auth failure as a
+          // warning so the caller can still drive the login flow manually.
+          const message = err instanceof Error ? err.message : String(err);
+          authRestored = {
+            profile: authProfile,
+            keychain: false,
+            warning: `auth_restore_native failed: ${message}`,
+          };
+        }
+      }
 
       const result = await manager.launchApp(deviceId, bundleId, { args, env });
 
       return {
         content: [{
           type: 'text' as const,
-          text: JSON.stringify(result),
+          text: JSON.stringify({ ...result, authRestored }),
         }],
       };
     },

--- a/tests/unit/app-launch-auth-seed.test.ts
+++ b/tests/unit/app-launch-auth-seed.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for PR4 — `app_launch` auth pre-seed hook.
+ *
+ * Verifies the new `authProfile` argument hands off to
+ * NativeAuthManager.restore() before manager.launchApp() runs, and that
+ * restore failures degrade gracefully to a warning instead of aborting
+ * the launch.
+ */
+
+const mockRestore = jest.fn();
+const mockLaunchApp = jest.fn();
+const mockListBooted = jest.fn();
+
+jest.mock('../../src/auth/native-manager', () => ({
+  NativeAuthManager: jest.fn().mockImplementation(() => ({
+    restore: mockRestore,
+  })),
+}));
+
+jest.mock('../../src/simulator', () => ({
+  SimulatorManager: jest.fn().mockImplementation(() => ({
+    launchApp: mockLaunchApp,
+    listBooted: mockListBooted,
+  })),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'DEV-1',
+  }),
+}));
+
+import { registerAppLaunchTool } from '../../src/tools/app-launch';
+
+type Handler = (sessionId: string, params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function captureHandler(): Handler {
+  let handler: Handler | undefined;
+  const server = {
+    registerTool: (_descriptor: unknown, fn: Handler) => {
+      handler = fn;
+    },
+  } as unknown as Parameters<typeof registerAppLaunchTool>[0];
+  registerAppLaunchTool(server);
+  if (!handler) throw new Error('handler not registered');
+  return handler;
+}
+
+describe('app_launch with authProfile', () => {
+  beforeEach(() => {
+    mockRestore.mockReset();
+    mockLaunchApp.mockReset();
+    mockListBooted.mockReset();
+    mockListBooted.mockResolvedValue([{ udid: 'DEV-1' }]);
+    mockLaunchApp.mockResolvedValue({ launched: true, pid: 12345 });
+  });
+
+  it('restores the native auth profile before launchApp and reports keychain status', async () => {
+    mockRestore.mockResolvedValue({
+      profile: 'logged-in',
+      bundleId: 'com.example.app',
+      deviceUdid: 'DEV-1',
+      keychainArchive: '/tmp/keychains.tar',
+    });
+
+    const handler = captureHandler();
+    const result = await handler('s', { bundleId: 'com.example.app', authProfile: 'logged-in' });
+    const body = JSON.parse(result.content[0].text);
+
+    // restore was called BEFORE launchApp.
+    const restoreOrder = mockRestore.mock.invocationCallOrder[0];
+    const launchOrder = mockLaunchApp.mock.invocationCallOrder[0];
+    expect(restoreOrder).toBeLessThan(launchOrder);
+
+    expect(mockRestore).toHaveBeenCalledWith('DEV-1', 'com.example.app', 'logged-in');
+    expect(body.launched).toBe(true);
+    expect(body.authRestored).toEqual({ profile: 'logged-in', keychain: true });
+  });
+
+  it('surfaces restore failure as a warning but still launches', async () => {
+    mockRestore.mockRejectedValue(new Error('container.tar missing'));
+
+    const handler = captureHandler();
+    const result = await handler('s', { bundleId: 'com.example.app', authProfile: 'broken' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockLaunchApp).toHaveBeenCalled();
+    expect(body.launched).toBe(true);
+    expect(body.authRestored).toMatchObject({
+      profile: 'broken',
+      keychain: false,
+      warning: expect.stringContaining('container.tar missing'),
+    });
+  });
+
+  it('skips restore entirely when authProfile is omitted', async () => {
+    const handler = captureHandler();
+    const result = await handler('s', { bundleId: 'com.example.app' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockRestore).not.toHaveBeenCalled();
+    expect(body.authRestored).toBe(false);
+  });
+});


### PR DESCRIPTION
> **Stacked on** #769 (NativeAuthManager). Diff against \`feature/native-auth-manager\`; re-target to \`develop\` after #769 lands.

## Summary
Adds an `authProfile` argument to `app_launch` that restores a saved `NativeAuthManager` profile (data container + optional Keychain) **before** launching, so Flutter native apps can start already signed-in without the caller wiring `auth_restore_native` + `app_launch` together each time.

### Behaviour
- With `authProfile`: handler calls `nativeAuth.restore(deviceId, bundleId, profile)` first — terminate app, wipe container, untar saved state, optionally reseed Keychain — **then** runs `manager.launchApp`.
- Restore failure (profile missing, archive corrupted, etc.) **does not abort** the launch. The response surfaces `authRestored.warning` describing the failure so the caller can still drive a manual login fallback.
- Without `authProfile`: pure pass-through. Response shape is stable with `authRestored: false`.

## Background
Audit recommendation A-8. NativeAuthManager (#769) gave us the capture/restore primitives; this PR makes the "logged-in launch" path a 1st-class workflow instead of a 2-step manual recipe.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`app-launch-auth-seed.test.ts\` (3 tests): restore-before-launch ordering via \`invocationCallOrder\`, restore failure → warning + launch still runs, no \`authProfile\` → no restore call.
- [ ] Manual: \`auth_save_native\` against a logged-in Flutter app, \`simctl uninstall\` + \`simctl install\`, \`app_launch { authProfile: 'main' }\` → app should come up signed in with no manual login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)