### PR TITLE
feat(native): queryWithRecovery + pressWithRecovery — extend AX recovery to query/press paths

### DIFF
--- a/src/native/ax-bridge-recovery.ts
+++ b/src/native/ax-bridge-recovery.ts
@@ -59,7 +59,7 @@ export const DEFAULT_REACTIVATE_TIMEOUT_MS = 2500;
 export interface AxBridgeRecoveryStage {
   /** 1-indexed attempt number associated with this stage. */
   attempt: number;
-  action: 'dump' | 'reactivate' | 'sleep';
+  action: 'dump' | 'query' | 'press' | 'reactivate' | 'sleep';
   /** `Date.now()` when the stage began. */
   startedAt: number;
   durationMs: number;
@@ -296,4 +296,183 @@ function attachRecoveryReport(
   report: AxBridgeRecoveryReport,
 ): void {
   (err as AccessibilityBridgeError & { recovery?: AxBridgeRecoveryReport }).recovery = report;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// PR11: generalised recovery wrapper + query / press variants
+// ────────────────────────────────────────────────────────────────────────
+
+/** Subset of dumpTreeWithRecovery's options that applies to ANY ax-bridge
+ *  call — used by `queryWithRecovery` / `pressWithRecovery` so they can
+ *  honour the same retry policy without dragging in `AXDumpOptions`. */
+export interface AxOperationRecoveryOptions {
+  deviceId?: string;
+  bundleId?: string;
+  maxAttempts?: number;
+  backoffMs?: number[];
+  reactivateOnRetry?: boolean;
+  reactivate?: (
+    deviceId: string,
+    opts: { forceRefresh: true; timeout: number; bundleId?: string },
+  ) => Promise<boolean>;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Generic recovery loop for AX operations other than `dumpTree`. Mirrors
+ * the policy of `dumpTreeWithRecovery` but takes the call to retry as a
+ * lambda — `attempt` is the 1-indexed attempt number, useful when the
+ * caller wants to log or vary behaviour on the first vs later attempts.
+ *
+ * Recovery is identical to dump: recoverable codes trigger backoff +
+ * optional `ensureSemanticsActive({ forceRefresh: true })`, non-
+ * recoverable codes surface immediately, and the final error gets a
+ * `.recovery` report attached.
+ */
+export async function runAxOperationWithRecovery<T>(
+  operation: (attempt: number) => Promise<T>,
+  options: AxOperationRecoveryOptions,
+  actionLabel: 'query' | 'press' = 'query',
+): Promise<{ result: T; recovery: AxBridgeRecoveryReport }> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+  const reactivateOnRetry = options.reactivateOnRetry ?? true;
+  const sleep = options.sleep ?? defaultSleep;
+  const reactivate = options.reactivate ?? ensureSemanticsActive;
+
+  const stages: AxBridgeRecoveryStage[] = [];
+  let attempt = 0;
+  let lastError: AccessibilityBridgeError | undefined;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+
+    const opStart = Date.now();
+    try {
+      const result = await operation(attempt);
+      stages.push({
+        attempt,
+        action: actionLabel,
+        startedAt: opStart,
+        durationMs: Date.now() - opStart,
+        outcome: 'ok',
+      });
+      return {
+        result,
+        recovery: { attempts: attempt, recovered: true, stages },
+      };
+    } catch (err) {
+      const durationMs = Date.now() - opStart;
+      const code = err instanceof AccessibilityBridgeError ? err.code : 'UNKNOWN';
+      stages.push({
+        attempt,
+        action: actionLabel,
+        startedAt: opStart,
+        durationMs,
+        outcome: 'error',
+        errorCode: code,
+      });
+
+      if (!isRecoverableError(err)) {
+        const wrapped = err instanceof AccessibilityBridgeError
+          ? err
+          : new AccessibilityBridgeError(
+            err instanceof Error ? err.message : String(err),
+            'UNKNOWN',
+          );
+        attachRecoveryReport(wrapped, {
+          attempts: attempt,
+          recovered: false,
+          stages,
+          lastErrorCode: wrapped.code,
+        });
+        throw wrapped;
+      }
+
+      lastError = err;
+      if (attempt >= maxAttempts) break;
+
+      const backoff = resolveBackoff(options.backoffMs, attempt - 1);
+      if (backoff > 0) {
+        const sleepStart = Date.now();
+        await sleep(backoff);
+        stages.push({
+          attempt,
+          action: 'sleep',
+          startedAt: sleepStart,
+          durationMs: Date.now() - sleepStart,
+          outcome: 'ok',
+        });
+      }
+
+      if (reactivateOnRetry && options.deviceId) {
+        const reactStart = Date.now();
+        try {
+          const reactivated = await reactivate(options.deviceId, {
+            forceRefresh: true,
+            timeout: DEFAULT_REACTIVATE_TIMEOUT_MS,
+            bundleId: options.bundleId,
+          });
+          stages.push({
+            attempt,
+            action: 'reactivate',
+            startedAt: reactStart,
+            durationMs: Date.now() - reactStart,
+            outcome: reactivated ? 'ok' : 'error',
+            errorCode: reactivated ? undefined : 'REACTIVATE_RETURNED_FALSE',
+          });
+        } catch (rErr) {
+          stages.push({
+            attempt,
+            action: 'reactivate',
+            startedAt: reactStart,
+            durationMs: Date.now() - reactStart,
+            outcome: 'error',
+            errorCode: rErr instanceof AccessibilityBridgeError ? rErr.code : 'REACTIVATE_THREW',
+          });
+        }
+      }
+    }
+  }
+
+  const finalError = lastError ?? new AccessibilityBridgeError(
+    `ax operation '${actionLabel}' failed after ${attempt} attempts`,
+    'UNKNOWN',
+  );
+  attachRecoveryReport(finalError, {
+    attempts: attempt,
+    recovered: false,
+    stages,
+    lastErrorCode: finalError.code,
+  });
+  throw finalError;
+}
+
+/** Wraps `AccessibilityBridge.query()` with the same recovery policy as
+ *  `dumpTreeWithRecovery`. Use this from alert handler / tap-element /
+ *  inspect paths so a single `AX_TIMEOUT` or `DEVICE_CONTENT_ROOT_EMPTY`
+ *  doesn't fail an entire flow when an `ensureSemanticsActive` retry
+ *  would have fixed it. */
+export async function queryWithRecovery<TQuery, TResult>(
+  bridge: { query: (q: TQuery, opts?: { deviceId?: string }) => Promise<TResult> },
+  query: TQuery,
+  options: AxOperationRecoveryOptions,
+): Promise<{ result: TResult; recovery: AxBridgeRecoveryReport }> {
+  return runAxOperationWithRecovery(
+    () => bridge.query(query, { deviceId: options.deviceId }),
+    options,
+    'query',
+  );
+}
+
+/** Wraps `AccessibilityBridge.press()` with the same recovery policy. */
+export async function pressWithRecovery<TResult>(
+  bridge: { press: (path: string, deviceId?: string) => Promise<TResult> },
+  elementPath: string,
+  options: AxOperationRecoveryOptions,
+): Promise<{ result: TResult; recovery: AxBridgeRecoveryReport }> {
+  return runAxOperationWithRecovery(
+    () => bridge.press(elementPath, options.deviceId),
+    options,
+    'press',
+  );
 }

--- a/tests/unit/ax-recovery-query-press.test.ts
+++ b/tests/unit/ax-recovery-query-press.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for PR11 — queryWithRecovery / pressWithRecovery /
+ * runAxOperationWithRecovery.
+ *
+ * Mirrors the policy already proven by dumpTreeWithRecovery: recoverable
+ * errors trigger backoff + reactivation + retry; non-recoverable errors
+ * surface immediately with the diagnostics report attached.
+ */
+
+import {
+  queryWithRecovery,
+  pressWithRecovery,
+  runAxOperationWithRecovery,
+} from '../../src/native/ax-bridge-recovery';
+import { AccessibilityBridgeError } from '../../src/native/accessibility-bridge';
+
+describe('queryWithRecovery', () => {
+  it('returns the result and reports a successful first attempt', async () => {
+    const bridge = {
+      query: jest.fn().mockResolvedValue({ matches: [{ role: 'AXButton' }], ambiguous: false }),
+    };
+    const { result, recovery } = await queryWithRecovery(
+      bridge,
+      { label: 'OK' },
+      { deviceId: 'DEV-1', sleep: async () => undefined },
+    );
+    expect(result).toEqual({ matches: [{ role: 'AXButton' }], ambiguous: false });
+    expect(recovery.attempts).toBe(1);
+    expect(recovery.recovered).toBe(true);
+    expect(bridge.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on recoverable errors and succeeds on the second attempt', async () => {
+    const bridge = {
+      query: jest
+        .fn()
+        .mockRejectedValueOnce(new AccessibilityBridgeError('content root empty', 'DEVICE_CONTENT_ROOT_EMPTY'))
+        .mockResolvedValueOnce({ matches: [], ambiguous: false }),
+    };
+    const reactivate = jest.fn().mockResolvedValue(true);
+
+    const { result, recovery } = await queryWithRecovery(
+      bridge,
+      { label: 'OK' },
+      {
+        deviceId: 'DEV-1',
+        bundleId: 'com.example.app',
+        sleep: async () => undefined,
+        reactivate,
+      },
+    );
+
+    expect(result).toEqual({ matches: [], ambiguous: false });
+    expect(bridge.query).toHaveBeenCalledTimes(2);
+    expect(reactivate).toHaveBeenCalledTimes(1);
+    expect(recovery.attempts).toBe(2);
+    expect(recovery.stages.map((s) => s.action)).toEqual(
+      expect.arrayContaining(['query', 'reactivate', 'sleep']),
+    );
+  });
+
+  it('surfaces non-recoverable errors immediately', async () => {
+    const bridge = {
+      query: jest.fn().mockRejectedValue(
+        new AccessibilityBridgeError('xcode missing', 'XCODE_NOT_FOUND'),
+      ),
+    };
+    await expect(
+      queryWithRecovery(bridge, { label: 'OK' }, { deviceId: 'DEV-1', sleep: async () => undefined }),
+    ).rejects.toMatchObject({ code: 'XCODE_NOT_FOUND' });
+    expect(bridge.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('attaches the recovery report when the budget is exhausted', async () => {
+    const bridge = {
+      query: jest.fn().mockRejectedValue(
+        new AccessibilityBridgeError('timeout', 'AX_TIMEOUT'),
+      ),
+    };
+    await expect(
+      queryWithRecovery(bridge, { label: 'OK' }, {
+        deviceId: 'DEV-1',
+        maxAttempts: 2,
+        sleep: async () => undefined,
+        reactivate: async () => true,
+      }),
+    ).rejects.toMatchObject({
+      code: 'AX_TIMEOUT',
+      recovery: expect.objectContaining({ recovered: false }),
+    });
+  });
+});
+
+describe('pressWithRecovery', () => {
+  it('passes the element path + deviceId through and returns the response', async () => {
+    const bridge = { press: jest.fn().mockResolvedValue({ ok: true }) };
+    const { result } = await pressWithRecovery(bridge, '/AXButton[1]', {
+      deviceId: 'DEV-1',
+      sleep: async () => undefined,
+    });
+    expect(result).toEqual({ ok: true });
+    expect(bridge.press).toHaveBeenCalledWith('/AXButton[1]', 'DEV-1');
+  });
+});
+
+describe('runAxOperationWithRecovery', () => {
+  it('exposes the generalised wrapper for arbitrary AX ops', async () => {
+    let calls = 0;
+    const { result, recovery } = await runAxOperationWithRecovery(
+      async () => {
+        calls += 1;
+        if (calls === 1) throw new AccessibilityBridgeError('rooted empty', 'DEVICE_CONTENT_ROOT_EMPTY');
+        return 'final-value';
+      },
+      {
+        deviceId: 'DEV-1',
+        sleep: async () => undefined,
+        reactivate: async () => true,
+      },
+      'query',
+    );
+    expect(result).toBe('final-value');
+    expect(recovery.recovered).toBe(true);
+    expect(recovery.attempts).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
Generalises the retry-and-reactivate policy already proven by \`dumpTreeWithRecovery\` and exposes wrappers for the two remaining AX call shapes:

- \`queryWithRecovery(bridge, query, options)\` — wraps \`AccessibilityBridge.query()\`
- \`pressWithRecovery(bridge, path, options)\` — wraps \`AccessibilityBridge.press()\`

Plus \`runAxOperationWithRecovery<T>(op, options, 'query' | 'press')\` — the generalised loop, exported so callers with bespoke AX operations can opt into the same policy without duplicating it.

### Behaviour (mirrors \`dumpTreeWithRecovery\` exactly)
- Recoverable error codes (\`DEVICE_CONTENT_ROOT_EMPTY\`, \`AX_TIMEOUT\`, \`BRIDGE_EXEC_FAILED\`, …) trigger inter-attempt sleep + optional \`ensureSemanticsActive({ forceRefresh: true })\`.
- Non-recoverable codes (\`XCODE_NOT_FOUND\`, \`AX_PERMISSION_DENIED\`, …) are surfaced immediately.
- The final error gets a structured \`recovery\` report attached so callers can introspect \`attempts / stages / lastErrorCode\`.

\`AxBridgeRecoveryStage.action\` now also accepts \`'query'\` and \`'press'\`. Existing dump-only stage labels remain stable so callers that switch on \`action === 'dump'\` keep working.

## Background
Audit recommendations H-1 + H-2. Pre-PR11 the carefully-tuned recovery loop only protected \`dumpTree\`, so a single transient \`AX_TIMEOUT\` from \`bridge.query\` or \`bridge.press\` would fail an entire flow even though one reactivation would have fixed it. This PR makes the same primitive available without each caller open-coding the loop.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`ax-recovery-query-press.test.ts\` (6 tests):
  - queryWithRecovery happy path, recoverable retry-then-success, non-recoverable immediate surface, budget-exhausted attaches \`recovery\` report
  - pressWithRecovery forwards path + deviceId correctly
  - runAxOperationWithRecovery handles the generalised case
- [x] Existing \`ax-bridge-recovery.test.ts\` (14 tests) unaffected
- [ ] Follow-up: migrate the alert-handler / app_tap_element / app_inspect call sites to use these wrappers (out of scope for this PR — those tools have substantial extra logic that needs careful sequencing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)