### PR TITLE
feat(session): rehydrate SessionManager from simctl on server start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,39 @@ export async function createServer(options?: {
 }): Promise<MCPServer> {
   const server = new MCPServer();
   registerAllTools(server);
+
+  // Rehydrate the in-memory SessionManager from any simulators that were
+  // booted before this server started. Without this, an MCP client
+  // reconnect leaves SessionManager empty and the LLM tries to re-boot
+  // the simulator it's already talking to. Best-effort: missing simctl,
+  // permissions issues, or weird states fall through without aborting
+  // server startup.
+  try {
+    // Late-bound imports so this module can stay free of a static
+    // dependency on the simulator/* sources at module-load time (helps
+    // smaller `import { ... } from '.'` bundles).
+    const { getSessionManager } = await import('./session-manager');
+    const { getDefaultSimulatorManager } = await import('./simulator');
+    const { DEVICE_PRESETS } = await import('./simulator/presets');
+    const presetLookup = (name: string) => {
+      const entry = Object.values(DEVICE_PRESETS).find((p) => p.name === name);
+      return entry ? { w: entry.w, h: entry.h } : undefined;
+    };
+    const result = await getSessionManager().rehydrateFromSimctl(
+      getDefaultSimulatorManager(),
+      { presetLookup },
+    );
+    if (result.rehydrated.length > 0) {
+      console.error(
+        `[OpenSafari] Rehydrated ${result.rehydrated.length} simulator(s) from simctl: ${result.rehydrated.join(', ')}`,
+      );
+    }
+  } catch (err) {
+    console.error(
+      `[OpenSafari] SessionManager rehydrate skipped: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   if (options?.allTools) {
     server.setTier(3);
   } else if (process.env.OPENSAFARI_TOOL_TIER) {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -216,6 +216,63 @@ export class SessionManager extends EventEmitter {
     this.emit('worker:removed', { name });
   }
 
+  /**
+   * Re-discover already-booted simulators after an MCP client reconnects.
+   *
+   * The SessionManager state is in-memory only. When the MCP transport
+   * drops and reconnects (e.g. CLI restart, IDE reload, process recycle)
+   * the maps come back empty even though `simctl list booted` still
+   * reports the same UDIDs. Tools then think "no device booted" and the
+   * LLM either re-runs `device_boot` (wasting 20 s + risking a fresh
+   * cold-boot) or fails outright.
+   *
+   * Rehydration walks the live `simctl list devices -j` snapshot and
+   * re-registers each booted device with the SessionManager. WebKit /
+   * Flutter VM connections are NOT re-established here — those need a
+   * proxy and an open Safari target, which `device_boot`'s fast path
+   * (PR7) already handles cleanly. We just rebuild the lightweight
+   * SimulatorInfo entries so `getSoleDeviceId()` and `listSimulators()`
+   * work on the very next tool call.
+   *
+   * Idempotent — safe to call multiple times. The caller passes the
+   * lookup interface so this module doesn't have to import simulator
+   * code (avoids a circular dependency).
+   */
+  async rehydrateFromSimctl(
+    lookup: { listBooted: () => Promise<Array<{ udid: string; name: string }>> },
+    options?: { presetLookup?: (deviceType: string) => { w: number; h: number } | undefined },
+  ): Promise<{ rehydrated: string[]; skipped: string[] }> {
+    const rehydrated: string[] = [];
+    const skipped: string[] = [];
+    let booted: Array<{ udid: string; name: string }> = [];
+    try {
+      booted = await lookup.listBooted();
+    } catch (err) {
+      console.error(
+        `[SessionManager] rehydrateFromSimctl failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { rehydrated, skipped };
+    }
+    for (const device of booted) {
+      if (this.simulators.has(device.udid)) {
+        skipped.push(device.udid);
+        continue;
+      }
+      const viewport = options?.presetLookup?.(device.name) ?? { w: 390, h: 844 };
+      this.addSimulator(device.udid, {
+        deviceId: device.udid,
+        deviceType: device.name,
+        state: 'booted',
+        viewport: { width: viewport.w, height: viewport.h },
+        // bootedAt is unknowable post-reconnect; use now as a lower bound.
+        bootedAt: Date.now(),
+        lastActivity: Date.now(),
+      });
+      rehydrated.push(device.udid);
+    }
+    return { rehydrated, skipped };
+  }
+
   // Cleanup
   async shutdown(): Promise<void> {
     for (const session of this.tabSessions.values()) {

--- a/tests/unit/session-rehydrate.test.ts
+++ b/tests/unit/session-rehydrate.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for PR8 — SessionManager.rehydrateFromSimctl.
+ *
+ * Verifies the manager re-registers any simulator simctl reports as booted,
+ * is idempotent, swallows lookup failures gracefully, and honours the
+ * presetLookup hook for accurate viewport dimensions.
+ */
+
+import { SessionManager } from '../../src/session-manager';
+
+describe('SessionManager.rehydrateFromSimctl', () => {
+  it('registers each booted device with sensible defaults', async () => {
+    const sm = new SessionManager();
+    const lookup = {
+      listBooted: jest.fn().mockResolvedValue([
+        { udid: 'DEV-A', name: 'iPhone 16' },
+        { udid: 'DEV-B', name: 'iPad Pro 11-inch' },
+      ]),
+    };
+
+    const result = await sm.rehydrateFromSimctl(lookup);
+
+    expect(result.rehydrated).toEqual(['DEV-A', 'DEV-B']);
+    expect(result.skipped).toEqual([]);
+    expect(sm.listSimulators().map((s) => s.deviceId)).toEqual(['DEV-A', 'DEV-B']);
+    expect(sm.getSimulator('DEV-A')?.state).toBe('booted');
+  });
+
+  it('honours presetLookup for viewport dimensions', async () => {
+    const sm = new SessionManager();
+    const lookup = {
+      listBooted: jest.fn().mockResolvedValue([{ udid: 'DEV-A', name: 'iPhone 16' }]),
+    };
+    const presetLookup = (name: string) =>
+      name === 'iPhone 16' ? { w: 393, h: 852 } : undefined;
+
+    await sm.rehydrateFromSimctl(lookup, { presetLookup });
+
+    expect(sm.getSimulator('DEV-A')?.viewport).toEqual({ width: 393, height: 852 });
+  });
+
+  it('skips devices already known to the SessionManager (idempotent)', async () => {
+    const sm = new SessionManager();
+    sm.addSimulator('DEV-A', {
+      deviceId: 'DEV-A',
+      deviceType: 'iPhone 16',
+      state: 'booted',
+      viewport: { width: 100, height: 200 },
+      bootedAt: 1,
+      lastActivity: 1,
+    });
+    const lookup = {
+      listBooted: jest.fn().mockResolvedValue([
+        { udid: 'DEV-A', name: 'iPhone 16' },
+        { udid: 'DEV-B', name: 'iPhone 16' },
+      ]),
+    };
+
+    const result = await sm.rehydrateFromSimctl(lookup);
+
+    expect(result.rehydrated).toEqual(['DEV-B']);
+    expect(result.skipped).toEqual(['DEV-A']);
+    // Pre-existing viewport must NOT be clobbered.
+    expect(sm.getSimulator('DEV-A')?.viewport).toEqual({ width: 100, height: 200 });
+  });
+
+  it('returns empty + logs when simctl lookup throws', async () => {
+    const sm = new SessionManager();
+    const lookup = {
+      listBooted: jest.fn().mockRejectedValue(new Error('simctl missing')),
+    };
+
+    const result = await sm.rehydrateFromSimctl(lookup);
+
+    expect(result.rehydrated).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(sm.listSimulators()).toEqual([]);
+  });
+});


### PR DESCRIPTION
> **Stacked on** #772. Re-target to \`develop\` after #772 lands.

## Summary
Restores in-memory SessionManager state after an MCP client reconnect so tools stop reporting "no device booted" against simulators that are demonstrably running.

### Problem
SessionManager keeps \`simulators\`, \`connections\`, \`workers\`, \`tabSessions\` purely in memory. When the MCP transport drops and reconnects (CLI restart, IDE reload, process recycle) the maps come back empty even though \`simctl list booted\` still reports the same UDIDs. Tools then conclude \"no device booted\" and either the LLM re-runs \`device_boot\` (wasting 20 s on cold boot) or fails outright with \`DEVICE_NOT_BOOTED\`.

### Fix
- New \`SessionManager.rehydrateFromSimctl(lookup, { presetLookup })\`: pulls current booted device list, registers any UDID not already known as a \`SimulatorInfo\` with viewport defaulted from \`DEVICE_PRESETS\`. Idempotent — pre-existing entries are skipped, not clobbered. Lookup failures (missing simctl, permissions) are logged and the call returns empty rather than aborting.
- Caller passes the lookup interface so \`session-manager\` doesn't need a static dependency on \`simulator/*\` (avoids a circular import).
- \`createServer()\` calls rehydrate once after \`registerAllTools\` and before \`server.start\`, surfacing the result via \`console.error\` so users see what was picked up. Errors are swallowed — rehydrate failure never blocks server startup.

WebKit / Flutter VM connections are intentionally NOT re-established here — those need a proxy and an open Safari target, which PR7's \`device_boot\` fast-path already handles cleanly. We just rebuild the lightweight SimulatorInfo so the very next tool call's \`getSoleDeviceId()\` / \`listSimulators()\` returns truthful data.

## Background
Audit recommendation R-5. Pre-PR8 every IDE reload forced the user back through the cold-boot path.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`session-rehydrate.test.ts\` (4 tests): basic register, viewport via presetLookup, idempotent skip of known devices (no clobber), simctl failure returns empty + leaves state untouched.
- [ ] Manual: boot a sim, kill+restart the MCP server, call any \`app_*\` tool without re-running \`device_boot\` — should resolve the device instead of returning \`DEVICE_NOT_BOOTED\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)