### PR TITLE
feat(errors): StructuredErrorException + toMcpErrorResponse — surface code/recoverable/suggestion

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,3 +1,9 @@
 export { OpenSafariTimeoutError, isTimeoutError } from './timeout';
 export { ErrorCode, ERROR_CATALOG } from './codes';
 export type { StructuredError } from './codes';
+export {
+  StructuredErrorException,
+  isStructuredErrorException,
+  toMcpErrorResponse,
+} from './structured-error';
+export type { McpToolErrorResponse } from './structured-error';

--- a/src/errors/structured-error.ts
+++ b/src/errors/structured-error.ts
@@ -1,0 +1,104 @@
+/**
+ * `StructuredErrorException` — Throwable carrier for the structured-error
+ * metadata defined in `codes.ts`.
+ *
+ * Before this class, callers either threw plain `Error` (losing the
+ * `code` / `recoverable` / `suggestion` fields the catalog already
+ * defined) or returned ad-hoc `{ error, message }` payloads that no
+ * downstream auto-retry layer could introspect. With
+ * `StructuredErrorException`:
+ *
+ *   throw StructuredErrorException.fromCode(ErrorCode.WEBKIT_CONNECT_FAILED,
+ *     `Could not reach ${host}:${port}`);
+ *
+ * yields an Error whose `.code`, `.recoverable`, and `.suggestion`
+ * surface through `instanceof` and `toMcpResponse()` produces a stable
+ * MCP tool response shape ready to return from a handler.
+ */
+
+import { ErrorCode, ERROR_CATALOG, type StructuredError } from './codes';
+
+export interface McpToolErrorResponse {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+}
+
+export class StructuredErrorException extends Error implements StructuredError {
+  readonly code: ErrorCode;
+  readonly recoverable: boolean;
+  readonly suggestion: string;
+
+  constructor(structured: StructuredError) {
+    super(structured.message);
+    this.name = 'StructuredErrorException';
+    this.code = structured.code;
+    this.recoverable = structured.recoverable;
+    this.suggestion = structured.suggestion;
+    // Preserve V8 stack traces.
+    if (typeof (Error as unknown as { captureStackTrace?: (target: object, ctor?: unknown) => void }).captureStackTrace === 'function') {
+      (Error as unknown as { captureStackTrace: (target: object, ctor: unknown) => void })
+        .captureStackTrace(this, StructuredErrorException);
+    }
+  }
+
+  /** Build a StructuredErrorException from one of the catalog codes,
+   *  layering a free-form message on top of the catalog's suggestion. */
+  static fromCode(code: ErrorCode, message: string): StructuredErrorException {
+    const entry = ERROR_CATALOG[code];
+    return new StructuredErrorException({
+      code: entry.code,
+      message,
+      recoverable: entry.recoverable,
+      suggestion: entry.suggestion,
+    });
+  }
+
+  /** Stringify into an MCP tool error response. Pass extra payload fields
+   *  through `extra` to keep tool-specific diagnostics attached. */
+  toMcpResponse(extra?: Record<string, unknown>): McpToolErrorResponse {
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          error: this.code,
+          message: this.message,
+          recoverable: this.recoverable,
+          suggestion: this.suggestion,
+          ...(extra ?? {}),
+        }),
+      }],
+      isError: true,
+    };
+  }
+
+  /** Plain-object form for logging / telemetry. */
+  toJSON(): StructuredError {
+    return {
+      code: this.code,
+      message: this.message,
+      recoverable: this.recoverable,
+      suggestion: this.suggestion,
+    };
+  }
+}
+
+/** Type-guard wrappers so call sites can branch on structured errors
+ *  without an `instanceof` import dance. */
+export function isStructuredErrorException(err: unknown): err is StructuredErrorException {
+  return err instanceof StructuredErrorException;
+}
+
+/** Convert any thrown value into a typed MCP error response. Unknown
+ *  errors fall back to `APP_STATE_UNKNOWN` (recoverable=true) so the
+ *  caller still sees a useful suggestion. */
+export function toMcpErrorResponse(
+  err: unknown,
+  fallbackCode: ErrorCode = ErrorCode.APP_STATE_UNKNOWN,
+  extra?: Record<string, unknown>,
+): McpToolErrorResponse {
+  if (isStructuredErrorException(err)) {
+    return err.toMcpResponse(extra);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return StructuredErrorException.fromCode(fallbackCode, message).toMcpResponse(extra);
+}

--- a/tests/unit/structured-error-exception.test.ts
+++ b/tests/unit/structured-error-exception.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for PR20 — StructuredErrorException + toMcpErrorResponse.
+ */
+
+import {
+  ErrorCode,
+  StructuredErrorException,
+  isStructuredErrorException,
+  toMcpErrorResponse,
+} from '../../src/errors';
+
+describe('StructuredErrorException', () => {
+  it('fromCode pulls recoverable + suggestion from the catalog', () => {
+    const err = StructuredErrorException.fromCode(
+      ErrorCode.WEBKIT_CONNECT_FAILED,
+      'Could not reach localhost:9322',
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe(ErrorCode.WEBKIT_CONNECT_FAILED);
+    expect(err.recoverable).toBe(true);
+    expect(err.suggestion).toMatch(/ios-webkit-debug-proxy/);
+    expect(err.message).toContain('Could not reach');
+  });
+
+  it('toMcpResponse stringifies code + suggestion + recoverable', () => {
+    const err = StructuredErrorException.fromCode(ErrorCode.XCODE_NOT_FOUND, 'xcrun missing');
+    const response = err.toMcpResponse({ deviceId: 'DEV-1' });
+    expect(response.isError).toBe(true);
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload).toMatchObject({
+      error: ErrorCode.XCODE_NOT_FOUND,
+      message: 'xcrun missing',
+      recoverable: false,
+      deviceId: 'DEV-1',
+    });
+    expect(typeof payload.suggestion).toBe('string');
+  });
+
+  it('toJSON returns plain object', () => {
+    const err = StructuredErrorException.fromCode(ErrorCode.APP_NOT_INSTALLED, 'no bundle');
+    const obj = err.toJSON();
+    expect(obj.code).toBe(ErrorCode.APP_NOT_INSTALLED);
+    expect(obj.recoverable).toBe(false);
+  });
+});
+
+describe('isStructuredErrorException', () => {
+  it('identifies wrapped structured errors', () => {
+    const err = StructuredErrorException.fromCode(ErrorCode.SIM_BOOT_FAILED, 'oops');
+    expect(isStructuredErrorException(err)).toBe(true);
+  });
+
+  it('rejects plain Errors', () => {
+    expect(isStructuredErrorException(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('toMcpErrorResponse', () => {
+  it('round-trips a StructuredErrorException', () => {
+    const err = StructuredErrorException.fromCode(ErrorCode.AUTH_EXPIRED, 'token expired');
+    const response = toMcpErrorResponse(err);
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload.error).toBe(ErrorCode.AUTH_EXPIRED);
+    expect(payload.recoverable).toBe(true);
+  });
+
+  it('wraps an unknown Error with the fallback code', () => {
+    const response = toMcpErrorResponse(new Error('mystery'), ErrorCode.APP_STATE_UNKNOWN);
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload.error).toBe(ErrorCode.APP_STATE_UNKNOWN);
+    expect(payload.message).toBe('mystery');
+    expect(payload.recoverable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a throwable that carries the structured-error metadata already declared in \`ERROR_CATALOG\` out to every layer that handles it. Before PR20 the catalog defined \`recoverable\`/\`suggestion\` for each \`ErrorCode\`, but those fields almost never reached MCP responses — most tool handlers threw plain \`Error\` or returned ad-hoc \`{ error, message }\` payloads that the auto-retry layer couldn't introspect.

### API
- \`StructuredErrorException\` — subclass of \`Error\` implementing \`StructuredError\`. \`instanceof Error\` works for catch blocks; \`.code\`, \`.recoverable\`, \`.suggestion\` are first-class fields.
- \`StructuredErrorException.fromCode(code, message)\` — pulls recoverable/suggestion from \`ERROR_CATALOG\`.
- \`.toMcpResponse(extra?)\` — standard MCP error response shape with \`error\`/\`message\`/\`recoverable\`/\`suggestion\` plus tool-specific \`extra\`.
- \`.toJSON()\` — plain object for logging.
- \`isStructuredErrorException(err)\` — type guard.
- \`toMcpErrorResponse(err, fallbackCode?, extra?)\` — universal adapter: round-trips structured errors, wraps anything else with the fallback code (default \`APP_STATE_UNKNOWN\`, recoverable=true).

## Background
Audit recommendation H-13. Pre-PR20 the catalog's \`recoverable\` flag was inert — no caller saw it because nothing threw a typed error.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`structured-error-exception.test.ts\` (7 tests): fromCode pulls from catalog; toMcpResponse stringifies fields + merges extra; toJSON; isStructuredErrorException type guard; toMcpErrorResponse round-trips and wraps unknown errors.
- [ ] Follow-up PRs (out of scope): migrate tool handlers to throw StructuredErrorException + use toMcpErrorResponse instead of ad-hoc { error, message } payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)