### PR TITLE
feat(tools): app_tap_element labelAliases — cross-locale / synonym fallback

### DIFF
--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -91,6 +91,12 @@ export function registerAppTapElementTool(server: MCPServer): void {
             type: 'string',
             description: 'Target app bundle ID. When provided, the tool re-activates the app and rejects mismatched native contexts.',
           },
+          labelAliases: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Additional label strings to try in order when the primary `label`/`text`/`identifier` query does not match. Useful for cross-locale variants ("Sign in" / "로그인" / "Anmelden") or synonyms ("Continue" / "Next"). Each alias is tried as a label-substring match.',
+          },
         },
         required: [],
       },
@@ -179,6 +185,26 @@ export function registerAppTapElementTool(server: MCPServer): void {
           }
         }
 
+        // PR16: when the primary query missed, try each alias in turn as
+        // a label-substring match. This lets one tool call survive locale
+        // drift ("Sign in" / "로그인" / "Anmelden") without rebuilding
+        // the call from scratch.
+        const labelAliases = Array.isArray(params.labelAliases)
+          ? (params.labelAliases as unknown[]).filter((s): s is string => typeof s === 'string')
+          : [];
+        if (!match && labelAliases.length > 0) {
+          for (const alias of labelAliases) {
+            const aliasResult = await bridge.query({ label: alias }, { deviceId });
+            if (aliasResult.matches.length > index) {
+              match = aliasResult.matches[index];
+              queryResult = aliasResult;
+              totalMatches = aliasResult.matches.length;
+              ambiguous = aliasResult.ambiguous;
+              break;
+            }
+          }
+        }
+
         if (!match) {
           return {
             content: [{
@@ -186,6 +212,7 @@ export function registerAppTapElementTool(server: MCPServer): void {
               text: JSON.stringify({
                 error: 'Element not found',
                 query,
+                labelAliases: labelAliases.length > 0 ? labelAliases : undefined,
                 index,
                 timeout,
                 _meta: { context: contextMeta },


### PR DESCRIPTION
## Summary
Adds an opt-in \`labelAliases: string[]\` parameter to \`app_tap_element\` so one call can survive locale drift or synonyms without the caller rebuilding the query.

### Behaviour
- When the primary \`identifier\`/\`label\`/\`text\`/\`role\` query misses, the tool iterates through each \`labelAliases[]\` entry and runs a label-substring AX query. The first alias yielding ≥ \`index + 1\` matches is adopted.
- Aliases share the same \`index\` semantics as the primary query.
- Diagnostics include the aliases that were tried when the element is still not found, so error payloads stay actionable.
- No behaviour change when \`labelAliases\` is omitted.

### Use cases
\`\`\`
app_tap_element { label: "Sign in", labelAliases: ["로그인", "Anmelden", "Log in"] }
app_tap_element { label: "Continue", labelAliases: ["Next", "다음"] }
\`\`\`

## Background
Audit recommendation N-7 / N-8 (subset). One-shot fallback chain is sufficient for most cross-locale flows; a full fuzzy/Levenshtein matcher is deferred until concrete need.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] Existing \`app-tap-element.test.ts\` (52 tests) passes unchanged
- [ ] Manual: localized Flutter app with "Sign in" in English locale + "로그인" in Korean locale; same tool call with both labels in aliases should succeed regardless of current locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)