### PR TITLE
feat(network): NetworkInterceptor reinject + page-load hook

### DIFF
--- a/src/network-interceptor.ts
+++ b/src/network-interceptor.ts
@@ -110,6 +110,40 @@ export class NetworkInterceptor {
     await this.inject(client);
   }
 
+  /**
+   * Re-inject the interceptor after a page navigation has wiped the JS
+   * context. Callers should hook this into the browser backend's
+   * "page loaded" event (WebKit `Page.loadEventFired` / `Page.frameNavigated`).
+   * Safe to call when disabled — it's a no-op and returns false.
+   */
+  async reinject(client: InterceptorClient): Promise<boolean> {
+    if (!this._enabled) return false;
+    await this.inject(client);
+    return true;
+  }
+
+  /**
+   * Subscribe the interceptor to a page-load event source so it
+   * automatically re-injects after every navigation. Returns the
+   * unsubscribe function so the caller can detach when tearing down a
+   * session. We accept a thin wiring shim rather than importing
+   * WebKitClient directly so this module stays test-friendly and usable
+   * from non-WebKit backends in the future.
+   */
+  installReinjectionHook(
+    client: InterceptorClient,
+    subscribe: (onLoad: () => void) => (() => void) | void,
+  ): () => void {
+    const unsubscribe = subscribe(() => {
+      void this.reinject(client).catch((err) => {
+        console.error(
+          `[NetworkInterceptor] auto-reinject failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+    return typeof unsubscribe === 'function' ? unsubscribe : () => undefined;
+  }
+
   private async inject(client: InterceptorClient): Promise<void> {
     const rulesJson = JSON.stringify(this.listRules());
     const offlineFlag = this._offline ? 'true' : 'false';


### PR DESCRIPTION
## Summary
Adds two public methods to \`NetworkInterceptor\` so the fetch/XHR overrides survive page navigation:

- \`reinject(client)\` — manually re-runs the injection after the browser context wiped the bindings. No-op when the interceptor is disabled.
- \`installReinjectionHook(client, subscribe)\` — accepts a subscribe shim that wires the underlying browser backend's "page loaded" event to a callback that calls \`reinject\`. Returns the unsubscribe function.

### Why
Before PR18 the interceptor injected once per \`enable()\` call; after a single navigation the \`__os*\` globals were gone but \`_enabled\` stayed true, so callers thought interception was active even though no fetch or XHR was being routed. With the subscribe shim, the WebKit tool layer can bind \`Page.loadEventFired\` to auto-reinject and keep the contract honest.

### Implementation
- The injection script itself is unchanged — re-injecting the same payload is idempotent (it preserves \`__osOriginalFetch\` etc. before overriding so re-running does not double-wrap).
- The hook is a thin wiring shim rather than a direct import of \`WebKitClient\` so this module stays test-friendly and usable from any future browser backend.

## Background
Audit recommendation H-11. #764 scoped the interceptor per-session but did not address navigation-induced wipe.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] Existing interceptor unit tests untouched (pure addition)
- [ ] Manual: \`network_intercept_add\` → navigate to a new page → confirm fetch still routes through the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)