### PR TITLE
feat(auth): JWT-aware auth profile validation (inspectAuthJwts)

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,2 +1,4 @@
 export { AuthManager } from './manager';
 export type { AuthProfile, ExpiryInfo } from './manager';
+export { inspectAuthJwts, decodeJwtPayload } from './jwt-inspect';
+export type { AuthValidationReport, InspectedJwt } from './jwt-inspect';

--- a/src/auth/jwt-inspect.ts
+++ b/src/auth/jwt-inspect.ts
@@ -1,0 +1,119 @@
+/**
+ * Best-effort JWT inspection helpers for saved auth profiles.
+ *
+ * PR26 adds a JWT-aware view on top of `AuthManager.checkExpiry`: the
+ * original signal (cookie `expires`) misses the case where the actual
+ * auth lifetime is gated by a Bearer token stored in `localStorage`
+ * or a session cookie value, which is the norm for SPA apps.
+ *
+ * We DO NOT verify the JWT signature — that requires the issuer's
+ * public key. We just decode the payload to read `exp` so callers can
+ * know whether a saved profile is still inside its server-side TTL.
+ */
+
+import type { AuthProfile } from './manager';
+import type { Cookie } from '../types/browser-backend';
+
+const JWT_RE = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
+
+export interface InspectedJwt {
+  source: 'cookie' | 'localStorage' | 'sessionStorage';
+  /** Identifier within source: cookie name / storage key. */
+  key: string;
+  /** Decoded payload (subset — `exp`, `iat`, `nbf`, plus any other claims). */
+  payload: Record<string, unknown>;
+  /** Unix seconds. Undefined when payload had no `exp`. */
+  exp?: number;
+}
+
+export interface AuthValidationReport {
+  totalJwts: number;
+  expiredCount: number;
+  expiringCount: number;
+  /** Earliest `exp` across all inspected JWTs (unix seconds). Infinity when none. */
+  earliestExpiry: number;
+  isExpired: boolean;
+  isExpiring: boolean;
+  jwts: InspectedJwt[];
+}
+
+/** Base64url → utf-8 string. Returns null when not parseable. */
+function decodeBase64Url(input: string): string | null {
+  try {
+    const padded = input.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((input.length + 3) % 4);
+    return Buffer.from(padded, 'base64').toString('utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/** Return the decoded payload object if `token` looks like a JWT. */
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const json = decodeBase64Url(parts[1]);
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === 'object') return parsed as Record<string, unknown>;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function scanString(
+  source: InspectedJwt['source'],
+  key: string,
+  value: string,
+  out: InspectedJwt[],
+): void {
+  const match = value.match(JWT_RE);
+  if (!match) return;
+  const payload = decodeJwtPayload(match[0]);
+  if (!payload) return;
+  const exp = typeof payload.exp === 'number' ? (payload.exp as number) : undefined;
+  out.push({ source, key, payload, exp });
+}
+
+/**
+ * Walk every cookie + localStorage + sessionStorage value, decode any
+ * JWT-shaped strings, and return per-token expiry info plus aggregate
+ * counts.
+ */
+export function inspectAuthJwts(
+  profile: AuthProfile,
+  options?: { expiringWindowSec?: number },
+): AuthValidationReport {
+  const expiringWindow = options?.expiringWindowSec ?? 300;
+  const jwts: InspectedJwt[] = [];
+
+  for (const cookie of profile.cookies as Cookie[]) {
+    if (cookie.value && typeof cookie.value === 'string') {
+      scanString('cookie', cookie.name, cookie.value, jwts);
+    }
+  }
+  for (const [key, value] of Object.entries(profile.localStorage ?? {})) {
+    if (typeof value === 'string') scanString('localStorage', key, value, jwts);
+  }
+  for (const [key, value] of Object.entries(profile.sessionStorage ?? {})) {
+    if (typeof value === 'string') scanString('sessionStorage', key, value, jwts);
+  }
+
+  const now = Date.now() / 1000;
+  const withExp = jwts.filter((j) => typeof j.exp === 'number');
+  const expired = withExp.filter((j) => (j.exp as number) < now);
+  const expiring = withExp.filter(
+    (j) => (j.exp as number) >= now && (j.exp as number) - now < expiringWindow,
+  );
+
+  return {
+    totalJwts: jwts.length,
+    expiredCount: expired.length,
+    expiringCount: expiring.length,
+    earliestExpiry: withExp.reduce((min, j) => Math.min(min, j.exp as number), Infinity),
+    isExpired: expired.length > 0,
+    isExpiring: expiring.length > 0,
+    jwts,
+  };
+}

--- a/tests/unit/jwt-inspect.test.ts
+++ b/tests/unit/jwt-inspect.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for PR26 — JWT-aware auth validation.
+ */
+
+import { decodeJwtPayload, inspectAuthJwts } from '../../src/auth/jwt-inspect';
+import type { AuthProfile } from '../../src/auth/manager';
+
+function buildJwt(payload: Record<string, unknown>): string {
+  const b64u = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+  return `${b64u({ alg: 'HS256', typ: 'JWT' })}.${b64u(payload)}.sig`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('decodes a valid JWT payload', () => {
+    const token = buildJwt({ sub: 'user-1', exp: 1700000000 });
+    const out = decodeJwtPayload(token);
+    expect(out).toMatchObject({ sub: 'user-1', exp: 1700000000 });
+  });
+
+  it('returns null for non-JWT strings', () => {
+    expect(decodeJwtPayload('plain string')).toBeNull();
+    expect(decodeJwtPayload('one.two')).toBeNull();
+  });
+});
+
+describe('inspectAuthJwts', () => {
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const past = Math.floor(Date.now() / 1000) - 60;
+
+  function profile(over: Partial<AuthProfile> = {}): AuthProfile {
+    return {
+      site: 'example.com',
+      savedAt: new Date().toISOString(),
+      currentUrl: 'https://example.com',
+      cookies: [],
+      localStorage: {},
+      sessionStorage: {},
+      ...over,
+    };
+  }
+
+  it('finds JWTs across cookies / localStorage / sessionStorage', () => {
+    const t1 = buildJwt({ exp: future });
+    const t2 = buildJwt({ exp: past });
+    const report = inspectAuthJwts(
+      profile({
+        cookies: [{
+          name: 'session', value: t1, domain: 'example.com', path: '/',
+          expires: 0, httpOnly: false, secure: true, sameSite: 'Lax',
+        }],
+        localStorage: { idToken: t2, junk: 'not a jwt' },
+      }),
+    );
+    expect(report.totalJwts).toBe(2);
+    expect(report.expiredCount).toBe(1);
+    expect(report.expiringCount).toBe(0);
+    expect(report.isExpired).toBe(true);
+    expect(report.earliestExpiry).toBe(past);
+  });
+
+  it('flags expiring tokens within the configurable window', () => {
+    const soon = Math.floor(Date.now() / 1000) + 60; // 60 s away
+    const report = inspectAuthJwts(
+      profile({ localStorage: { soon: buildJwt({ exp: soon }) } }),
+      { expiringWindowSec: 120 },
+    );
+    expect(report.isExpiring).toBe(true);
+    expect(report.expiringCount).toBe(1);
+  });
+
+  it('returns 0 totals on a JWT-free profile', () => {
+    const report = inspectAuthJwts(profile({ localStorage: { x: 'plain' } }));
+    expect(report.totalJwts).toBe(0);
+    expect(report.earliestExpiry).toBe(Infinity);
+  });
+});


### PR DESCRIPTION
## Summary
Adds best-effort JWT inspection on top of \`AuthManager.checkExpiry\` so callers can tell whether a saved profile's actual auth lifetime (not just its cookie expiry) is still inside the server-side TTL. The original \`checkExpiry\` only looked at cookie \`expires\`, which misses the SPA-common pattern where the lifetime is gated by a Bearer token embedded in \`localStorage\` or a session-cookie value.

### API
- \`decodeJwtPayload(token)\` — base64url-decodes the JWT payload claim block. Returns null when the input isn't shaped like a JWT. (We never verify the signature; that needs the issuer's public key.)
- \`inspectAuthJwts(profile, { expiringWindowSec? })\` — walks every cookie/localStorage/sessionStorage value, scans for JWT-shaped substrings, reports per-token expiry plus aggregate counts.
- Returned \`AuthValidationReport\`: \`totalJwts\`, \`expiredCount\`, \`expiringCount\`, \`earliestExpiry\` (unix sec or Infinity), \`isExpired\`, \`isExpiring\`, \`jwts[]\`.

Re-exported from \`src/auth/index.ts\`.

## Background
Audit recommendation A-9 (subset). The deeplink token cache and multi-account keying parts were scoped out — they require larger refactors of \`AuthManager.save/restore\` and merit their own PRs.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] New \`jwt-inspect.test.ts\` (5 tests): decode happy/sad; JWTs across all three storage surfaces; expiry totals; configurable expiring window; JWT-free profile returns zeros.
- [ ] Follow-up: surface as an \`auth_validate\` MCP tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)