### PR TITLE
feat(tools): app_reset snapshotAuthProfile option

### DIFF
--- a/src/tools/app-reset.ts
+++ b/src/tools/app-reset.ts
@@ -1,14 +1,19 @@
 import { MCPServer } from '../mcp-server';
 import { SimulatorManager } from '../simulator';
 import { getSessionManager } from '../session-manager';
+import { NativeAuthManager } from '../auth/native-manager';
 
 export function registerAppResetTool(server: MCPServer): void {
+  const nativeAuth = new NativeAuthManager();
+
   server.registerTool(
     {
       name: 'app_reset',
       description:
         'Reset app state on a booted iOS Simulator. Terminates the app, resets privacy permissions, ' +
-        'and uninstalls it to clear all data. The app must be reinstalled after reset.',
+        'and uninstalls it to clear all data. The app must be reinstalled after reset. ' +
+        'Optionally capture the app\'s native auth snapshot first (see snapshotAuthProfile / includeKeychain) ' +
+        'so the caller can restore the logged-in state after the post-reset reinstall.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -19,6 +24,16 @@ export function registerAppResetTool(server: MCPServer): void {
           deviceId: {
             type: 'string',
             description: 'Device UDID. Falls back to active device if omitted.',
+          },
+          snapshotAuthProfile: {
+            type: 'string',
+            description:
+              'Profile name to capture the current native auth state into BEFORE the reset. After reinstalling the app, call auth_restore_native with this profile to bring the signed-in state back.',
+          },
+          includeKeychain: {
+            type: 'boolean',
+            description:
+              'When snapshotAuthProfile is set, also capture the simulator-wide Keychain DB. Requires temporarily shutting the simulator down — leave off for fast captures that only need plist/sqlite/hive stores.',
           },
         },
         required: ['bundleId'],
@@ -38,12 +53,39 @@ export function registerAppResetTool(server: MCPServer): void {
       }
 
       const bundleId = params.bundleId as string;
+      const snapshotAuthProfile = params.snapshotAuthProfile as string | undefined;
+      const includeKeychain = Boolean(params.includeKeychain);
+
+      // Capture native auth FIRST so the subsequent uninstall doesn't take
+      // it down with the data container. Failure here surfaces as a warning
+      // but does NOT block the reset — the caller can always re-login
+      // manually if the snapshot didn't work.
+      let snapshot: false | { profile: string; keychain: boolean; warning?: string } = false;
+      if (snapshotAuthProfile) {
+        try {
+          const saved = await nativeAuth.save(deviceId, bundleId, snapshotAuthProfile, {
+            includeKeychain,
+          });
+          snapshot = {
+            profile: saved.profile,
+            keychain: Boolean(saved.keychainArchive),
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          snapshot = {
+            profile: snapshotAuthProfile,
+            keychain: false,
+            warning: `auth_save_native failed before reset: ${message}`,
+          };
+        }
+      }
+
       const result = await manager.resetApp(deviceId, bundleId);
 
       return {
         content: [{
           type: 'text' as const,
-          text: JSON.stringify(result),
+          text: JSON.stringify({ ...result, authSnapshot: snapshot }),
         }],
       };
     },

--- a/tests/unit/app-reset-preserve-auth.test.ts
+++ b/tests/unit/app-reset-preserve-auth.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for PR9 — `app_reset` snapshotAuthProfile option.
+ *
+ * Verifies the snapshot happens BEFORE the reset (so the uninstall doesn't
+ * take the data container down with it) and that snapshot failures degrade
+ * to a warning without blocking the reset.
+ */
+
+const mockSave = jest.fn();
+const mockResetApp = jest.fn();
+const mockListBooted = jest.fn();
+
+jest.mock('../../src/auth/native-manager', () => ({
+  NativeAuthManager: jest.fn().mockImplementation(() => ({
+    save: mockSave,
+  })),
+}));
+
+jest.mock('../../src/simulator', () => ({
+  SimulatorManager: jest.fn().mockImplementation(() => ({
+    listBooted: mockListBooted,
+    resetApp: mockResetApp,
+  })),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => 'DEV-1',
+  }),
+}));
+
+import { registerAppResetTool } from '../../src/tools/app-reset';
+
+type Handler = (sessionId: string, params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function captureHandler(): Handler {
+  let handler: Handler | undefined;
+  const server = {
+    registerTool: (_d: unknown, fn: Handler) => {
+      handler = fn;
+    },
+  } as unknown as Parameters<typeof registerAppResetTool>[0];
+  registerAppResetTool(server);
+  if (!handler) throw new Error('handler not registered');
+  return handler;
+}
+
+describe('app_reset snapshotAuthProfile', () => {
+  beforeEach(() => {
+    mockSave.mockReset();
+    mockResetApp.mockReset();
+    mockListBooted.mockReset();
+    mockListBooted.mockResolvedValue([{ udid: 'DEV-1' }]);
+    mockResetApp.mockResolvedValue({ reset: true, bundleId: 'com.example.app', deviceId: 'DEV-1', steps: ['terminated', 'privacy_reset', 'uninstalled'] });
+  });
+
+  it('captures the native auth snapshot BEFORE resetApp', async () => {
+    mockSave.mockResolvedValue({
+      profile: 'pre-reset',
+      bundleId: 'com.example.app',
+      deviceUdid: 'DEV-1',
+      keychainArchive: '/tmp/keychains.tar',
+    });
+
+    const handler = captureHandler();
+    const result = await handler('s', {
+      bundleId: 'com.example.app',
+      snapshotAuthProfile: 'pre-reset',
+      includeKeychain: true,
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    const saveOrder = mockSave.mock.invocationCallOrder[0];
+    const resetOrder = mockResetApp.mock.invocationCallOrder[0];
+    expect(saveOrder).toBeLessThan(resetOrder);
+
+    expect(mockSave).toHaveBeenCalledWith('DEV-1', 'com.example.app', 'pre-reset', { includeKeychain: true });
+    expect(body.authSnapshot).toEqual({ profile: 'pre-reset', keychain: true });
+  });
+
+  it('surfaces snapshot failure as a warning but still resets', async () => {
+    mockSave.mockRejectedValue(new Error('container missing'));
+
+    const handler = captureHandler();
+    const result = await handler('s', {
+      bundleId: 'com.example.app',
+      snapshotAuthProfile: 'broken',
+    });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockResetApp).toHaveBeenCalled();
+    expect(body.reset).toBe(true);
+    expect(body.authSnapshot).toMatchObject({
+      profile: 'broken',
+      keychain: false,
+      warning: expect.stringContaining('container missing'),
+    });
+  });
+
+  it('skips snapshot when snapshotAuthProfile is omitted', async () => {
+    const handler = captureHandler();
+    const result = await handler('s', { bundleId: 'com.example.app' });
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(body.authSnapshot).toBe(false);
+  });
+});


### PR DESCRIPTION
> **Stacked on** #769 (NativeAuthManager). Re-target to \`develop\` after #769 lands.

## Summary
Adds a \`snapshotAuthProfile\` argument that captures the app's native auth state (via \`NativeAuthManager.save\` from #769) BEFORE running the existing terminate → privacy reset → uninstall sequence, so the caller can re-apply the signed-in state after a fresh install without manually wiring \`auth_save_native\` first.

### Behaviour
- \`snapshotAuthProfile=<name>\` → captures profile, then resets. Pass \`includeKeychain: true\` to also snapshot the Keychain DB (NativeAuthManager shuts the simulator down briefly and re-boots afterwards).
- Snapshot failure (corrupted container, missing tar, etc.) becomes \`authSnapshot.warning\` instead of aborting the reset — the caller can still drive the rest of the flow manually.
- Omitting \`snapshotAuthProfile\` preserves the previous behaviour exactly (\`authSnapshot: false\`).

### Caller flow for full preserve-auth round-trip
\`\`\`
app_reset { bundleId, snapshotAuthProfile: 'pre-reset' }
→ reinstall the app
→ auth_restore_native { profile: 'pre-reset', bundleId, relaunch: true }
\`\`\`

## Background
Audit recommendation A-2. Pre-PR9 \`app_reset\` always wiped both data and auth, forcing a manual re-login every test cycle.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`app-reset-preserve-auth.test.ts\` (3 tests): save invoked BEFORE resetApp via \`invocationCallOrder\`; save failure surfaces as warning + reset still runs; no \`snapshotAuthProfile\` ⇒ no save call.
- [ ] Manual: log into a Flutter app, \`app_reset { snapshotAuthProfile: 'main' }\`, reinstall, \`auth_restore_native { profile: 'main', relaunch: true }\` → app should come up signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)