### PR TITLE
feat(tools): app_biometric automation + Face/Touch ID alert label coverage

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b62dba66-abdc-4951-8e70-674549aea677","pid":51989,"procStart":"Wed May 20 15:33:56 2026","acquiredAt":1779333431078}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b62dba66-abdc-4951-8e70-674549aea677","pid":51989,"procStart":"Wed May 20 15:33:56 2026","acquiredAt":1779333431078}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ npm-debug.log*
 
 # Generated verification reports
 scripts/.verify-issue-10-healthy.report.json
+
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock

--- a/src/security/high-risk-tools.ts
+++ b/src/security/high-risk-tools.ts
@@ -59,6 +59,10 @@ export const HIGH_RISK_MCP_TOOLS: Readonly<Record<string, HighRiskToolMetadata>>
     category: 'credential-movement',
     requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
   },
+  app_biometric: {
+    category: 'credential-movement',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
   cookies: {
     category: 'credential-movement',
     requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,

--- a/src/tools/app-biometric.ts
+++ b/src/tools/app-biometric.ts
@@ -1,0 +1,142 @@
+/**
+ * `app_biometric` — drive the iOS Simulator's biometric sensor non-interactively
+ * via `xcrun simctl ui <device> biometric ...`.
+ *
+ * Without this tool, any Flutter app that protects a token via `local_auth`
+ * or `flutter_secure_storage(useBiometricAuthentication: true)` blocks
+ * automation at the first Face ID / Touch ID prompt. The simulator can be
+ * told to satisfy or fail an in-flight prompt and to enroll/un-enroll the
+ * sensor itself, but those simctl verbs live under `simctl ui` and aren't
+ * surfaced anywhere else in OpenSafari yet.
+ *
+ * Supported actions
+ *   enroll       — turn on the simulated sensor (so subsequent prompts can match)
+ *   unenroll     — turn the sensor off (forces the app's "no biometric" fallback)
+ *   match        — satisfy the next pending prompt (Face/Touch matched)
+ *   nonmatch     — fail the next pending prompt
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { MCPServer } from '../mcp-server';
+import { SimulatorManager } from '../simulator';
+import { getSessionManager } from '../session-manager';
+
+const execFileAsync = promisify(execFile);
+
+const ACTIONS = ['enroll', 'unenroll', 'match', 'nonmatch'] as const;
+type BiometricAction = (typeof ACTIONS)[number];
+
+async function resolveDeviceId(params: Record<string, unknown>): Promise<string | null> {
+  const explicit = params.deviceId as string | undefined;
+  if (explicit) return explicit;
+  const sm = getSessionManager();
+  const sole = sm.getSoleDeviceId();
+  if (sole) return sole;
+  try {
+    const booted = await new SimulatorManager().listBooted();
+    if (booted.length === 1) return booted[0].udid;
+  } catch {
+    // simctl unavailable
+  }
+  return null;
+}
+
+async function runBiometric(deviceId: string, action: BiometricAction): Promise<void> {
+  // simctl ui biometric subcommands:
+  //   enrollment [--enroll=<true|false>]     — set/clear enrollment
+  //   match                                  — satisfy pending prompt
+  //   nonmatch                               — fail pending prompt
+  switch (action) {
+    case 'enroll':
+      await execFileAsync('xcrun', ['simctl', 'ui', deviceId, 'biometric', 'enrollment', '--enroll=true']);
+      return;
+    case 'unenroll':
+      await execFileAsync('xcrun', ['simctl', 'ui', deviceId, 'biometric', 'enrollment', '--enroll=false']);
+      return;
+    case 'match':
+      await execFileAsync('xcrun', ['simctl', 'ui', deviceId, 'biometric', 'match']);
+      return;
+    case 'nonmatch':
+      await execFileAsync('xcrun', ['simctl', 'ui', deviceId, 'biometric', 'nonmatch']);
+      return;
+  }
+}
+
+export function registerAppBiometricTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_biometric',
+      description:
+        'Drive the simulator\'s biometric sensor. Use `enroll` once per session to arm Face/Touch ID, then `match`/`nonmatch` to satisfy or fail each pending in-app prompt without manual taps.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          action: {
+            type: 'string',
+            enum: [...ACTIONS],
+            description: 'enroll | unenroll | match | nonmatch',
+          },
+          deviceId: {
+            type: 'string',
+            description: 'Simulator UDID (defaults to the sole booted device)',
+          },
+        },
+        required: ['action'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      const action = params.action as BiometricAction | undefined;
+      if (!action || !ACTIONS.includes(action)) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'INVALID_ACTION',
+              message: `action must be one of: ${ACTIONS.join(', ')}`,
+            }),
+          }],
+          isError: true,
+        };
+      }
+
+      const deviceId = await resolveDeviceId(params);
+      if (!deviceId) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'DEVICE_NOT_BOOTED',
+              message: 'No booted simulator found. Call device_boot first.',
+            }),
+          }],
+          isError: true,
+        };
+      }
+
+      try {
+        await runBiometric(deviceId, action);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({ success: true, action, deviceId }),
+          }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'BIOMETRIC_FAILED',
+              action,
+              deviceId,
+              message,
+            }),
+          }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/app-handle-alert-labels.ts
+++ b/src/tools/app-handle-alert-labels.ts
@@ -8,10 +8,30 @@ export interface AlertLabel {
 }
 
 export const ACCEPT_LABELS: Record<AlertLocale, string[]> = {
-  en: ['Allow', 'OK', 'Allow Once', 'Allow While Using App', 'Allow All', 'Continue', 'Yes', 'Open Settings', 'Enable'],
-  ko: ['허용', '확인', '한 번 허용', '앱을 사용하는 동안 허용', '계속', '설정 열기', '켜기'],
-  ja: ['許可', 'OK', '常に許可', '一度だけ許可', '続ける', '設定を開く'],
-  'zh-Hans': ['允许', '好', '始终允许', '仅允许一次', '继续', '打开设置'],
+  en: [
+    'Allow', 'OK', 'Allow Once', 'Allow While Using App', 'Allow All', 'Continue', 'Yes',
+    'Open Settings', 'Enable',
+    // Biometric / passcode prompts surfaced by LAContext + flutter_secure_storage.
+    // Apple sometimes adds the sensor name to the button label; include all
+    // common variants so app_alert_handle can dismiss them without needing
+    // the simctl ui biometric path (the tool exists for in-app prompts but
+    // the system-level "Continue" sheet has its own accept verb).
+    'Use Face ID', 'Use Touch ID', 'Use Passcode',
+    'Continue with Face ID', 'Continue with Touch ID',
+    'Enable Face ID', 'Enable Touch ID',
+  ],
+  ko: [
+    '허용', '확인', '한 번 허용', '앱을 사용하는 동안 허용', '계속', '설정 열기', '켜기',
+    'Face ID 사용', 'Touch ID 사용', '암호 사용',
+  ],
+  ja: [
+    '許可', 'OK', '常に許可', '一度だけ許可', '続ける', '設定を開く',
+    'Face IDを使用', 'Touch IDを使用', 'パスコードを使用',
+  ],
+  'zh-Hans': [
+    '允许', '好', '始终允许', '仅允许一次', '继续', '打开设置',
+    '使用面容 ID', '使用触控 ID', '使用密码',
+  ],
 };
 
 export const DISMISS_LABELS: Record<AlertLocale, string[]> = {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -83,6 +83,7 @@ import { registerAppAssertTool } from './app-assert';
 import { registerAppWebviewConnectTool } from './app-webview-connect';
 import { registerSetActiveContextTool } from './set-active-context';
 import { registerAppPermissionTools } from './app-permission';
+import { registerAppBiometricTool } from './app-biometric';
 import { registerQaFlutterTouchTargetsTool } from './qa-flutter-touch-targets';
 import { registerQaFlutterSemanticsTool } from './qa-flutter-semantics';
 import { registerQaFlutterDarkModeTool } from './qa-flutter-dark-mode';
@@ -275,6 +276,7 @@ export function registerAllTools(server: MCPServer): void {
   registerSetActiveContextTool(server);
   // Tier 2: Native App — System Surfaces
   registerAppPermissionTools(server);
+  registerAppBiometricTool(server);
 
   // Tier 2: Flutter QA Detectors
   registerQaFlutterTouchTargetsTool(server);

--- a/tests/unit/app-biometric.test.ts
+++ b/tests/unit/app-biometric.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for PR5 — `app_biometric` tool + Face/Touch ID alert label coverage.
+ *
+ * Mocks child_process.execFile so the test never shells out to the real
+ * xcrun. Verifies the four supported actions map to the right
+ * `simctl ui ... biometric` invocations.
+ */
+
+import { ACCEPT_LABELS, matchLabel } from '../../src/tools/app-handle-alert-labels';
+
+const mockExecFile = jest.fn();
+jest.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => mockExecFile(...args),
+}));
+
+jest.mock('../../src/simulator', () => ({
+  SimulatorManager: jest.fn().mockImplementation(() => ({
+    listBooted: jest.fn().mockResolvedValue([{ udid: 'DEV-1' }]),
+  })),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'DEV-1',
+  }),
+}));
+
+import { registerAppBiometricTool } from '../../src/tools/app-biometric';
+
+type Handler = (sessionId: string, params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function captureHandler(): Handler {
+  let handler: Handler | undefined;
+  const server = {
+    registerTool: (_d: unknown, fn: Handler) => {
+      handler = fn;
+    },
+  } as unknown as Parameters<typeof registerAppBiometricTool>[0];
+  registerAppBiometricTool(server);
+  if (!handler) throw new Error('handler not registered');
+  return handler;
+}
+
+describe('app_biometric tool', () => {
+  beforeEach(() => {
+    mockExecFile.mockReset();
+    // promisify(execFile)(...) is what the production code awaits; the
+    // node `util.promisify` adapter handles a (err, value) callback. Make
+    // the mock invoke its callback synchronously with no error.
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: unknown, value: unknown) => void) => {
+      cb(null, { stdout: '', stderr: '' });
+    });
+  });
+
+  it.each([
+    ['enroll', ['simctl', 'ui', 'DEV-1', 'biometric', 'enrollment', '--enroll=true']],
+    ['unenroll', ['simctl', 'ui', 'DEV-1', 'biometric', 'enrollment', '--enroll=false']],
+    ['match', ['simctl', 'ui', 'DEV-1', 'biometric', 'match']],
+    ['nonmatch', ['simctl', 'ui', 'DEV-1', 'biometric', 'nonmatch']],
+  ])('action=%s issues the correct simctl ui command', async (action, expectedArgs) => {
+    const handler = captureHandler();
+    const result = await handler('s', { action });
+    const body = JSON.parse(result.content[0].text);
+    expect(body.success).toBe(true);
+    const call = mockExecFile.mock.calls[0];
+    expect(call[0]).toBe('xcrun');
+    expect(call[1]).toEqual(expectedArgs);
+  });
+
+  it('rejects invalid action', async () => {
+    const handler = captureHandler();
+    const result = await handler('s', { action: 'identify' });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toBe('INVALID_ACTION');
+  });
+
+  it('surfaces simctl failure via BIOMETRIC_FAILED', async () => {
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: unknown) => void) => {
+      cb(new Error('simctl: no such device'));
+    });
+    const handler = captureHandler();
+    const result = await handler('s', { action: 'match' });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toBe('BIOMETRIC_FAILED');
+    expect(body.message).toContain('simctl');
+  });
+});
+
+describe('biometric alert labels in ACCEPT_LABELS corpus', () => {
+  it.each([
+    ['Use Face ID', 'en'],
+    ['Use Touch ID', 'en'],
+    ['Continue with Face ID', 'en'],
+    ['Face ID 사용', 'ko'],
+    ['Touch ID 사용', 'ko'],
+    ['Face IDを使用', 'ja'],
+    ['使用面容 ID', 'zh-Hans'],
+  ])('matches %s as accept (locale=%s)', (label, locale) => {
+    const result = matchLabel(label, 'accept');
+    expect(result).not.toBeNull();
+    expect(result?.locale).toBe(locale);
+  });
+
+  it('keeps prior English Allow/OK/Continue labels working', () => {
+    expect(ACCEPT_LABELS.en).toContain('Allow');
+    expect(ACCEPT_LABELS.en).toContain('OK');
+    expect(ACCEPT_LABELS.en).toContain('Continue');
+  });
+});


### PR DESCRIPTION
## Summary
Adds non-interactive control over the iOS Simulator's biometric sensor so Flutter apps that protect tokens via \`local_auth\` / \`flutter_secure_storage(useBiometricAuthentication: true)\` no longer block automation at the first Face ID / Touch ID prompt.

### New tool: \`app_biometric\`
Wraps \`xcrun simctl ui <device> biometric ...\`:
- \`enroll\` → \`enrollment --enroll=true\` (arm the sensor)
- \`unenroll\` → \`enrollment --enroll=false\` (force "no biometric" fallback)
- \`match\` → satisfy the pending prompt
- \`nonmatch\` → fail the pending prompt

\`deviceId\` resolution falls back to \`SessionManager.getSoleDeviceId()\` and \`simctl list booted\` if exactly one device is up, matching every other \`app_*\` tool. simctl failures surface a structured \`BIOMETRIC_FAILED\` instead of an uncaught exception.

### Alert label corpus
\`ACCEPT_LABELS\` picks up biometric-prompt accept verbs across en / ko / ja / zh-Hans so \`app_alert_handle\` can dismiss the system-level \"Continue with Face ID\" / \"Use Touch ID\" sheets without needing the biometric path:
| Locale | Labels added |
|---|---|
| en | Use Face ID, Use Touch ID, Use Passcode, Continue with Face ID, Continue with Touch ID, Enable Face/Touch ID |
| ko | Face ID 사용, Touch ID 사용, 암호 사용 |
| ja | Face IDを使用, Touch IDを使用, パスコードを使用 |
| zh-Hans | 使用面容 ID, 使用触控 ID, 使用密码 |

## Background
Audit recommendation A-4. Previously, any Flutter app gated by \`local_auth\` paused automation at the first Face ID prompt — no programmatic accept path existed and the alert label corpus didn't even know the prompts.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`app-biometric.test.ts\` (14 tests):
  - Each of the 4 actions maps to the correct \`simctl ui\` invocation
  - Invalid action → \`INVALID_ACTION\`
  - simctl failure → \`BIOMETRIC_FAILED\` with underlying message
  - \`matchLabel\` resolves biometric labels across en/ko/ja/zh-Hans
  - Pre-existing Allow/OK/Continue labels still match
- [ ] Manual: \`app_biometric { action: 'enroll' }\` on a fresh sim, launch a Flutter app that calls \`local_auth.authenticate()\`, run \`app_biometric { action: 'match' }\` → prompt should be satisfied without user input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)