### PR TITLE
feat(tools): findFreshCrashes — helper for detecting crashes mid-action

### DIFF
--- a/src/tools/app-crash-reports.ts
+++ b/src/tools/app-crash-reports.ts
@@ -184,3 +184,50 @@ export function registerAppCrashReportsTool(server: MCPServer): void {
     },
   );
 }
+
+/**
+ * PR25: detect crash reports that landed in DiagnosticReports AFTER a
+ * reference timestamp. Designed for "run high-risk op (launch / tap /
+ * type) → record start ts → call this; if anything matches, that op
+ * almost certainly crashed the app and the caller should retry once
+ * instead of returning a useless success".
+ *
+ * Filtering rules:
+ *   - mtime > sinceMs        — only reports newer than the op start.
+ *   - extension is .ips/.crash.
+ *   - When `processName` is supplied (the bundle's process portion of
+ *     the file name is a useful proxy), reports must contain it as a
+ *     filename prefix. When omitted, any fresh report is returned.
+ *
+ * Returns an empty array on any read failure (no DiagnosticReports dir,
+ * permissions, etc.) — the caller decides whether to surface that.
+ */
+export async function findFreshCrashes(
+  processName: string | undefined,
+  sinceMs: number,
+): Promise<Array<{ filename: string; mtimeMs: number }>> {
+  const out: Array<{ filename: string; mtimeMs: number }> = [];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(DIAGNOSTIC_REPORTS_DIR);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const ext = path.extname(entry).toLowerCase();
+    if (!CRASH_EXTENSIONS.has(ext)) continue;
+    if (processName) {
+      const stem = entry.replace(/\.(ips|crash)$/, '').split('_')[0];
+      if (stem !== processName) continue;
+    }
+    try {
+      const stat = await fs.stat(path.join(DIAGNOSTIC_REPORTS_DIR, entry));
+      if (stat.mtimeMs > sinceMs) {
+        out.push({ filename: entry, mtimeMs: stat.mtimeMs });
+      }
+    } catch {
+      // unreadable file — skip
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
Adds an exported helper \`findFreshCrashes(processName?, sinceMs)\` so caller tools (\`app_launch\` / \`app_tap\` / \`app_type_text\` / orchestration engine) can detect that a high-risk op crashed the target app mid-call and react with a retry/abort policy instead of returning a useless success.

### Usage pattern
\`\`\`
const opStart = Date.now();
try { await manager.launchApp(...); }
finally {
  const fresh = await findFreshCrashes(processName, opStart);
  if (fresh.length > 0) {
    // App crashed during launch — caller decides: retry once,
    // surface as APP_CRASHED, etc.
  }
}
\`\`\`

### Filter rules
- \`mtime > sinceMs\` (skips pre-existing crash reports)
- Extension is \`.ips\` / \`.crash\`
- When \`processName\` is provided, the filename prefix must match (the simple \`<process>_<timestamp>\` convention used by DiagnosticReports). Omitting it returns every fresh report.

Read failures (missing DiagnosticReports dir, permissions, unreadable files) are tolerated — the helper returns an empty array.

## Background
Audit recommendation H-8. Pre-PR25 \`app_crash_reports\` only listed reports on demand; nothing in the launch / tap path actively checked for fresh ones, so an app crash mid-call was indistinguishable from a successful op.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] Pure addition — existing crash-reports tests unaffected.
- [ ] Follow-up PR: wire \`findFreshCrashes\` into \`app_launch\` / \`app_tap_element\` finalizers so they auto-retry once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)