### PR TITLE
feat(tools): app_pop_until postcondition + attempt history (#801 PR1)

### DIFF
--- a/docs/app-pop-until.md
+++ b/docs/app-pop-until.md
@@ -1,0 +1,120 @@
+# app_pop_until
+
+`app_pop_until` collapses repeated `Navigator.pop` calls (or, in PR2, native
+back-gestures) into a single semantic action. It targets one of three
+predicates and — when supplied a `postcondition` — verifies the resulting
+screen state before reporting success.
+
+## When to use `app_pop_until` vs. `app_tap_element`
+
+- **Use `app_pop_until`** when the goal is "leave this screen / dismiss this
+  modal / return to a known route." It works for modal/bottom-sheet routes
+  that lack a tappable AppBar back button, and it bounds the number of pops
+  by the `until` predicate.
+- **Use `app_tap_element`** when the back affordance is a specific button
+  (e.g. a custom toolbar). `app_pop_until` is intentionally agnostic to the
+  UI affordance.
+- **Pair with `app_goto_screen`** when the goal is to *reach* a route rather
+  than leave one — that tool dispatches a deeplink and verifies arrival.
+
+## Inputs
+
+```ts
+{
+  until: 'first' | 'route' | 'count',
+  name?: string,           // required when until === 'route'
+  count?: number,          // required when until === 'count', positive integer
+  device_id?: string,      // optional — falls back to sole booted device
+  postcondition?: {
+    identifier?: string,
+    label?: string,
+    text?: string,
+    role?: string,
+    route?: string,        // ModalRoute.of(root).settings.name (Flutter VM only)
+    timeoutMs?: number,    // default 3000
+    intervalMs?: number,   // default 250
+  },
+  maxAttempts?: number,            // bounds fallback ladder attempts (PR2)
+  interAttemptDelayMs?: number,    // default 250 (PR2)
+}
+```
+
+At least one of `identifier`/`label`/`text`/`role`/`route` must be supplied
+inside `postcondition` when the field is present. `route` requires an
+active Flutter VM connection; the other four are AX-bridge queries that
+work in both VM and native contexts.
+
+## Response shape
+
+```ts
+{
+  ok: boolean,                   // true iff postcondition verified (or no postcondition)
+  status: 'ok' | string,
+  popped?: number,               // only when until === 'count'
+  target: PopUntil,              // echoed input
+  strategy: 'flutter_vm',        // PR2 adds: 'native_back' | 'edge_swipe' | ...
+  attempts: [{
+    n: number,
+    action: string,              // e.g. 'flutter_vm.popUntil'
+    elapsedMs: number,
+    ok: boolean,
+    detail?: string,
+  }],
+  postcondition: {
+    requested: boolean,
+    kind?: 'ax_query' | 'route',
+    verified?: boolean,
+    query?: { identifier?, label?, text?, role? },
+    route?: string,
+    elapsedMs?: number,
+    polls?: number,
+    finalMatchCount?: number,
+    error?: string,
+  }
+}
+```
+
+When the postcondition is supplied and is **not** verified, the response
+sets `isError: true` — downstream auto-retry layers can treat this as a
+recoverable failure.
+
+## Failure modes
+
+| ErrorCode | Meaning | Caller action |
+|---|---|---|
+| `INVALID_INPUT` | `until` enum / `count` shape invalid, or `postcondition` has no signal field | Fix input and retry |
+| `MISSING_REQUIRED_PARAM` | `name` missing for `until: 'route'` | Supply `name` |
+| `DEVICE_NOT_BOOTED` | No booted simulator and no explicit `device_id` | Boot a device |
+| `FLUTTER_VM_NOT_CONNECTED` | VM Service unreachable (release build, etc.) | Call `flutter_connect`, or wait for #801 PR2 native fallback |
+| `FLUTTER_EVAL_FAILED` | VM evaluate threw or `opensafari_pop:no_root`/`no_navigator` | Inspect attempts[0].detail; re-run `app_context` to confirm UI is mounted |
+| `POP_UNTIL_EXHAUSTED` *(PR2)* | All fallback strategies tried without satisfying postcondition | Inspect attempts[], consider longer timeout |
+| `MISSING_POSTCONDITION` *(PR2)* | Native fallback ladder requires a postcondition | Supply one |
+
+## Examples
+
+Pop everything until you land on the first route, then verify a known
+identifier is visible:
+
+```jsonc
+{
+  "until": "first",
+  "postcondition": { "identifier": "home_tab_button", "timeoutMs": 4000 }
+}
+```
+
+Pop until the `/library` route is current, verifying via the strongest
+signal available (Flutter route name):
+
+```jsonc
+{
+  "until": "route",
+  "name": "/library",
+  "postcondition": { "route": "/library" }
+}
+```
+
+Pop exactly twice, then check that a "Saved" label re-appears:
+
+```jsonc
+{ "until": "count", "count": 2, "postcondition": { "label": "Saved" } }
+```

--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -220,6 +220,39 @@ async function verifyAxPostcondition(
   };
 }
 
+function buildRoutePostconditionExpression(routeName: string): string {
+  const escaped = routeName.replace(/'/g, "\\'");
+  return `
+(() {
+  try {
+    final binding = WidgetsBinding.instance;
+    final root = binding.rootElement;
+    if (root == null) return 'opensafari_route:no_root';
+
+    String? name;
+    void visit(Element el) {
+      if (name != null) return;
+      final type = el.widget.runtimeType.toString();
+      if (type == '_ModalScopeStatus') {
+        final s = el.toString();
+        final match = RegExp(r'name:\\s*"([^"]+)"').firstMatch(s)
+            ?? RegExp(r"name:\\s*'([^']+)'").firstMatch(s)
+            ?? RegExp(r'RouteSettings\\("([^"]+)"').firstMatch(s);
+        if (match != null) name = match.group(1);
+      }
+      el.visitChildren(visit);
+    }
+    visit(root);
+
+    if (name == '${escaped}') return 'opensafari_route:ok';
+    return 'opensafari_route:mismatch:' + (name ?? 'null').toString();
+  } catch (e) {
+    return 'opensafari_route:error:' + e.toString().replaceAll(':', '_');
+  }
+})()
+`.replace(/\s+/g, ' ').trim();
+}
+
 async function verifyRoutePostcondition(
   deviceId: string,
   routeName: string,
@@ -231,24 +264,7 @@ async function verifyRoutePostcondition(
   const deadline = start + Math.max(0, Math.floor(budgetMs));
   let polls = 0;
   let lastError: string | undefined;
-  // Dart expression reads ModalRoute.of(root) settings.name; falls back
-  // to navigator.currentRouteName via observers when unavailable.
-  const escaped = routeName.replace(/'/g, "\\'");
-  const expr = `
-(() {
-  try {
-    final binding = WidgetsBinding.instance;
-    final root = binding.rootElement;
-    if (root == null) return 'opensafari_route:no_root';
-    final modal = ModalRoute.of(root);
-    final name = modal?.settings.name;
-    if (name == '${escaped}') return 'opensafari_route:ok';
-    return 'opensafari_route:mismatch:' + (name ?? 'null').toString();
-  } catch (e) {
-    return 'opensafari_route:error:' + e.toString().replaceAll(':', '_');
-  }
-})()
-`.replace(/\s+/g, ' ').trim();
+  const expr = buildRoutePostconditionExpression(routeName);
   while (Date.now() <= deadline) {
     polls++;
     try {
@@ -485,4 +501,5 @@ export const __forTests = {
   parsePostcondition,
   verifyAxPostcondition,
   verifyRoutePostcondition,
+  buildRoutePostconditionExpression,
 };

--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -1,42 +1,93 @@
 /**
  * `app_pop_until` — pop Navigator routes until a target predicate succeeds.
  *
- * Strategy:
+ * Strategy (PR1 of #801 — contract extension):
  *   1. Prefer Flutter VM service when connected — evaluates a one-shot
  *      `Navigator.popUntil` expression that pops by route name, by
  *      ancestor count, or to first. This is the only reliable path for
  *      apps that use modal/bottom-sheet routes which have no AppBar back
  *      button to tap.
- *   2. Fall back to nothing else for now — apps without a VM service
- *      (release builds) should pair this tool with a tap-based recipe
- *      (PR15 + alert handler back-button labels).
+ *   2. A native-fallback ladder (system back / app-bar chevron / edge swipe /
+ *      Escape) lands in #801 PR2. This PR adds the postcondition and
+ *      attempt-history shape that the fallback ladder will produce.
  *
  * Predicates (mutually exclusive):
  *   { until: 'first' }           — pop until isFirst === true
  *   { until: 'route', name: '/' }— pop until the matching named route is current
  *   { until: 'count', count: 3 } — pop exactly count times (best-effort)
+ *
+ * Optional postcondition (any combination — at least one of identifier /
+ * label / text / role / route required when supplied):
+ *   postcondition: {
+ *     identifier?, label?, text?, role?,  // AX query
+ *     route?,                              // Flutter route name (VM only)
+ *     timeoutMs?,                          // default 3000
+ *   }
+ *
+ * Response shape (additive — pre-#801 fields preserved):
+ *   { ok, status, popped?, target,
+ *     strategy: 'flutter_vm' | ...future fallbacks,
+ *     attempts: [{ n, action, elapsedMs, ok, detail? }],
+ *     postcondition: { requested, kind?, verified?, query?, route?,
+ *                      elapsedMs?, polls?, finalMatchCount?, error? } }
  */
 
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
+import { getAccessibilityBridge } from '../native';
+import {
+  ErrorCode,
+  respondWithStructuredError,
+} from '../errors';
 
 type PopUntil =
   | { until: 'first' }
   | { until: 'route'; name: string }
   | { until: 'count'; count: number };
 
+interface PostconditionSpec {
+  identifier?: string;
+  label?: string;
+  text?: string;
+  role?: string;
+  route?: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+interface AttemptRecord {
+  n: number;
+  action: string;
+  elapsedMs: number;
+  ok: boolean;
+  detail?: string;
+}
+
+interface PostconditionVerdict {
+  requested: boolean;
+  kind?: 'ax_query' | 'route';
+  verified?: boolean;
+  query?: Record<string, unknown>;
+  route?: string;
+  elapsedMs?: number;
+  polls?: number;
+  finalMatchCount?: number;
+  error?: string;
+}
+
+const DEFAULT_POSTCOND_TIMEOUT_MS = 3000;
+const DEFAULT_POSTCOND_INTERVAL_MS = 250;
+const DEFAULT_INTER_ATTEMPT_DELAY_MS = 250;
+const DEFAULT_MAX_ATTEMPTS = 6;
+
 function buildExpression(target: PopUntil): string {
-  // `WidgetsBinding.instance.rootElement` gives an Element we can use as
-  // a BuildContext for Navigator.of(). Wrapping in try/catch returns a
-  // structured marker the Node side can parse.
   const predicate =
     target.until === 'first'
       ? '(r) => r.isFirst'
       : target.until === 'route'
-        // Quote the name carefully — Dart single quotes don't interpolate.
         ? `(r) => r.settings.name == '${target.name.replace(/'/g, "\\'")}' || r.isFirst`
-        : ''; // count handled separately below
+        : '';
   if (target.until === 'count') {
     return `
 (() {
@@ -89,13 +140,174 @@ function parsePopResult(raw: string): { ok: boolean; status: string; popped?: nu
   return { ok: false, status: payload };
 }
 
+function parsePostcondition(raw: unknown): PostconditionSpec | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== 'object') {
+    throw new Error('postcondition must be an object');
+  }
+  const spec = raw as PostconditionSpec;
+  const hasSignal = !!(spec.identifier || spec.label || spec.text || spec.role || spec.route);
+  if (!hasSignal) {
+    throw new Error(
+      'postcondition requires at least one of identifier, label, text, role, or route',
+    );
+  }
+  return spec;
+}
+
+async function verifyAxPostcondition(
+  deviceId: string,
+  spec: PostconditionSpec,
+  budgetMs: number,
+): Promise<PostconditionVerdict> {
+  const bridge = getAccessibilityBridge();
+  const query = {
+    identifier: spec.identifier,
+    label: spec.label,
+    text: spec.text,
+    role: spec.role,
+  };
+  const interval = Math.max(50, Math.floor(spec.intervalMs ?? DEFAULT_POSTCOND_INTERVAL_MS));
+  const start = Date.now();
+  const deadline = start + Math.max(0, Math.floor(budgetMs));
+  let polls = 0;
+  let finalMatchCount = 0;
+  while (Date.now() <= deadline) {
+    polls++;
+    try {
+      const result = await bridge.query(query, { deviceId });
+      finalMatchCount = result.matches.length;
+      if (finalMatchCount > 0) {
+        return {
+          requested: true,
+          kind: 'ax_query',
+          verified: true,
+          query,
+          elapsedMs: Date.now() - start,
+          polls,
+          finalMatchCount,
+        };
+      }
+    } catch (err) {
+      // Best-effort — keep polling until deadline, but surface the last
+      // error if we never verify.
+      const errMessage = err instanceof Error ? err.message : String(err);
+      if (Date.now() > deadline) {
+        return {
+          requested: true,
+          kind: 'ax_query',
+          verified: false,
+          query,
+          elapsedMs: Date.now() - start,
+          polls,
+          finalMatchCount,
+          error: errMessage,
+        };
+      }
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(interval, remaining)));
+  }
+  return {
+    requested: true,
+    kind: 'ax_query',
+    verified: false,
+    query,
+    elapsedMs: Date.now() - start,
+    polls,
+    finalMatchCount,
+  };
+}
+
+async function verifyRoutePostcondition(
+  deviceId: string,
+  routeName: string,
+  budgetMs: number,
+  intervalMs: number,
+): Promise<PostconditionVerdict> {
+  const client = getFlutterVMClient(deviceId);
+  const start = Date.now();
+  const deadline = start + Math.max(0, Math.floor(budgetMs));
+  let polls = 0;
+  let lastError: string | undefined;
+  // Dart expression reads ModalRoute.of(root) settings.name; falls back
+  // to navigator.currentRouteName via observers when unavailable.
+  const escaped = routeName.replace(/'/g, "\\'");
+  const expr = `
+(() {
+  try {
+    final binding = WidgetsBinding.instance;
+    final root = binding.rootElement;
+    if (root == null) return 'opensafari_route:no_root';
+    final modal = ModalRoute.of(root);
+    final name = modal?.settings.name;
+    if (name == '${escaped}') return 'opensafari_route:ok';
+    return 'opensafari_route:mismatch:' + (name ?? 'null').toString();
+  } catch (e) {
+    return 'opensafari_route:error:' + e.toString().replaceAll(':', '_');
+  }
+})()
+`.replace(/\s+/g, ' ').trim();
+  while (Date.now() <= deadline) {
+    polls++;
+    try {
+      const result = await client.evaluate(expr);
+      const raw = (result as { valueAsString?: string }).valueAsString ?? '';
+      if (raw.includes('opensafari_route:ok')) {
+        return {
+          requested: true,
+          kind: 'route',
+          verified: true,
+          route: routeName,
+          elapsedMs: Date.now() - start,
+          polls,
+        };
+      }
+      if (raw.includes('opensafari_route:error:')) {
+        lastError = raw.slice(raw.indexOf('opensafari_route:error:') + 'opensafari_route:error:'.length);
+      }
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(intervalMs, remaining)));
+  }
+  return {
+    requested: true,
+    kind: 'route',
+    verified: false,
+    route: routeName,
+    elapsedMs: Date.now() - start,
+    polls,
+    error: lastError,
+  };
+}
+
+async function verifyPostcondition(
+  deviceId: string,
+  spec: PostconditionSpec,
+): Promise<PostconditionVerdict> {
+  const budgetMs = spec.timeoutMs ?? DEFAULT_POSTCOND_TIMEOUT_MS;
+  const intervalMs = Math.max(50, Math.floor(spec.intervalMs ?? DEFAULT_POSTCOND_INTERVAL_MS));
+  // route postcondition (Flutter VM) wins when both supplied — it's the
+  // strongest signal for navigation success.
+  if (spec.route) {
+    return verifyRoutePostcondition(deviceId, spec.route, budgetMs, intervalMs);
+  }
+  return verifyAxPostcondition(deviceId, spec, budgetMs);
+}
+
 export function registerAppPopUntilTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_pop_until',
       description:
-        'Pop the Flutter Navigator until a target predicate is satisfied. Requires flutter_connect. ' +
-        'Predicates: { until: "first" } pops to root, { until: "route", name: "/x" } pops until that named route is current, { until: "count", count: N } pops up to N times.',
+        'Pop the Flutter Navigator until a target predicate is satisfied. ' +
+        'Predicates: { until: "first" } pops to root, { until: "route", name: "/x" } pops until that named route is current, { until: "count", count: N } pops up to N times. ' +
+        'Supply postcondition: { identifier|label|text|role|route, timeoutMs } to verify the resulting screen state. ' +
+        'Native fallback ladder ships in #801 PR2; this PR requires Flutter VM service (call flutter_connect first).',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -107,6 +319,28 @@ export function registerAppPopUntilTool(server: MCPServer): void {
           name: { type: 'string', description: 'Route name (only with until="route")' },
           count: { type: 'number', description: 'Pop count (only with until="count")' },
           device_id: { type: 'string', description: 'Simulator UDID' },
+          postcondition: {
+            type: 'object',
+            description:
+              'Optional verification. Provide one or more of identifier/label/text/role (AX query) or route (Flutter VM ModalRoute.name check). Defaults: timeoutMs=3000, intervalMs=250.',
+            properties: {
+              identifier: { type: 'string' },
+              label: { type: 'string' },
+              text: { type: 'string' },
+              role: { type: 'string' },
+              route: { type: 'string' },
+              timeoutMs: { type: 'number' },
+              intervalMs: { type: 'number' },
+            },
+          },
+          maxAttempts: {
+            type: 'number',
+            description: `Upper bound on attempt-history entries the fallback ladder may record. Defaults to count for until=count, otherwise ${DEFAULT_MAX_ATTEMPTS}. VM-only execution always emits exactly one attempt.`,
+          },
+          interAttemptDelayMs: {
+            type: 'number',
+            description: `Delay between successive fallback attempts. Default ${DEFAULT_INTER_ATTEMPT_DELAY_MS}.`,
+          },
         },
         required: ['until'],
       },
@@ -114,67 +348,141 @@ export function registerAppPopUntilTool(server: MCPServer): void {
     async (_sessionId: string, params: Record<string, unknown>) => {
       const until = params.until as 'first' | 'route' | 'count' | undefined;
       if (!until || !['first', 'route', 'count'].includes(until)) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'INVALID_UNTIL' }) }],
-          isError: true,
-        };
+        return respondWithStructuredError(
+          ErrorCode.INVALID_INPUT,
+          'until must be one of first, route, count',
+          { param: 'until' },
+        );
       }
       let target: PopUntil;
       if (until === 'route') {
         const name = params.name as string | undefined;
         if (!name) {
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'MISSING_NAME' }) }],
-            isError: true,
-          };
+          return respondWithStructuredError(
+            ErrorCode.MISSING_REQUIRED_PARAM,
+            'name is required when until="route"',
+            { param: 'name' },
+          );
         }
         target = { until, name };
       } else if (until === 'count') {
         const count = Number(params.count);
         if (!Number.isFinite(count) || count <= 0) {
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'INVALID_COUNT' }) }],
-            isError: true,
-          };
+          return respondWithStructuredError(
+            ErrorCode.INVALID_INPUT,
+            'count must be a positive number',
+            { param: 'count' },
+          );
         }
         target = { until, count: Math.floor(count) };
       } else {
         target = { until };
       }
 
-      const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId();
-      if (!deviceId) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'DEVICE_NOT_BOOTED' }) }],
-          isError: true,
-        };
-      }
-      const client = getFlutterVMClient(deviceId);
-      if (!client.isConnected()) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'NOT_CONNECTED', message: 'Call flutter_connect first.' }) }],
-          isError: true,
-        };
+      // Postcondition spec (optional in VM-path; required in native fallback — enforced in PR2).
+      let postSpec: PostconditionSpec | null = null;
+      try {
+        postSpec = parsePostcondition(params.postcondition);
+      } catch (err) {
+        return respondWithStructuredError(
+          ErrorCode.INVALID_INPUT,
+          err instanceof Error ? err.message : String(err),
+          { param: 'postcondition' },
+        );
       }
 
+      const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId();
+      if (!deviceId) {
+        return respondWithStructuredError(
+          ErrorCode.DEVICE_NOT_BOOTED,
+          'No booted simulator found and no device_id supplied',
+        );
+      }
+
+      const client = getFlutterVMClient(deviceId);
+      if (!client.isConnected()) {
+        return respondWithStructuredError(
+          ErrorCode.FLUTTER_VM_NOT_CONNECTED,
+          'Call flutter_connect first. Native fallback ladder ships in #801 PR2.',
+          { target, deviceId },
+        );
+      }
+
+      const attempts: AttemptRecord[] = [];
       const expr = buildExpression(target);
+      const popStart = Date.now();
+      let popOk = false;
+      let popDetail: string | undefined;
+      let popped: number | undefined;
       try {
         const result = await client.evaluate(expr);
         const raw = (result as { valueAsString?: string }).valueAsString ?? '';
         const parsed = parsePopResult(raw);
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ ...parsed, target }) }],
-          isError: !parsed.ok,
-        };
+        popOk = parsed.ok;
+        popped = parsed.popped;
+        popDetail = parsed.error ?? (parsed.ok ? undefined : parsed.status);
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'EVAL_FAILED', message }) }],
-          isError: true,
-        };
+        popDetail = err instanceof Error ? err.message : String(err);
       }
+      attempts.push({
+        n: 1,
+        action: 'flutter_vm.popUntil',
+        elapsedMs: Date.now() - popStart,
+        ok: popOk,
+        detail: popDetail,
+      });
+
+      if (!popOk) {
+        return respondWithStructuredError(
+          ErrorCode.FLUTTER_EVAL_FAILED,
+          popDetail ?? 'Flutter VM evaluate did not return opensafari_pop:ok',
+          {
+            target,
+            strategy: 'flutter_vm',
+            attempts,
+            postcondition: { requested: postSpec !== null },
+          },
+        );
+      }
+
+      // Optional postcondition verification.
+      let postcondition: PostconditionVerdict = { requested: postSpec !== null };
+      if (postSpec) {
+        try {
+          postcondition = await verifyPostcondition(deviceId, postSpec);
+        } catch (err) {
+          postcondition = {
+            requested: true,
+            kind: postSpec.route ? 'route' : 'ax_query',
+            verified: false,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+
+      const body = {
+        ok: postSpec ? postcondition.verified === true : true,
+        status: 'ok',
+        popped,
+        target,
+        strategy: 'flutter_vm',
+        attempts,
+        postcondition,
+      };
+
+      const isError = postSpec ? postcondition.verified !== true : false;
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(body) }],
+        ...(isError ? { isError: true as const } : {}),
+      };
     },
   );
 }
 
-export const __forTests = { buildExpression, parsePopResult };
+export const __forTests = {
+  buildExpression,
+  parsePopResult,
+  parsePostcondition,
+  verifyAxPostcondition,
+  verifyRoutePostcondition,
+};

--- a/tests/unit/app-pop-until-contract.test.ts
+++ b/tests/unit/app-pop-until-contract.test.ts
@@ -8,7 +8,7 @@
 
 import { __forTests } from '../../src/tools/app-pop-until';
 
-const { parsePostcondition } = __forTests;
+const { parsePostcondition, buildRoutePostconditionExpression } = __forTests;
 
 describe('app_pop_until parsePostcondition (#801 PR1)', () => {
   it('returns null when no postcondition is supplied', () => {
@@ -35,8 +35,6 @@ describe('app_pop_until parsePostcondition (#801 PR1)', () => {
 });
 
 describe('app_pop_until VM path verifyRoutePostcondition (#801 PR1)', () => {
-  const { verifyRoutePostcondition } = __forTests;
-
   it('returns verified=true when ModalRoute name matches', async () => {
     // We can exercise the VM helper directly with a stubbed flutter client.
     // The helper resolves the client via getFlutterVMClient, so we wire a
@@ -70,6 +68,14 @@ describe('app_pop_until VM path verifyRoutePostcondition (#801 PR1)', () => {
     jest.dontMock('../../src/flutter');
   });
 
+
+  it('uses the route tree-walk marker rather than ModalRoute.of(rootElement)', () => {
+    const expr = buildRoutePostconditionExpression('/home');
+    expect(expr).toContain('_ModalScopeStatus');
+    expect(expr).toContain('visit(root)');
+    expect(expr).not.toContain('ModalRoute.of(root)');
+  });
+
   it('surfaces VM evaluate errors in the last error field', async () => {
     jest.resetModules();
     jest.doMock('../../src/flutter', () => ({
@@ -88,8 +94,6 @@ describe('app_pop_until VM path verifyRoutePostcondition (#801 PR1)', () => {
 });
 
 describe('app_pop_until VM path verifyAxPostcondition (#801 PR1)', () => {
-  const { verifyAxPostcondition } = __forTests;
-
   it('reports verified=true on first non-empty AX match', async () => {
     jest.resetModules();
     jest.doMock('../../src/native', () => ({

--- a/tests/unit/app-pop-until-contract.test.ts
+++ b/tests/unit/app-pop-until-contract.test.ts
@@ -1,0 +1,130 @@
+/**
+ * #801 PR1 — app_pop_until contract extension tests.
+ *
+ * Pin the new helpers (parsePostcondition, verifyAxPostcondition,
+ * verifyRoutePostcondition) and the response-shape contract that
+ * downstream consumers will rely on.
+ */
+
+import { __forTests } from '../../src/tools/app-pop-until';
+
+const { parsePostcondition } = __forTests;
+
+describe('app_pop_until parsePostcondition (#801 PR1)', () => {
+  it('returns null when no postcondition is supplied', () => {
+    expect(parsePostcondition(undefined)).toBeNull();
+    expect(parsePostcondition(null)).toBeNull();
+  });
+
+  it('accepts a spec with at least one signal field', () => {
+    expect(parsePostcondition({ identifier: 'home_tab' })).toEqual({ identifier: 'home_tab' });
+    expect(parsePostcondition({ label: 'Home' })).toEqual({ label: 'Home' });
+    expect(parsePostcondition({ route: '/home' })).toEqual({ route: '/home' });
+    expect(parsePostcondition({ role: 'button' })).toEqual({ role: 'button' });
+  });
+
+  it('rejects a spec with no signal fields', () => {
+    expect(() => parsePostcondition({})).toThrow(/at least one/);
+    expect(() => parsePostcondition({ timeoutMs: 1000 })).toThrow(/at least one/);
+  });
+
+  it('rejects non-object specs', () => {
+    expect(() => parsePostcondition('home_tab')).toThrow(/object/);
+    expect(() => parsePostcondition(42)).toThrow(/object/);
+  });
+});
+
+describe('app_pop_until VM path verifyRoutePostcondition (#801 PR1)', () => {
+  const { verifyRoutePostcondition } = __forTests;
+
+  it('returns verified=true when ModalRoute name matches', async () => {
+    // We can exercise the VM helper directly with a stubbed flutter client.
+    // The helper resolves the client via getFlutterVMClient, so we wire a
+    // module-level stub for this test.
+    jest.resetModules();
+    jest.doMock('../../src/flutter', () => ({
+      getFlutterVMClient: () => ({
+        evaluate: async () => ({ valueAsString: 'opensafari_route:ok' }),
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyRoutePostcondition('DEV-1', '/home', 1000, 50);
+    expect(verdict.verified).toBe(true);
+    expect(verdict.route).toBe('/home');
+    expect(verdict.kind).toBe('route');
+    jest.dontMock('../../src/flutter');
+  });
+
+  it('returns verified=false with a finite poll count when the deadline expires', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/flutter', () => ({
+      getFlutterVMClient: () => ({
+        evaluate: async () => ({ valueAsString: 'opensafari_route:mismatch:/other' }),
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyRoutePostcondition('DEV-1', '/home', 200, 50);
+    expect(verdict.verified).toBe(false);
+    expect(verdict.kind).toBe('route');
+    expect((verdict.polls ?? 0)).toBeGreaterThanOrEqual(1);
+    jest.dontMock('../../src/flutter');
+  });
+
+  it('surfaces VM evaluate errors in the last error field', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/flutter', () => ({
+      getFlutterVMClient: () => ({
+        evaluate: async () => {
+          throw new Error('isolate paused');
+        },
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyRoutePostcondition('DEV-1', '/home', 100, 50);
+    expect(verdict.verified).toBe(false);
+    expect(verdict.error).toMatch(/isolate paused/);
+    jest.dontMock('../../src/flutter');
+  });
+});
+
+describe('app_pop_until VM path verifyAxPostcondition (#801 PR1)', () => {
+  const { verifyAxPostcondition } = __forTests;
+
+  it('reports verified=true on first non-empty AX match', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => ({
+        query: async () => ({ matches: [{ id: 'home_tab' }] }),
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyAxPostcondition(
+      'DEV-1',
+      { identifier: 'home_tab' },
+      1000,
+    );
+    expect(verdict.verified).toBe(true);
+    expect(verdict.kind).toBe('ax_query');
+    expect(verdict.finalMatchCount).toBe(1);
+    jest.dontMock('../../src/native');
+  });
+
+  it('returns verified=false with finalMatchCount=0 when AX never matches', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => ({
+        query: async () => ({ matches: [] }),
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyAxPostcondition(
+      'DEV-1',
+      { identifier: 'never_matches' },
+      150,
+    );
+    expect(verdict.verified).toBe(false);
+    expect(verdict.finalMatchCount).toBe(0);
+    expect((verdict.polls ?? 0)).toBeGreaterThanOrEqual(1);
+    jest.dontMock('../../src/native');
+  });
+});


### PR DESCRIPTION
Fixes part of #801. Depends on #805 (catalog expansion).

## Summary
Extend the \`app_pop_until\` contract before the native fallback ladder lands in PR2 so consumers can adopt the new shape immediately on top of the existing VM path.

- Optional \`postcondition\` input — verifies the resulting screen via AX query (\`identifier\` / \`label\` / \`text\` / \`role\`) or Flutter route name (\`route\`).
- Response shape gains \`strategy\`, \`attempts[]\`, \`postcondition\` (additive — pre-PR1 keys preserved). VM-only path always emits exactly one attempt.
- \`isError\` reflects \`postcondition.verified\` when one is requested.
- All failure responses migrated to the structured-error catalog from #805.
- New \`docs/app-pop-until.md\` covers inputs, response shape, error codes, and when to use vs \`app_tap_element\` / \`app_goto_screen\`.

## Test
- \`npx jest tests/unit/app-pop-until.test.ts tests/unit/app-pop-until-contract.test.ts --runInBand\` — 17 passing
- \`npx tsc --noEmit\` — clean

## Scope
- VM path preserved bit-for-bit. No fallback dispatch in this PR — that's #801 PR2.
- \`buildExpression\` / \`parsePopResult\` helpers untouched so PR15-era tests still pin them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)