### PR TITLE
feat(tools): app_pop_until — VM-service-driven Navigator.popUntil

### DIFF
--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -1,0 +1,180 @@
+/**
+ * `app_pop_until` — pop Navigator routes until a target predicate succeeds.
+ *
+ * Strategy:
+ *   1. Prefer Flutter VM service when connected — evaluates a one-shot
+ *      `Navigator.popUntil` expression that pops by route name, by
+ *      ancestor count, or to first. This is the only reliable path for
+ *      apps that use modal/bottom-sheet routes which have no AppBar back
+ *      button to tap.
+ *   2. Fall back to nothing else for now — apps without a VM service
+ *      (release builds) should pair this tool with a tap-based recipe
+ *      (PR15 + alert handler back-button labels).
+ *
+ * Predicates (mutually exclusive):
+ *   { until: 'first' }           — pop until isFirst === true
+ *   { until: 'route', name: '/' }— pop until the matching named route is current
+ *   { until: 'count', count: 3 } — pop exactly count times (best-effort)
+ */
+
+import { MCPServer } from '../mcp-server';
+import { getFlutterVMClient } from '../flutter';
+import { getSessionManager } from '../session-manager';
+
+type PopUntil =
+  | { until: 'first' }
+  | { until: 'route'; name: string }
+  | { until: 'count'; count: number };
+
+function buildExpression(target: PopUntil): string {
+  // `WidgetsBinding.instance.rootElement` gives an Element we can use as
+  // a BuildContext for Navigator.of(). Wrapping in try/catch returns a
+  // structured marker the Node side can parse.
+  const predicate =
+    target.until === 'first'
+      ? '(r) => r.isFirst'
+      : target.until === 'route'
+        // Quote the name carefully — Dart single quotes don't interpolate.
+        ? `(r) => r.settings.name == '${target.name.replace(/'/g, "\\'")}' || r.isFirst`
+        : ''; // count handled separately below
+  if (target.until === 'count') {
+    return `
+(() {
+  try {
+    final binding = WidgetsBinding.instance;
+    final root = binding.rootElement;
+    if (root == null) return 'opensafari_pop:no_root';
+    final nav = Navigator.maybeOf(root);
+    if (nav == null) return 'opensafari_pop:no_navigator';
+    var popped = 0;
+    while (popped < ${target.count} && nav.canPop()) {
+      nav.pop();
+      popped += 1;
+    }
+    return 'opensafari_pop:ok:popped=' + popped.toString();
+  } catch (e) {
+    return 'opensafari_pop:error:' + e.toString().replaceAll(':', '_');
+  }
+})()
+`.replace(/\s+/g, ' ').trim();
+  }
+  return `
+(() {
+  try {
+    final binding = WidgetsBinding.instance;
+    final root = binding.rootElement;
+    if (root == null) return 'opensafari_pop:no_root';
+    final nav = Navigator.maybeOf(root);
+    if (nav == null) return 'opensafari_pop:no_navigator';
+    nav.popUntil(${predicate});
+    return 'opensafari_pop:ok';
+  } catch (e) {
+    return 'opensafari_pop:error:' + e.toString().replaceAll(':', '_');
+  }
+})()
+`.replace(/\s+/g, ' ').trim();
+}
+
+function parsePopResult(raw: string): { ok: boolean; status: string; popped?: number; error?: string } {
+  const idx = raw.indexOf('opensafari_pop:');
+  if (idx < 0) return { ok: false, status: 'unknown' };
+  const payload = raw.slice(idx + 'opensafari_pop:'.length);
+  if (payload.startsWith('ok')) {
+    const m = payload.match(/^ok:popped=(\d+)/);
+    return { ok: true, status: 'ok', popped: m ? Number(m[1]) : undefined };
+  }
+  if (payload.startsWith('error:')) {
+    return { ok: false, status: 'error', error: payload.slice('error:'.length) };
+  }
+  return { ok: false, status: payload };
+}
+
+export function registerAppPopUntilTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_pop_until',
+      description:
+        'Pop the Flutter Navigator until a target predicate is satisfied. Requires flutter_connect. ' +
+        'Predicates: { until: "first" } pops to root, { until: "route", name: "/x" } pops until that named route is current, { until: "count", count: N } pops up to N times.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          until: {
+            type: 'string',
+            enum: ['first', 'route', 'count'],
+            description: 'Predicate kind',
+          },
+          name: { type: 'string', description: 'Route name (only with until="route")' },
+          count: { type: 'number', description: 'Pop count (only with until="count")' },
+          device_id: { type: 'string', description: 'Simulator UDID' },
+        },
+        required: ['until'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      const until = params.until as 'first' | 'route' | 'count' | undefined;
+      if (!until || !['first', 'route', 'count'].includes(until)) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'INVALID_UNTIL' }) }],
+          isError: true,
+        };
+      }
+      let target: PopUntil;
+      if (until === 'route') {
+        const name = params.name as string | undefined;
+        if (!name) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'MISSING_NAME' }) }],
+            isError: true,
+          };
+        }
+        target = { until, name };
+      } else if (until === 'count') {
+        const count = Number(params.count);
+        if (!Number.isFinite(count) || count <= 0) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'INVALID_COUNT' }) }],
+            isError: true,
+          };
+        }
+        target = { until, count: Math.floor(count) };
+      } else {
+        target = { until };
+      }
+
+      const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId();
+      if (!deviceId) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'DEVICE_NOT_BOOTED' }) }],
+          isError: true,
+        };
+      }
+      const client = getFlutterVMClient(deviceId);
+      if (!client.isConnected()) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'NOT_CONNECTED', message: 'Call flutter_connect first.' }) }],
+          isError: true,
+        };
+      }
+
+      const expr = buildExpression(target);
+      try {
+        const result = await client.evaluate(expr);
+        const raw = (result as { valueAsString?: string }).valueAsString ?? '';
+        const parsed = parsePopResult(raw);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ ...parsed, target }) }],
+          isError: !parsed.ok,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'EVAL_FAILED', message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+export const __forTests = { buildExpression, parsePopResult };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -126,6 +126,7 @@ import { registerAppTapElementTool } from './app-tap-element';
 import { registerAppTypeElementTool } from './app-type-element';
 import { registerAppWaitForNativeTool } from './app-wait-for';
 import { registerAppAssertElementTool } from './app-assert-element';
+import { registerAppPopUntilTool } from './app-pop-until';
 import { registerDiagnoseTool } from './diagnose';
 
 export { setWorkflowEngine } from './orchestration-tools';
@@ -330,6 +331,7 @@ export function registerAllTools(server: MCPServer): void {
   // Tier 2: Native App — Semantic Wait & Assert (Flutter-compatible)
   registerAppWaitForNativeTool(server);
   registerAppAssertElementTool(server);
+  registerAppPopUntilTool(server);
 
   // Tier 1: Diagnostics
   registerDiagnoseTool(server);

--- a/tests/unit/app-pop-until.test.ts
+++ b/tests/unit/app-pop-until.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for PR15 — app_pop_until.
+ *
+ * The Dart-side popUntil is exercised only against a real Flutter app,
+ * but expression generation and result parsing happen on the Node side
+ * and are worth pinning here.
+ */
+
+import { __forTests } from '../../src/tools/app-pop-until';
+
+const { buildExpression, parsePopResult } = __forTests;
+
+describe('app_pop_until buildExpression', () => {
+  it('builds an isFirst predicate for until=first', () => {
+    const expr = buildExpression({ until: 'first' });
+    expect(expr).toContain('popUntil((r) => r.isFirst)');
+    expect(expr).toContain('rootElement');
+    expect(expr).toContain('opensafari_pop:');
+  });
+
+  it('builds a route-name predicate for until=route with escape handling', () => {
+    const expr = buildExpression({ until: 'route', name: "/it's-fine" });
+    // Single quote should be escaped to prevent breaking the Dart string.
+    expect(expr).toContain("r.settings.name == '/it\\'s-fine'");
+  });
+
+  it('builds a count-bounded pop loop for until=count', () => {
+    const expr = buildExpression({ until: 'count', count: 3 });
+    expect(expr).toContain('popped < 3');
+    expect(expr).toContain('nav.canPop()');
+    expect(expr).toContain('popped += 1');
+  });
+});
+
+describe('app_pop_until parsePopResult', () => {
+  it('parses the bare ok marker', () => {
+    expect(parsePopResult('opensafari_pop:ok')).toEqual({ ok: true, status: 'ok' });
+  });
+
+  it('parses the ok marker with popped count', () => {
+    expect(parsePopResult('opensafari_pop:ok:popped=2')).toEqual({
+      ok: true,
+      status: 'ok',
+      popped: 2,
+    });
+  });
+
+  it('parses the error marker', () => {
+    const result = parsePopResult('opensafari_pop:error:Some Dart exception');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe('error');
+    expect(result.error).toBe('Some Dart exception');
+  });
+
+  it('parses no_root / no_navigator', () => {
+    expect(parsePopResult('opensafari_pop:no_root').ok).toBe(false);
+    expect(parsePopResult('opensafari_pop:no_navigator').ok).toBe(false);
+  });
+
+  it('returns unknown when prefix missing', () => {
+    expect(parsePopResult('garbage')).toEqual({ ok: false, status: 'unknown' });
+  });
+});


### PR DESCRIPTION
> **Stacked on** #767 (Flutter VM lifecycle). Re-target to \`develop\` after #767 lands.

## Summary
New MCP tool that pops the Flutter Navigator until a target predicate is satisfied. Eliminates the previous LLM recipe of "tap the AppBar back button N times" (which doesn't work for modal/bottom-sheet routes that have no back button at all).

### Predicates
- \`{ until: "first" }\` — pop until \`isFirst === true\` (back to root)
- \`{ until: "route", name }\` — pop until that named route is current (escapes single quotes in the Dart string)
- \`{ until: "count", count }\` — pop up to \`count\` times, bounded by \`nav.canPop()\` so it never pops past root

### Implementation
Renders a small Dart IIFE that:
1. Resolves Navigator via \`Navigator.maybeOf(WidgetsBinding.instance.rootElement)\`.
2. Calls \`popUntil(predicate)\` or a \`nav.pop()\` loop for the count variant.
3. Returns a structured marker (\`opensafari_pop:ok\` / \`:error:<msg>\` / \`:no_root\` / \`:no_navigator\`) the Node side parses into a typed response.

Requires \`flutter_connect\` — surfaces \`NOT_CONNECTED\` with a hint to call flutter_connect first. Resolves the deviceId from \`SessionManager.getSoleDeviceId()\` when omitted.

## Background
Audit recommendation N-3. Without programmatic pop, modal-heavy flows (bottom sheets, dialogs, full-screen modals) required manual coordinate taps or full app relaunch.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`app-pop-until.test.ts\` (8 tests): expression generation for all three predicates including single-quote escaping; parser covers ok / ok+popped count / error / no_root / no_navigator / missing-prefix branches.
- [ ] Manual: open a Flutter app with nested Material routes, call \`app_pop_until { until: "first" }\` → should return to root regardless of stack depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)