### PR TITLE
feat(tools): app_tap_element tryAllFields — relaxed-field fallback

### DIFF
--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -91,6 +91,11 @@ export function registerAppTapElementTool(server: MCPServer): void {
             type: 'string',
             description: 'Target app bundle ID. When provided, the tool re-activates the app and rejects mismatched native contexts.',
           },
+          tryAllFields: {
+            type: 'boolean',
+            description:
+              'When the primary identifier/label/text/role query misses, retry with a relaxed `text` substring built from all provided query fields. Catches the common case where the desired string lives in `value` rather than `label`. Default false.',
+          },
         },
         required: [],
       },
@@ -176,6 +181,25 @@ export function registerAppTapElementTool(server: MCPServer): void {
           if (result.matches.length > index) {
             match = result.matches[index];
             queryResult = result;
+          }
+        }
+
+        // PR22: relaxed-field fallback. When the user opts in, retry the
+        // query with a `text` substring built from whichever query
+        // fields the caller supplied. AX bridges sometimes expose the
+        // visible string in `value` rather than `label` (e.g. text
+        // fields and badges), and this retry finds them without forcing
+        // the caller to re-issue the call with `text:` set.
+        if (!match && params.tryAllFields === true) {
+          const fallbackText = [identifier, label, text].filter(Boolean).join(' ').trim();
+          if (fallbackText.length > 0) {
+            const relaxedResult = await bridge.query({ text: fallbackText, role }, { deviceId });
+            if (relaxedResult.matches.length > index) {
+              match = relaxedResult.matches[index];
+              queryResult = relaxedResult;
+              totalMatches = relaxedResult.matches.length;
+              ambiguous = relaxedResult.ambiguous;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
Extends \`app_tap_element\` with an opt-in fallback strategy: when the primary identifier/label/text query misses, retry with a \`text\` substring built from whichever fields the caller supplied. AX bridges sometimes expose the visible string in \`value\` rather than \`label\` (text fields, badges, action sheet items), and this catches the common "I passed label='Save' but the node only carries value='Save'" miss without forcing the caller to re-issue the call.

### Behaviour
- \`tryAllFields: true\` activates. Default false preserves existing behaviour exactly.
- Runs only when the primary query produced zero matches AND the user provided at least one searchable field.
- Combines the provided fields into a single space-joined substring and re-queries with \`{ text: <fallback>, role }\`.
- The original \`role\` filter is kept so the relaxed match doesn't pull in static text when the caller asked for a button.

## Background
Audit recommendation N-13. Together with PR13 (\`autoScroll\`) and PR16 (\`labelAliases\`), this completes the tap-element fallback ladder: identifier → label → relaxed text → labelAliases → auto-scroll.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] No behavioural change for existing callers (52 tap-element tests still pass)
- [ ] Manual: AX node where the visible string is in \`value\`, \`app_tap_element { label: "Save", tryAllFields: true }\` → should find via the relaxed retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)