### PR TITLE
feat(tools): app_dismiss_keyboard responsive defocus tap

### DIFF
--- a/src/tools/app-dismiss-keyboard.ts
+++ b/src/tools/app-dismiss-keyboard.ts
@@ -1,8 +1,39 @@
 import { MCPServer } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
 import { SimulatorManager } from '../simulator';
+import { DEVICE_PRESETS } from '../simulator/presets';
 import { getInputBackend } from './native-input-backend';
 import { runInputOp } from './native-input-utils';
+
+/**
+ * PR24: compute a safe defocus tap coordinate from the device preset
+ * instead of the pre-PR24 hard-coded (195, 50) which only hit the
+ * status bar on compact iPhones. We tap at 50 % width, 8 % height —
+ * under the status bar / Dynamic Island but above any input affordance
+ * on every preset we ship.
+ */
+async function computeDefocusTap(
+  deviceId: string,
+  manager: SimulatorManager,
+): Promise<{ x: number; y: number; source: 'preset' | 'fallback' }> {
+  try {
+    const booted = await manager.listBooted();
+    const device = booted.find((d) => d.udid === deviceId);
+    if (device) {
+      const preset = Object.values(DEVICE_PRESETS).find((p) => p.name === device.name);
+      if (preset) {
+        return {
+          x: Math.round(preset.w * 0.5),
+          y: Math.round(preset.h * 0.08),
+          source: 'preset',
+        };
+      }
+    }
+  } catch {
+    // listBooted failed — fall through to the historical default
+  }
+  return { x: 195, y: 50, source: 'fallback' };
+}
 
 export function registerAppDismissKeyboardTool(server: MCPServer): void {
   server.registerTool(
@@ -53,15 +84,24 @@ export function registerAppDismissKeyboardTool(server: MCPServer): void {
         console.error(`[app_dismiss_keyboard] sendkey failed: ${err}`);
       }
 
-      // Fallback: tap on status bar area to defocus text fields
+      // Fallback: tap on the status-bar area to defocus text fields. The
+      // coordinate is derived from the device preset (PR24) so iPad and
+      // landscape sims don't end up tapping outside the frame.
+      const defocus = await computeDefocusTap(deviceId, manager);
       try {
         const { meta } = await runInputOp(backend, deviceId, () =>
-          backend.tap(deviceId, 195, 50),
+          backend.tap(deviceId, defocus.x, defocus.y),
         );
         return {
           content: [{
             type: 'text' as const,
-            text: JSON.stringify({ dismissed: true, deviceId, method: 'tap_fallback', _meta: meta }),
+            text: JSON.stringify({
+              dismissed: true,
+              deviceId,
+              method: 'tap_fallback',
+              tapCoord: { x: defocus.x, y: defocus.y, source: defocus.source },
+              _meta: meta,
+            }),
           }],
         };
       } catch (err) {


### PR DESCRIPTION
## Summary
Replaces the hard-coded \`(195, 50)\` defocus coordinate with one derived from the device preset so the \`tap_fallback\` path works on iPad, landscape, and Dynamic Island form factors. Pre-PR24 the fixed coordinate either missed the status bar entirely (iPad, landscape) or landed inside the system island on iPhone Pro hardware, leaving the keyboard up.

### Behaviour
- Looks up the booted device, finds the matching \`DEVICE_PRESETS\` entry, and taps at 50 % width / 8 % height — just under the status bar / Dynamic Island, above any input affordance on every preset we ship.
- Falls back to the historical \`(195, 50)\` when the device can't be resolved, so behaviour degrades to "previous" instead of erroring.
- Response payload now includes \`tapCoord: { x, y, source: 'preset' | 'fallback' }\` so callers can introspect which path ran.

## Background
Audit recommendation H-6. KEYBOARD_LAYOUT_NOT_LATIN auto-toggle (H-7) was scoped out — it requires Settings-app navigation that overlaps significantly with PR5 / PR23 and deserves a dedicated PR.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] Existing keyboard tool tests untouched (only the fallback branch changes and the new diagnostic field is additive)
- [ ] Manual: iPad sim with the keyboard up, \`app_dismiss_keyboard\` → \`tap_fallback\` should land inside the iPad frame instead of missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)