### PR TITLE
feat(tools): auth_otp_fetch — OTP retrieval from dev mailboxes

### DIFF
--- a/src/security/high-risk-tools.ts
+++ b/src/security/high-risk-tools.ts
@@ -59,6 +59,10 @@ export const HIGH_RISK_MCP_TOOLS: Readonly<Record<string, HighRiskToolMetadata>>
     category: 'credential-movement',
     requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
   },
+  auth_otp_fetch: {
+    category: 'credential-movement',
+    requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,
+  },
   cookies: {
     category: 'credential-movement',
     requiredCapability: HTTP_HIGH_RISK_TOOL_CAPABILITY,

--- a/src/tools/auth-otp-fetch.ts
+++ b/src/tools/auth-otp-fetch.ts
@@ -1,0 +1,184 @@
+/**
+ * `auth_otp_fetch` — retrieve a one-time password from a developer-side
+ * mailbox so OTP-gated logins can be automated end-to-end.
+ *
+ * Backends supported in this first cut:
+ *   mailhog       — GET <baseUrl>/api/v2/messages, scan latest first,
+ *                   extract a numeric code matching `codePattern`.
+ *   webhook       — GET <baseUrl> and parse the response body. The
+ *                   caller's webhook should return JSON `{ code }` or
+ *                   any body containing a numeric block that matches
+ *                   `codePattern`. Useful for ngrok/inlets sinks that
+ *                   re-emit Twilio's webhook payload.
+ *   custom        — caller supplies the URL directly and we run the
+ *                   same scan against the response body.
+ *
+ * NOTE: We deliberately do NOT support production Twilio / Auth0 / etc.
+ * with API keys — those require secret management and rate-limit
+ * coordination that belong in a separate, security-reviewed PR. This
+ * tool is for developer/test inboxes only.
+ */
+
+import { MCPServer } from '../mcp-server';
+
+const PROVIDERS = ['mailhog', 'webhook', 'custom'] as const;
+type Provider = (typeof PROVIDERS)[number];
+
+const DEFAULT_CODE_PATTERN = '\\b\\d{4,8}\\b';
+
+interface FetchResult {
+  code: string | null;
+  provider: Provider;
+  source: 'subject' | 'body' | 'json' | 'none';
+  matchedText?: string;
+}
+
+async function httpGetJson(url: string, timeoutMs = 5000): Promise<{
+  status: number;
+  text: string;
+}> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: ac.signal });
+    const text = await res.text();
+    return { status: res.status, text };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function extractCode(haystack: string, codePattern: string): string | null {
+  try {
+    const re = new RegExp(codePattern);
+    const m = haystack.match(re);
+    return m ? m[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchFromMailhog(baseUrl: string, codePattern: string, recipient?: string): Promise<FetchResult> {
+  // mailhog v2 API returns { total, items: [ { Content: { Headers: {...}, Body }, Raw: {...} } ] }
+  const url = baseUrl.replace(/\/$/, '') + '/api/v2/messages';
+  const { status, text } = await httpGetJson(url);
+  if (status >= 400) {
+    throw new Error(`mailhog responded ${status}`);
+  }
+  let parsed: { items?: Array<{ Content?: { Headers?: Record<string, string[]>; Body?: string } }> };
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('mailhog: response was not JSON');
+  }
+  const items = parsed.items ?? [];
+  for (const item of items) {
+    const headers = item.Content?.Headers ?? {};
+    if (recipient) {
+      const to = (headers.To ?? []).join(',');
+      if (!to.toLowerCase().includes(recipient.toLowerCase())) continue;
+    }
+    const subject = (headers.Subject ?? []).join(' ');
+    const fromSubject = extractCode(subject, codePattern);
+    if (fromSubject) {
+      return { code: fromSubject, provider: 'mailhog', source: 'subject', matchedText: subject };
+    }
+    const body = item.Content?.Body ?? '';
+    const fromBody = extractCode(body, codePattern);
+    if (fromBody) {
+      return { code: fromBody, provider: 'mailhog', source: 'body', matchedText: body.slice(0, 120) };
+    }
+  }
+  return { code: null, provider: 'mailhog', source: 'none' };
+}
+
+async function fetchFromWebhookOrCustom(
+  url: string,
+  codePattern: string,
+  provider: Provider,
+): Promise<FetchResult> {
+  const { status, text } = await httpGetJson(url);
+  if (status >= 400) {
+    throw new Error(`${provider}: responded ${status}`);
+  }
+  // Try to read JSON `{ code }` first.
+  try {
+    const parsed = JSON.parse(text) as { code?: string | number };
+    if (parsed && (typeof parsed.code === 'string' || typeof parsed.code === 'number')) {
+      return { code: String(parsed.code), provider, source: 'json' };
+    }
+  } catch {
+    // Not JSON — fall through to regex scan
+  }
+  const m = extractCode(text, codePattern);
+  return m
+    ? { code: m, provider, source: 'body', matchedText: text.slice(0, 120) }
+    : { code: null, provider, source: 'none' };
+}
+
+export function registerAuthOtpFetchTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'auth_otp_fetch',
+      description:
+        'Retrieve a one-time password from a developer-side mailbox so OTP-gated logins can be automated end-to-end. Supports mailhog, webhook (returns { code }), and custom URL providers. NOT for production Twilio / Auth0 — those require secret management out of scope here.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          provider: { type: 'string', enum: [...PROVIDERS], description: 'mailhog | webhook | custom' },
+          baseUrl: { type: 'string', description: 'Base URL of the mailbox or webhook' },
+          recipient: { type: 'string', description: 'Filter by To: header (mailhog only)' },
+          codePattern: {
+            type: 'string',
+            description: `Regex matching the OTP digits (default: ${DEFAULT_CODE_PATTERN}).`,
+          },
+          timeoutMs: { type: 'number', description: 'HTTP timeout (default 5000)' },
+        },
+        required: ['provider', 'baseUrl'],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      const provider = params.provider as Provider | undefined;
+      if (!provider || !PROVIDERS.includes(provider)) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'INVALID_PROVIDER', allowed: PROVIDERS }) }],
+          isError: true,
+        };
+      }
+      const baseUrl = params.baseUrl as string | undefined;
+      if (!baseUrl) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'MISSING_BASE_URL' }) }],
+          isError: true,
+        };
+      }
+      const codePattern = (params.codePattern as string | undefined) ?? DEFAULT_CODE_PATTERN;
+      const recipient = params.recipient as string | undefined;
+
+      try {
+        let result: FetchResult;
+        if (provider === 'mailhog') {
+          result = await fetchFromMailhog(baseUrl, codePattern, recipient);
+        } else {
+          result = await fetchFromWebhookOrCustom(baseUrl, codePattern, provider);
+        }
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          isError: result.code === null,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({ error: 'OTP_FETCH_FAILED', provider, message }),
+          }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+/** Visible for tests. */
+export const __forTests = { extractCode };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -36,6 +36,7 @@ import { registerCompareDevicesTool } from './compare-devices';
 import { registerQADetectorTools } from './qa-detectors';
 import { registerQAAuditTools } from './qa-audit';
 import { registerAuthTools } from './auth';
+import { registerAuthOtpFetchTool } from './auth-otp-fetch';
 import { registerMockGeolocationTool } from './mock-geolocation';
 import { registerNetworkThrottleTool } from './network-throttle';
 import { registerErrorLogTool } from './error-log';
@@ -206,6 +207,7 @@ export function registerAllTools(server: MCPServer): void {
 
   // Tier 3: Auth Persistence
   registerAuthTools(server);
+  registerAuthOtpFetchTool(server);
 
   // Tier 2: Native App — System Surfaces
   registerAppOpenUrlTool(server);


### PR DESCRIPTION
## Summary
New MCP tool that pulls a one-time password out of a developer-side mailbox so OTP-gated login flows can be automated end-to-end without a human typing the code.

### Providers
- \`mailhog\` — \`GET <baseUrl>/api/v2/messages\`, walk items newest first, optionally filter by recipient, scan Subject then Body for \`codePattern\`.
- \`webhook\` — \`GET <baseUrl>\`. Caller's sink should respond with JSON \`{ code }\` or any body containing a numeric block matching \`codePattern\`. Useful for ngrok/inlets endpoints re-emitting Twilio's payload.
- \`custom\` — Same as webhook but allows arbitrary URLs (caller-managed sink).

Default \`codePattern\` is \`\\\\b\\\\d{4,8}\\\\b\` (any 4–8 digit block); caller can override for alphanumeric or longer codes.

### Not in scope
Production Twilio / Auth0 / etc. require API keys, secret management, and rate-limit coordination that belong in a separately security-reviewed PR. This tool is for developer/test inboxes only — the doc string says so explicitly.

## Background
Audit recommendation A-6. Pre-PR27 every OTP-protected flow blocked at the prompt with no programmatic recovery.

## Test plan
- [x] Typecheck (\`tsc --noEmit\`) clean
- [x] Pure addition — existing auth tests unaffected
- [ ] Manual: \`docker run mailhog/mailhog\`, send a test email containing "123456", \`auth_otp_fetch { provider: 'mailhog', baseUrl: 'http://127.0.0.1:8025' }\` → response should carry \`code: '123456'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)