### PR TITLE
feat(simulator): WarmSimPool golden-device seeding

### DIFF
--- a/src/simulator/warm-sim-pool.ts
+++ b/src/simulator/warm-sim-pool.ts
@@ -88,15 +88,27 @@ export class WarmSimPool {
    * Pre-acquire clones so that the pool reaches the requested warm
    * target for `preset`. Called explicitly at startup or lazily on
    * first `acquire`. Resolves once all clones have been booted.
+   *
+   * `options.seedFrom` overrides the master UDID for THIS warmUp call
+   * only — useful when bootstrapping a "logged-in golden device" pool
+   * where every acquire returns a clone of the golden snapshot. If
+   * persistent seeding is desired across replenish, use `useGoldenDevice`.
    */
-  async warmUp(preset: string, count?: number): Promise<void> {
+  async warmUp(
+    preset: string,
+    count?: number,
+    options?: { seedFrom?: string },
+  ): Promise<void> {
     const target = count ?? this.targetFor(preset);
     this.warmTargets.set(preset, target);
     const missing = target - this.warmCountFor(preset);
     if (missing <= 0) return;
 
+    const acquireOpts = options?.seedFrom
+      ? { masterUdid: options.seedFrom }
+      : undefined;
     const results = await Promise.allSettled(
-      Array.from({ length: missing }, () => this.base.acquire(preset)),
+      Array.from({ length: missing }, () => this.base.acquire(preset, acquireOpts)),
     );
     const bucket = this.ready.get(preset) ?? [];
     for (const r of results) {
@@ -107,6 +119,28 @@ export class WarmSimPool {
       }
     }
     this.ready.set(preset, bucket);
+  }
+
+  /**
+   * Bind a preset to a "golden" master device UDID so every subsequent
+   * acquire/replenish clones from that source instead of the preset's
+   * default device. Pass null to clear the override and return to the
+   * preset lookup behaviour.
+   *
+   * Typical usage: boot a sim, install the app, log in, shut it down,
+   * then call `useGoldenDevice('iphone-16', <udid>)`. The warm pool will
+   * hand out clones that boot already-signed-in, avoiding the per-test
+   * login tax for Flutter apps that can't easily be seeded via
+   * NativeAuthManager (e.g. apps with biometric-locked keychains the
+   * keychain export can't capture).
+   */
+  useGoldenDevice(preset: string, udid: string | null): void {
+    this.base.setMaster(preset, udid);
+  }
+
+  /** Inspect the currently bound golden device UDID for `preset`, or null. */
+  getGoldenDevice(preset: string): string | null {
+    return this.base.getMaster(preset);
   }
 
   /**

--- a/tests/unit/warm-sim-pool-golden.test.ts
+++ b/tests/unit/warm-sim-pool-golden.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for PR10 — WarmSimPool golden-device seeding.
+ *
+ * Verifies:
+ *   - warmUp(preset, count, { seedFrom }) forwards masterUdid to SimPool.acquire
+ *   - useGoldenDevice + getGoldenDevice round-trip via SimPool.setMaster/getMaster
+ *   - acquire/replenish honour the bound golden device when seedFrom is not supplied per call
+ */
+
+import { WarmSimPool } from '../../src/simulator/warm-sim-pool';
+
+function makeFakeSimPool() {
+  const acquireMock = jest.fn();
+  const setMasterMock = jest.fn();
+  const getMasterMock = jest.fn();
+  const releaseMock = jest.fn().mockResolvedValue(true);
+  const shutdownMock = jest.fn().mockResolvedValue(undefined);
+
+  const masters = new Map<string, string>();
+  setMasterMock.mockImplementation((preset: string, udid: string | null) => {
+    if (udid === null) masters.delete(preset);
+    else masters.set(preset, udid);
+  });
+  getMasterMock.mockImplementation((preset: string) => masters.get(preset) ?? null);
+
+  let cloneCounter = 0;
+  acquireMock.mockImplementation(async (preset: string, opts?: { masterUdid?: string }) => {
+    cloneCounter++;
+    return {
+      udid: `CLONE-${cloneCounter}`,
+      preset,
+      seededFrom: opts?.masterUdid ?? masters.get(preset) ?? null,
+    };
+  });
+
+  return {
+    acquire: acquireMock,
+    setMaster: setMasterMock,
+    getMaster: getMasterMock,
+    release: releaseMock,
+    shutdown: shutdownMock,
+  };
+}
+
+describe('WarmSimPool golden-device seeding', () => {
+  it('useGoldenDevice + getGoldenDevice round-trip via SimPool.setMaster/getMaster', () => {
+    const base = makeFakeSimPool();
+    const pool = new WarmSimPool({ basePool: base as never });
+
+    expect(pool.getGoldenDevice('iphone-16')).toBeNull();
+    pool.useGoldenDevice('iphone-16', 'GOLDEN-UDID');
+    expect(pool.getGoldenDevice('iphone-16')).toBe('GOLDEN-UDID');
+    expect(base.setMaster).toHaveBeenCalledWith('iphone-16', 'GOLDEN-UDID');
+
+    pool.useGoldenDevice('iphone-16', null);
+    expect(pool.getGoldenDevice('iphone-16')).toBeNull();
+  });
+
+  it('warmUp { seedFrom } forwards masterUdid per acquire', async () => {
+    const base = makeFakeSimPool();
+    const pool = new WarmSimPool({ basePool: base as never, defaultWarmTarget: 0 });
+
+    await pool.warmUp('iphone-16', 2, { seedFrom: 'GOLDEN-UDID' });
+
+    expect(base.acquire).toHaveBeenCalledTimes(2);
+    expect(base.acquire).toHaveBeenCalledWith('iphone-16', { masterUdid: 'GOLDEN-UDID' });
+    expect(pool.warmCountFor('iphone-16')).toBe(2);
+  });
+
+  it('subsequent acquire honours the bound golden device when seedFrom was set via useGoldenDevice', async () => {
+    const base = makeFakeSimPool();
+    const pool = new WarmSimPool({ basePool: base as never, defaultWarmTarget: 0 });
+
+    pool.useGoldenDevice('iphone-16', 'GOLDEN-UDID');
+
+    const clone = (await pool.acquire('iphone-16')) as unknown as { seededFrom: string | null };
+    // Fake SimPool surfaces the resolved source via clone.seededFrom — that
+    // comes from the per-acquire masterUdid OR the bound master. Since we
+    // didn't pass `masterUdid` and the warm pool has no acquire-level
+    // seedFrom (yet), the bound master should still apply via SimPool's
+    // own resolution. The clone payload should reflect that.
+    expect(clone.seededFrom).toBe('GOLDEN-UDID');
+  });
+
+  it('warmUp without seedFrom does NOT pass masterUdid (delegating to SimPool resolution)', async () => {
+    const base = makeFakeSimPool();
+    const pool = new WarmSimPool({ basePool: base as never, defaultWarmTarget: 0 });
+
+    await pool.warmUp('iphone-16', 1);
+
+    // No seedFrom → no masterUdid option object on the acquire call.
+    expect(base.acquire).toHaveBeenCalledWith('iphone-16', undefined);
+  });
+});


### PR DESCRIPTION
## Summary
First-class support for "logged-in golden device" warm pools so Flutter apps gated by biometric / OTP / SSO flows can be tested at warm-pool speed without re-running login on every acquire.

### API
- \`useGoldenDevice(preset, udid | null)\` — bind/unbind a master UDID for \`preset\`. Delegates to \`SimPool.setMaster\` so all future acquires (warm-pool replenishment included) clone from the bound device instead of the preset's default base device.
- \`getGoldenDevice(preset)\` — inspect the current binding.
- \`warmUp(preset, count, { seedFrom })\` — one-shot override that forces THIS warmUp invocation to acquire from \`seedFrom\` regardless of the bound master, useful during bootstrapping ("warm up 3 clones from this just-logged-in device") before flipping the global binding.

### Usage
\`\`\`
1. Boot a fresh sim, install the app, log in fully (Face ID enrolment,
   OTP, whatever), terminate the app, shut the sim down.
2. pool.useGoldenDevice('iphone-16', <udid>)
3. pool.warmUp('iphone-16', 3)  → three pre-acquired clones, each one
   reboots already-signed-in.
4. Every subsequent acquire / background replenish clones from the
   golden device until useGoldenDevice('iphone-16', null).
\`\`\`

## Background
Audit recommendation A-3. Pre-PR10, warm-pool clones came from the preset's vanilla base device, so even though acquisition was fast (~2 s vs 20 s cold), every clone still needed a manual login — defeating the purpose of warm pooling for auth-heavy apps.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`warm-sim-pool-golden.test.ts\` (4 tests):
  - \`useGoldenDevice\`/\`getGoldenDevice\` round-trip
  - \`warmUp { seedFrom }\` forwards \`masterUdid\` per acquire
  - Bound golden device flows through SimPool's normal resolution path
  - \`warmUp\` without seedFrom does not invent a masterUdid option
- [ ] Manual: log into a Flutter app on a fresh sim, shut it down, \`useGoldenDevice('iphone-16', <udid>)\`, \`warmUp\`, acquire → should boot already-signed-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)