### PR TITLE
feat(tools): auto scroll-to-find for app_tap_element + scroll_while_waiting for app_wait_for

### DIFF
--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -91,6 +91,15 @@ export function registerAppTapElementTool(server: MCPServer): void {
             type: 'string',
             description: 'Target app bundle ID. When provided, the tool re-activates the app and rejects mismatched native contexts.',
           },
+          autoScroll: {
+            type: 'boolean',
+            description:
+              'When true, if the element matches the query but is offscreen / invisible, swipe up to bring it into view and re-query, up to autoScrollMaxAttempts times. Default false to preserve the historical fail-fast contract.',
+          },
+          autoScrollMaxAttempts: {
+            type: 'number',
+            description: 'Maximum scroll-and-retry attempts when autoScroll is true. Default 6.',
+          },
         },
         required: [],
       },
@@ -193,6 +202,50 @@ export function registerAppTapElementTool(server: MCPServer): void {
             }],
             isError: true,
           };
+        }
+
+        // Auto-scroll-to-find (PR13): when the element is matched but
+        // off-screen, try swiping up to reveal it and re-query. We swipe
+        // when match.visible is false OR the frame has zero size (the AX
+        // tree often reports zero-size for nodes pinned outside the
+        // viewport). Direction defaults to "up" (drags content upward,
+        // revealing lower entries) because the common LLM workflow is
+        // "scroll a list to find an item further down".
+        const autoScroll = Boolean(params.autoScroll);
+        const autoScrollMax = Math.max(1, Number(params.autoScrollMaxAttempts) || 6);
+        if (
+          autoScroll &&
+          match &&
+          (!match.visible || match.frame.width <= 0 || match.frame.height <= 0)
+        ) {
+          try {
+            const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
+            for (let attempt = 0; attempt < autoScrollMax; attempt++) {
+              // Drag content upward — startY > endY scrolls toward the
+              // bottom of the list. Using device-agnostic coordinates that
+              // land inside both compact and Pro Max-sized viewports.
+              await backend.swipe(deviceId, 200, 600, 200, 200, 0.25);
+              await sleep(250);
+              const reResult = await bridge.query(query, { deviceId });
+              totalMatches = reResult.matches.length;
+              ambiguous = reResult.ambiguous;
+              if (reResult.matches.length > index) {
+                match = reResult.matches[index];
+                queryResult = reResult;
+                if (
+                  match.visible &&
+                  match.frame.width > 0 &&
+                  match.frame.height > 0
+                ) {
+                  break;
+                }
+              }
+            }
+          } catch (err) {
+            // Auto-scroll best-effort — log and fall through to the
+            // existing invisibility error if we still don't have it.
+            console.error(`[app_tap_element] autoScroll failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
         }
 
         // Validate element is visible and has nonzero size

--- a/src/tools/app-wait-for.ts
+++ b/src/tools/app-wait-for.ts
@@ -6,10 +6,11 @@
  * reliable automation after navigation, animations, or async data loading.
  */
 
-import { MCPServer } from '../mcp-server';
+import { MCPServer, getWebKitClient } from '../mcp-server';
 import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
+import { getInputBackend } from './native-input-utils';
 import {
   activateAndClassify,
   createContextMismatchError,
@@ -124,6 +125,11 @@ export function registerAppWaitForNativeTool(server: MCPServer): void {
           bundle_id: {
             type: 'string',
             description: 'Target app bundle ID. When provided, the tool re-activates the app and rejects mismatched native contexts.',
+          },
+          scroll_while_waiting: {
+            type: 'boolean',
+            description:
+              'When true, perform a small upward swipe between polls so an off-screen target in a scrollable ancestor is brought into view. Default false to preserve existing behaviour.',
           },
         },
         required: [],
@@ -244,6 +250,21 @@ export function registerAppWaitForNativeTool(server: MCPServer): void {
           // Don't sleep past deadline
           const remaining = deadline - Date.now();
           if (remaining <= 0) break;
+
+          // Optionally scroll the viewport between polls so an off-screen
+          // target in a scrollable ancestor (ListView, infinite list, etc.)
+          // is gradually brought into view instead of being timed out
+          // before it ever paints. Best-effort: a failed swipe doesn't
+          // break the wait loop.
+          if (params.scroll_while_waiting === true) {
+            try {
+              const backend = await getInputBackend(deviceId, getWebKitClient(deviceId));
+              await backend.swipe(deviceId, 200, 600, 200, 200, 0.2);
+            } catch {
+              // ignore — wait loop continues without scrolling
+            }
+          }
+
           await sleep(Math.min(interval, remaining));
         }
 


### PR DESCRIPTION
## Summary
Two related ergonomics fixes so off-screen targets in scrollable containers (ListView, infinite list, modal bottom sheet) stop returning "Element found but not visible" / timeout errors.

### \`app_tap_element { autoScroll, autoScrollMaxAttempts }\`
When the AX query matches an element but it's reported \`visible: false\` (common for ListView entries pinned outside the viewport) or carries a zero-sized frame, the tool now optionally swipes up to drag the scrollable content upward and re-queries — up to \`autoScrollMaxAttempts\` times (default 6). Swipes use \`getInputBackend.swipe(deviceId, 200, 600, 200, 200, 0.25)\` — device-agnostic coords that land inside both compact and Pro Max-sized viewports.

Auto-scroll is opt-in (\`autoScroll: false\` by default) to preserve the historical fail-fast contract for callers that rely on it. Swipe failures log and fall through to the existing invisibility error.

### \`app_wait_for { scroll_while_waiting }\`
Same idea inverted: when the target may exist further down a scrolling list, set \`scroll_while_waiting: true\` so each poll interval inserts a small upward swipe. Lets \`app_wait_for\` succeed against entries that weren't on screen at the start of the wait but will be after the user scrolls. Best-effort: swipe failures don't break the wait loop.

## Background
Audit recommendations N-5 + N-6. Pre-PR13 every "tap the 5th item in a list" recipe needed manual \`app_scroll_native\` calls interleaved with retries — repetitive boilerplate the LLM gets wrong roughly half the time.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] Existing \`app-tap-element.test.ts\` (52 tests) passes unchanged with \`autoScroll\` defaulting to false
- [x] Existing \`app-wait-for.test.ts\` + \`app-wait-for-diagnostics.test.ts\` (24 tests) pass with \`scroll_while_waiting\` defaulting to false
- [ ] Manual: long ListView in a Flutter app; \`app_tap_element { label: "Item 42", autoScroll: true }\` → should swipe and find without manual scroll steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)