### PR TITLE
feat(simulator): device_boot fast path — skip when already booted and healthy

### DIFF
--- a/src/tools/device-boot.ts
+++ b/src/tools/device-boot.ts
@@ -1,7 +1,7 @@
 import { MCPServer } from '../mcp-server';
-import { SimulatorManager } from '../simulator';
+import { getDefaultSimulatorManager } from '../simulator';
 import { SimctlExecutor } from '../simulator/simctl';
-import { getProxyForDevice, stopProxyForDevice } from '../simulator/proxy-manager';
+import { getProxyForDevice, stopProxyForDevice, peekProxyForDevice } from '../simulator/proxy-manager';
 import { WebKitClient } from '../webkit/client';
 import { addManagedDevice } from '../reliability/zombie-cleanup';
 import { getSessionManager } from '../session-manager';
@@ -23,14 +23,47 @@ export function registerDeviceBootTool(server: MCPServer): void {
       },
     },
     async (_sessionId: string, params: Record<string, unknown>) => {
-      const manager = new SimulatorManager();
+      const manager = getDefaultSimulatorManager();
 
       // Enforce max-simulator concurrency limit before attempting boot
       const maxSims = parseInt(process.env.OPENSAFARI_MAX_SIMULATORS ?? '', 10) || DEFAULT_MAX_SIMULATORS;
       const booted = await manager.listBooted();
-      const alreadyBooted = booted.some(
-        (d) => d.name === (params.device as string) || d.udid === (params.device as string),
+      const target = params.device as string;
+      const alreadyBootedDevice = booted.find(
+        (d) => d.name === target || d.udid === target,
       );
+      const alreadyBooted = Boolean(alreadyBootedDevice);
+
+      // Fast path: device is already booted AND we still have a healthy
+      // WebKitClient + proxy for it from a prior call. Skip the entire
+      // boot/openSafari/connectWebKit sequence — repeating it tears down
+      // an otherwise-good WebSocket and races against any Flutter VM
+      // service that's still using the proxy. Without this, every
+      // `device_boot` call paid a ~2-5 s tax on already-healthy sims.
+      if (alreadyBootedDevice) {
+        const sm = getSessionManager();
+        const existingClient = sm.getConnection(alreadyBootedDevice.udid);
+        const existingProxy = peekProxyForDevice(alreadyBootedDevice.udid);
+        if (existingClient && existingClient.isConnected() && existingProxy?.running) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify({
+                udid: alreadyBootedDevice.udid,
+                name: alreadyBootedDevice.name,
+                state: alreadyBootedDevice.state,
+                alreadyBootedAndHealthy: true,
+                proxy: {
+                  running: existingProxy.running,
+                  pid: existingProxy.pid,
+                  port: existingProxy.port,
+                },
+              }),
+            }],
+          };
+        }
+      }
+
       if (!alreadyBooted && booted.length >= maxSims) {
         return {
           content: [{

--- a/tests/unit/device-boot-fast-path.test.ts
+++ b/tests/unit/device-boot-fast-path.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit test for PR7 — `device_boot` short-circuits when the target is
+ * already booted AND has a healthy WebKit connection + proxy.
+ *
+ * We can't realistically test the long-path boot here (it spans
+ * SimulatorManager, proxy-manager, WebKitClient, etc.), but the fast
+ * path is a pure decision over already-mocked dependencies and is the
+ * surface that catches the "every device_boot call rebuilds the
+ * WebKit connection" regression.
+ */
+
+jest.mock('../../src/simulator', () => {
+  const listBooted = jest.fn();
+  const boot = jest.fn().mockRejectedValue(new Error('test bail-out'));
+  return {
+    getDefaultSimulatorManager: jest.fn(() => ({ listBooted, boot })),
+    __mocks: { listBooted, boot },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const simulatorMocks = (require('../../src/simulator') as unknown as {
+  __mocks: { listBooted: jest.Mock; boot: jest.Mock };
+}).__mocks;
+const mockListBooted = simulatorMocks.listBooted;
+const mockBoot = simulatorMocks.boot;
+const mockGetConnection = jest.fn();
+const mockPeekProxyForDevice = jest.fn();
+
+jest.mock('../../src/simulator/proxy-manager', () => ({
+  getProxyForDevice: jest.fn(),
+  stopProxyForDevice: jest.fn(),
+  peekProxyForDevice: (id: string) => mockPeekProxyForDevice(id),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getConnection: (id: string) => mockGetConnection(id),
+  }),
+}));
+
+import { registerDeviceBootTool } from '../../src/tools/device-boot';
+
+type Handler = (sessionId: string, params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function captureHandler(): Handler {
+  let handler: Handler | undefined;
+  const server = {
+    registerTool: (_d: unknown, fn: Handler) => {
+      handler = fn;
+    },
+  } as unknown as Parameters<typeof registerDeviceBootTool>[0];
+  registerDeviceBootTool(server);
+  if (!handler) throw new Error('handler not registered');
+  return handler;
+}
+
+describe('device_boot fast path', () => {
+  beforeEach(() => {
+    mockListBooted.mockReset();
+    mockGetConnection.mockReset();
+    mockPeekProxyForDevice.mockReset();
+    mockBoot.mockReset();
+    mockBoot.mockRejectedValue(new Error('test bail-out'));
+  });
+
+  it('short-circuits when device already booted + healthy connection + running proxy', async () => {
+    mockListBooted.mockResolvedValue([
+      { udid: 'DEV-1', name: 'iPhone 16', state: 'Booted' },
+    ]);
+    mockGetConnection.mockReturnValue({ isConnected: () => true });
+    mockPeekProxyForDevice.mockReturnValue({ running: true, pid: 4242, port: 9322 });
+
+    const handler = captureHandler();
+    const result = await handler('s', { device: 'iPhone 16' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.alreadyBootedAndHealthy).toBe(true);
+    expect(body.udid).toBe('DEV-1');
+    expect(body.proxy).toEqual({ running: true, pid: 4242, port: 9322 });
+    // No further boot/connect work should have been triggered — the fast
+    // path returns before touching proxy-manager.
+    expect(jest.requireMock('../../src/simulator/proxy-manager').getProxyForDevice).not.toHaveBeenCalled();
+  });
+
+  it('does NOT short-circuit when the WebKit connection has dropped', async () => {
+    mockListBooted.mockResolvedValue([
+      { udid: 'DEV-1', name: 'iPhone 16', state: 'Booted' },
+    ]);
+    mockGetConnection.mockReturnValue({ isConnected: () => false });
+    mockPeekProxyForDevice.mockReturnValue({ running: true, pid: 4242, port: 9322 });
+
+    const handler = captureHandler();
+    // boot() is mocked to reject; the fast path was NOT taken precisely
+    // because the connection is unhealthy — so the handler tries to
+    // re-boot, hits the rejection, and that confirms the decision logic.
+    await handler('s', { device: 'iPhone 16' }).catch(() => undefined);
+    expect(mockBoot).toHaveBeenCalledWith('iPhone 16');
+  });
+
+  it('does NOT short-circuit when the device is not booted', async () => {
+    mockListBooted.mockResolvedValue([]);
+
+    const handler = captureHandler();
+    // boot is mocked to reject (in the jest.mock factory), so calling the
+    // handler bubbles that — we just need to verify the fast path was not
+    // taken, i.e. mockBoot was actually reached.
+    await handler('s', { device: 'iPhone 16' }).catch(() => undefined);
+    expect(mockBoot).toHaveBeenCalledWith('iPhone 16');
+  });
+});


### PR DESCRIPTION
> **Stacked on** #772. Diff against \`feature/sim-manager-singleton\`; re-target to \`develop\` after #772 lands.

## Summary
Adds a short-circuit at the top of \`device_boot\` so callers that re-issue the boot tool against an already-booted UDID skip the entire boot/openSafari/connectWebKit sequence as long as we still hold a healthy WebKit connection AND a running ios-webkit-debug-proxy.

### Behaviour
1. Resolve the singleton SimulatorManager (PR6).
2. \`simctl list devices -j\` (already cached by the singleton).
3. If the target name/UDID matches a booted device AND \`SessionManager.getConnection(udid).isConnected()\` AND \`peekProxyForDevice(udid)?.running\` — return immediately with \`{ udid, name, state, alreadyBootedAndHealthy: true, proxy: {...} }\`.
4. Otherwise fall through to the existing full boot path, which already handles re-launching Safari, retrying WebKit connect, and restarting a stale proxy.

Previously every \`device_boot\` call paid a ~2-5 s tax tearing down the existing WebKit socket and re-opening Safari even on healthy sims, which also raced any Flutter VM Service session that was still using the proxy.

## Background
Audit recommendation R-3 + R-4. Combined with PR6's singleton, this finally makes "call device_boot at the top of every run" cheap when the sim is already up.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`device-boot-fast-path.test.ts\` (3 tests):
  - Fast path fires when booted + connected + proxy running
  - Fast path skipped when WebKit disconnected — falls through to \`manager.boot\`
  - Fast path skipped when device not in the booted list
- [ ] Manual: call \`device_boot\` twice in a row on the same UDID; the second response should carry \`alreadyBootedAndHealthy: true\` and skip the Safari re-launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)