### PR TITLE
feat(tools): app_pop_until native fallback ladder (#801 PR2)

### DIFF
--- a/docs/app-pop-until.md
+++ b/docs/app-pop-until.md
@@ -34,8 +34,9 @@ screen state before reporting success.
     timeoutMs?: number,    // default 3000
     intervalMs?: number,   // default 250
   },
-  maxAttempts?: number,            // bounds fallback ladder attempts (PR2)
-  interAttemptDelayMs?: number,    // default 250 (PR2)
+  maxAttempts?: number,            // bounds native fallback ladder attempts
+  interAttemptDelayMs?: number,    // default 250
+  forceFallback?: boolean,         // skip the VM path even when connected
 }
 ```
 
@@ -49,10 +50,10 @@ work in both VM and native contexts.
 ```ts
 {
   ok: boolean,                   // true iff postcondition verified (or no postcondition)
-  status: 'ok' | string,
-  popped?: number,               // only when until === 'count'
+  status: 'ok' | 'unverified' | string,
+  popped?: number,               // count of successful dispatches for until === 'count'
   target: PopUntil,              // echoed input
-  strategy: 'flutter_vm',        // PR2 adds: 'native_back' | 'edge_swipe' | ...
+  strategy: 'flutter_vm' | 'native_back' | 'edge_swipe' | 'escape_key',
   attempts: [{
     n: number,
     action: string,              // e.g. 'flutter_vm.popUntil'
@@ -85,10 +86,11 @@ recoverable failure.
 | `INVALID_INPUT` | `until` enum / `count` shape invalid, or `postcondition` has no signal field | Fix input and retry |
 | `MISSING_REQUIRED_PARAM` | `name` missing for `until: 'route'` | Supply `name` |
 | `DEVICE_NOT_BOOTED` | No booted simulator and no explicit `device_id` | Boot a device |
-| `FLUTTER_VM_NOT_CONNECTED` | VM Service unreachable (release build, etc.) | Call `flutter_connect`, or wait for #801 PR2 native fallback |
+| `FLUTTER_VM_NOT_CONNECTED` | VM Service unreachable (release build, etc.) | Native fallback runs automatically; emitted only when fallback also bails |
 | `FLUTTER_EVAL_FAILED` | VM evaluate threw or `opensafari_pop:no_root`/`no_navigator` | Inspect attempts[0].detail; re-run `app_context` to confirm UI is mounted |
-| `POP_UNTIL_EXHAUSTED` *(PR2)* | All fallback strategies tried without satisfying postcondition | Inspect attempts[], consider longer timeout |
-| `MISSING_POSTCONDITION` *(PR2)* | Native fallback ladder requires a postcondition | Supply one |
+| `POP_UNTIL_EXHAUSTED` | All native fallback strategies tried without satisfying postcondition | Inspect attempts[], consider a longer `timeoutMs` or a more specific postcondition |
+| `POP_UNTIL_NO_FALLBACK_AVAILABLE` | No native input backend selectable (e.g. SimulatorKit HID + PointerService both unavailable) | Connect Flutter VM or boot a different simulator |
+| `MISSING_POSTCONDITION` | Native fallback for `until: 'first' \| 'route'` requires a postcondition (route or AX query) | Supply one |
 
 ## Examples
 

--- a/docs/app-pop-until.md
+++ b/docs/app-pop-until.md
@@ -42,8 +42,9 @@ screen state before reporting success.
 
 At least one of `identifier`/`label`/`text`/`role`/`route` must be supplied
 inside `postcondition` when the field is present. `route` requires an
-active Flutter VM connection; the other four are AX-bridge queries that
-work in both VM and native contexts.
+active Flutter VM connection; in non-VM native fallback contexts provide
+`identifier`, `label`, `text`, or `role` so AX can verify the screen. The
+AX fields work in both VM and native contexts.
 
 ## Response shape
 

--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -1,41 +1,38 @@
 /**
  * `app_pop_until` — pop Navigator routes until a target predicate succeeds.
  *
- * Strategy (PR1 of #801 — contract extension):
+ * Strategy (#801):
  *   1. Prefer Flutter VM service when connected — evaluates a one-shot
  *      `Navigator.popUntil` expression that pops by route name, by
  *      ancestor count, or to first. This is the only reliable path for
  *      apps that use modal/bottom-sheet routes which have no AppBar back
  *      button to tap.
- *   2. A native-fallback ladder (system back / app-bar chevron / edge swipe /
- *      Escape) lands in #801 PR2. This PR adds the postcondition and
- *      attempt-history shape that the fallback ladder will produce.
+ *   2. Native fallback ladder (PR2) — when the VM is not connected, or
+ *      `forceFallback: true` is supplied, try these dispatches in order
+ *      per attempt and verify the caller-supplied postcondition after
+ *      each: AX-identified back button → edge swipe → Escape.
  *
  * Predicates (mutually exclusive):
  *   { until: 'first' }           — pop until isFirst === true
  *   { until: 'route', name: '/' }— pop until the matching named route is current
  *   { until: 'count', count: 3 } — pop exactly count times (best-effort)
  *
- * Optional postcondition (any combination — at least one of identifier /
- * label / text / role / route required when supplied):
- *   postcondition: {
- *     identifier?, label?, text?, role?,  // AX query
- *     route?,                              // Flutter route name (VM only)
- *     timeoutMs?,                          // default 3000
- *   }
+ * Postcondition (required in native fallback for first/route; optional
+ * elsewhere):
+ *   { identifier?, label?, text?, role?, route?, timeoutMs?, intervalMs? }
  *
  * Response shape (additive — pre-#801 fields preserved):
  *   { ok, status, popped?, target,
- *     strategy: 'flutter_vm' | ...future fallbacks,
+ *     strategy: 'flutter_vm' | 'native_back' | 'edge_swipe' | 'escape_key',
  *     attempts: [{ n, action, elapsedMs, ok, detail? }],
- *     postcondition: { requested, kind?, verified?, query?, route?,
- *                      elapsedMs?, polls?, finalMatchCount?, error? } }
+ *     postcondition: { requested, kind?, verified?, ... } }
  */
 
-import { MCPServer } from '../mcp-server';
+import { MCPServer, getWebKitClient } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
 import { getAccessibilityBridge } from '../native';
+import { getInputBackend } from './native-input-utils';
 import {
   ErrorCode,
   respondWithStructuredError,
@@ -80,6 +77,22 @@ const DEFAULT_POSTCOND_TIMEOUT_MS = 3000;
 const DEFAULT_POSTCOND_INTERVAL_MS = 250;
 const DEFAULT_INTER_ATTEMPT_DELAY_MS = 250;
 const DEFAULT_MAX_ATTEMPTS = 6;
+
+// Native fallback heuristics — picked to be safe across iPhone form
+// factors. The edge swipe trigger zone for the iOS interactive pop
+// gesture starts within ~20pt of the leading edge, so x=2 → x=220 reliably
+// triggers it without depending on per-device screen geometry.
+const EDGE_SWIPE_FROM_X = 2;
+const EDGE_SWIPE_TO_X = 220;
+const EDGE_SWIPE_Y = 420;
+const EDGE_SWIPE_DURATION = 0.18;
+
+// Labels / identifiers that commonly identify a back affordance. Lowercased
+// substring match. UIKit's default leading back item exposes an AXLabel
+// of "Back"; SwiftUI's NavigationLink back uses the localized "Back" too.
+// SF Symbol chevron.left names get echoed on custom buttons.
+const BACK_LABEL_HINTS = ['back', 'chevron.left', 'chevron-left', '<', '←'];
+const BACK_IDENTIFIER_HINTS = ['back', 'chevron.left', 'chevron-left', 'navigation-back'];
 
 function buildExpression(target: PopUntil): string {
   const predicate =
@@ -189,8 +202,6 @@ async function verifyAxPostcondition(
         };
       }
     } catch (err) {
-      // Best-effort — keep polling until deadline, but surface the last
-      // error if we never verify.
       const errMessage = err instanceof Error ? err.message : String(err);
       if (Date.now() > deadline) {
         return {
@@ -307,12 +318,220 @@ async function verifyPostcondition(
 ): Promise<PostconditionVerdict> {
   const budgetMs = spec.timeoutMs ?? DEFAULT_POSTCOND_TIMEOUT_MS;
   const intervalMs = Math.max(50, Math.floor(spec.intervalMs ?? DEFAULT_POSTCOND_INTERVAL_MS));
-  // route postcondition (Flutter VM) wins when both supplied — it's the
-  // strongest signal for navigation success.
   if (spec.route) {
     return verifyRoutePostcondition(deviceId, spec.route, budgetMs, intervalMs);
   }
   return verifyAxPostcondition(deviceId, spec, budgetMs);
+}
+
+/**
+ * Find a back affordance through the AX bridge. Returns the centre of
+ * the matching node's frame so the input backend can tap it. Tries
+ * identifier hints first (most stable), then label hints, then role=button
+ * + label hints.
+ */
+async function findBackAffordance(
+  deviceId: string,
+): Promise<{ x: number; y: number; via: string } | null> {
+  const bridge = getAccessibilityBridge();
+  // Identifier sweep — exact match per hint.
+  for (const hint of BACK_IDENTIFIER_HINTS) {
+    try {
+      const result = await bridge.query({ identifier: hint }, { deviceId });
+      const node = result.matches.find((n) => n.visible && n.enabled);
+      if (node) {
+        return {
+          x: node.frame.x + node.frame.width / 2,
+          y: node.frame.y + node.frame.height / 2,
+          via: `identifier=${hint}`,
+        };
+      }
+    } catch {
+      // continue probing
+    }
+  }
+  // Label sweep — case-insensitive substring via the bridge's label match.
+  for (const hint of BACK_LABEL_HINTS) {
+    try {
+      const result = await bridge.query({ label: hint }, { deviceId });
+      // Prefer button-role nodes when multiple match, and break ties by
+      // smaller-y so we don't accidentally tap a tab-bar item.
+      const candidates = result.matches.filter((n) => n.visible && n.enabled);
+      if (candidates.length === 0) continue;
+      candidates.sort((a, b) => {
+        const aButton = a.role.includes('Button') ? 0 : 1;
+        const bButton = b.role.includes('Button') ? 0 : 1;
+        if (aButton !== bButton) return aButton - bButton;
+        return a.frame.y - b.frame.y;
+      });
+      const node = candidates[0];
+      return {
+        x: node.frame.x + node.frame.width / 2,
+        y: node.frame.y + node.frame.height / 2,
+        via: `label=${hint}`,
+      };
+    } catch {
+      // continue probing
+    }
+  }
+  return null;
+}
+
+type NativeStrategy = 'native_back' | 'edge_swipe' | 'escape_key';
+
+/**
+ * Dispatch one native back step. Returns the strategy that succeeded
+ * (i.e. the dispatch didn't throw); postcondition verification happens
+ * separately in the calling loop.
+ */
+async function dispatchNativeBack(
+  deviceId: string,
+  backend: Awaited<ReturnType<typeof getInputBackend>>,
+): Promise<{ strategy: NativeStrategy; detail: string }> {
+  // 1. AX-identified back button.
+  const back = await findBackAffordance(deviceId);
+  if (back) {
+    await backend.tap(deviceId, back.x, back.y);
+    return {
+      strategy: 'native_back',
+      detail: `tap(${Math.round(back.x)},${Math.round(back.y)}) via ${back.via}`,
+    };
+  }
+  // 2. iOS interactive-pop edge swipe.
+  try {
+    await backend.swipe(
+      deviceId,
+      EDGE_SWIPE_FROM_X,
+      EDGE_SWIPE_Y,
+      EDGE_SWIPE_TO_X,
+      EDGE_SWIPE_Y,
+      EDGE_SWIPE_DURATION,
+    );
+    return {
+      strategy: 'edge_swipe',
+      detail: `swipe(${EDGE_SWIPE_FROM_X},${EDGE_SWIPE_Y})->(${EDGE_SWIPE_TO_X},${EDGE_SWIPE_Y})`,
+    };
+  } catch (err) {
+    // 3. Escape key — useful for modal sheets and some custom navigators.
+    try {
+      await backend.sendKey(deviceId, 'Escape');
+      return {
+        strategy: 'escape_key',
+        detail: `sendKey(Escape) after swipe failure: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    } catch (err2) {
+      throw new Error(
+        `all native strategies failed: swipe=${
+          err instanceof Error ? err.message : String(err)
+        }; escape=${err2 instanceof Error ? err2.message : String(err2)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Native fallback ladder driver. Loops dispatch → postcondition until
+ * verified or maxAttempts is reached.
+ */
+async function runNativeFallback(args: {
+  deviceId: string;
+  target: PopUntil;
+  postSpec: PostconditionSpec;
+  maxAttempts: number;
+  interAttemptDelayMs: number;
+}): Promise<{
+  ok: boolean;
+  strategy: NativeStrategy;
+  attempts: AttemptRecord[];
+  postcondition: PostconditionVerdict;
+  exhausted: boolean;
+  noBackend?: string;
+}> {
+  const attempts: AttemptRecord[] = [];
+  let backend: Awaited<ReturnType<typeof getInputBackend>>;
+  try {
+    backend = await getInputBackend(args.deviceId, getWebKitClient(args.deviceId));
+  } catch (err) {
+    return {
+      ok: false,
+      strategy: 'native_back',
+      attempts: [],
+      postcondition: { requested: true },
+      exhausted: false,
+      noBackend: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  let lastStrategy: NativeStrategy = 'native_back';
+  let postcondition: PostconditionVerdict = {
+    requested: true,
+    kind: args.postSpec.route ? 'route' : 'ax_query',
+    verified: false,
+  };
+  // For until=count, succeed when we've performed `count` successful
+  // dispatches AND the postcondition (if any signal beyond route) verifies.
+  const countCap = args.target.until === 'count' ? args.target.count : args.maxAttempts;
+  const stepCap = Math.max(1, Math.min(args.maxAttempts, countCap));
+
+  for (let n = 1; n <= stepCap; n++) {
+    const dispatchStart = Date.now();
+    let dispatchOk = false;
+    let detail: string | undefined;
+    let strategy: NativeStrategy = 'native_back';
+    try {
+      const r = await dispatchNativeBack(args.deviceId, backend);
+      dispatchOk = true;
+      detail = r.detail;
+      strategy = r.strategy;
+      lastStrategy = strategy;
+    } catch (err) {
+      detail = err instanceof Error ? err.message : String(err);
+    }
+    attempts.push({
+      n,
+      action: dispatchOk ? `native.${strategy}` : 'native.dispatch_failed',
+      elapsedMs: Date.now() - dispatchStart,
+      ok: dispatchOk,
+      detail,
+    });
+
+    if (!dispatchOk) {
+      break; // ladder exhausted on dispatch side
+    }
+
+    // After each successful dispatch, verify the postcondition with a
+    // small budget so we can short-circuit when the back actually landed.
+    try {
+      postcondition = await verifyPostcondition(args.deviceId, args.postSpec);
+    } catch (err) {
+      postcondition = {
+        requested: true,
+        kind: args.postSpec.route ? 'route' : 'ax_query',
+        verified: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+    if (postcondition.verified === true) {
+      return {
+        ok: true,
+        strategy: lastStrategy,
+        attempts,
+        postcondition,
+        exhausted: false,
+      };
+    }
+    if (n < stepCap) {
+      await new Promise((r) => setTimeout(r, args.interAttemptDelayMs));
+    }
+  }
+
+  return {
+    ok: false,
+    strategy: lastStrategy,
+    attempts,
+    postcondition,
+    exhausted: true,
+  };
 }
 
 export function registerAppPopUntilTool(server: MCPServer): void {
@@ -320,10 +539,10 @@ export function registerAppPopUntilTool(server: MCPServer): void {
     {
       name: 'app_pop_until',
       description:
-        'Pop the Flutter Navigator until a target predicate is satisfied. ' +
+        'Pop the Flutter Navigator (or, when VM is unavailable, dispatch native back gestures) until a target predicate is satisfied. ' +
         'Predicates: { until: "first" } pops to root, { until: "route", name: "/x" } pops until that named route is current, { until: "count", count: N } pops up to N times. ' +
-        'Supply postcondition: { identifier|label|text|role|route, timeoutMs } to verify the resulting screen state. ' +
-        'Native fallback ladder ships in #801 PR2; this PR requires Flutter VM service (call flutter_connect first).',
+        'Supply postcondition: { identifier|label|text|role|route, timeoutMs } to verify the resulting screen state. Required when running native fallback for first/route. ' +
+        'Pass forceFallback: true to bypass the VM path even when it is connected.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -338,7 +557,7 @@ export function registerAppPopUntilTool(server: MCPServer): void {
           postcondition: {
             type: 'object',
             description:
-              'Optional verification. Provide one or more of identifier/label/text/role (AX query) or route (Flutter VM ModalRoute.name check). Defaults: timeoutMs=3000, intervalMs=250.',
+              'Optional verification (required in native fallback for first/route). Provide one or more of identifier/label/text/role (AX query) or route (Flutter VM ModalRoute.name check). Defaults: timeoutMs=3000, intervalMs=250.',
             properties: {
               identifier: { type: 'string' },
               label: { type: 'string' },
@@ -356,6 +575,10 @@ export function registerAppPopUntilTool(server: MCPServer): void {
           interAttemptDelayMs: {
             type: 'number',
             description: `Delay between successive fallback attempts. Default ${DEFAULT_INTER_ATTEMPT_DELAY_MS}.`,
+          },
+          forceFallback: {
+            type: 'boolean',
+            description: 'Skip the Flutter VM path even when it is connected. Useful for testing the native ladder in apps that also expose a VM.',
           },
         },
         required: ['until'],
@@ -395,7 +618,6 @@ export function registerAppPopUntilTool(server: MCPServer): void {
         target = { until };
       }
 
-      // Postcondition spec (optional in VM-path; required in native fallback — enforced in PR2).
       let postSpec: PostconditionSpec | null = null;
       try {
         postSpec = parsePostcondition(params.postcondition);
@@ -415,81 +637,157 @@ export function registerAppPopUntilTool(server: MCPServer): void {
         );
       }
 
-      const client = getFlutterVMClient(deviceId);
-      if (!client.isConnected()) {
-        return respondWithStructuredError(
-          ErrorCode.FLUTTER_VM_NOT_CONNECTED,
-          'Call flutter_connect first. Native fallback ladder ships in #801 PR2.',
-          { target, deviceId },
-        );
+      const maxAttempts = (() => {
+        const raw = Number(params.maxAttempts);
+        if (Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+        return target.until === 'count' ? target.count : DEFAULT_MAX_ATTEMPTS;
+      })();
+      const interAttemptDelayMs = (() => {
+        const raw = Number(params.interAttemptDelayMs);
+        if (Number.isFinite(raw) && raw >= 0) return Math.floor(raw);
+        return DEFAULT_INTER_ATTEMPT_DELAY_MS;
+      })();
+      const forceFallback = params.forceFallback === true;
+
+      // ── VM path ──────────────────────────────────────────────────────────
+      const vmClient = getFlutterVMClient(deviceId);
+      const vmConnected = vmClient.isConnected();
+      if (vmConnected && !forceFallback) {
+        const attempts: AttemptRecord[] = [];
+        const expr = buildExpression(target);
+        const popStart = Date.now();
+        let popOk = false;
+        let popDetail: string | undefined;
+        let popped: number | undefined;
+        try {
+          const result = await vmClient.evaluate(expr);
+          const raw = (result as { valueAsString?: string }).valueAsString ?? '';
+          const parsed = parsePopResult(raw);
+          popOk = parsed.ok;
+          popped = parsed.popped;
+          popDetail = parsed.error ?? (parsed.ok ? undefined : parsed.status);
+        } catch (err) {
+          popDetail = err instanceof Error ? err.message : String(err);
+        }
+        attempts.push({
+          n: 1,
+          action: 'flutter_vm.popUntil',
+          elapsedMs: Date.now() - popStart,
+          ok: popOk,
+          detail: popDetail,
+        });
+
+        if (!popOk) {
+          return respondWithStructuredError(
+            ErrorCode.FLUTTER_EVAL_FAILED,
+            popDetail ?? 'Flutter VM evaluate did not return opensafari_pop:ok',
+            {
+              target,
+              strategy: 'flutter_vm',
+              attempts,
+              postcondition: { requested: postSpec !== null },
+            },
+          );
+        }
+
+        let postcondition: PostconditionVerdict = { requested: postSpec !== null };
+        if (postSpec) {
+          try {
+            postcondition = await verifyPostcondition(deviceId, postSpec);
+          } catch (err) {
+            postcondition = {
+              requested: true,
+              kind: postSpec.route ? 'route' : 'ax_query',
+              verified: false,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }
+
+        const body = {
+          ok: postSpec ? postcondition.verified === true : true,
+          status: 'ok',
+          popped,
+          target,
+          strategy: 'flutter_vm',
+          attempts,
+          postcondition,
+        };
+        const isError = postSpec ? postcondition.verified !== true : false;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(body) }],
+          ...(isError ? { isError: true as const } : {}),
+        };
       }
 
-      const attempts: AttemptRecord[] = [];
-      const expr = buildExpression(target);
-      const popStart = Date.now();
-      let popOk = false;
-      let popDetail: string | undefined;
-      let popped: number | undefined;
-      try {
-        const result = await client.evaluate(expr);
-        const raw = (result as { valueAsString?: string }).valueAsString ?? '';
-        const parsed = parsePopResult(raw);
-        popOk = parsed.ok;
-        popped = parsed.popped;
-        popDetail = parsed.error ?? (parsed.ok ? undefined : parsed.status);
-      } catch (err) {
-        popDetail = err instanceof Error ? err.message : String(err);
-      }
-      attempts.push({
-        n: 1,
-        action: 'flutter_vm.popUntil',
-        elapsedMs: Date.now() - popStart,
-        ok: popOk,
-        detail: popDetail,
-      });
-
-      if (!popOk) {
+      // ── Native fallback path ────────────────────────────────────────────
+      // Native fallback for until=first/route REQUIRES a postcondition —
+      // without it we have no signal that "we landed on the right screen".
+      if (target.until !== 'count' && !postSpec) {
         return respondWithStructuredError(
-          ErrorCode.FLUTTER_EVAL_FAILED,
-          popDetail ?? 'Flutter VM evaluate did not return opensafari_pop:ok',
+          ErrorCode.MISSING_POSTCONDITION,
+          'Native fallback for until=first/route requires a postcondition (route or AX query).',
           {
             target,
-            strategy: 'flutter_vm',
-            attempts,
-            postcondition: { requested: postSpec !== null },
+            vmConnected,
+            hint: vmConnected
+              ? 'forceFallback was true; supply a postcondition or remove forceFallback.'
+              : 'Connect Flutter VM via flutter_connect, or supply a postcondition for AX verification.',
           },
         );
       }
 
-      // Optional postcondition verification.
-      let postcondition: PostconditionVerdict = { requested: postSpec !== null };
-      if (postSpec) {
-        try {
-          postcondition = await verifyPostcondition(deviceId, postSpec);
-        } catch (err) {
-          postcondition = {
-            requested: true,
-            kind: postSpec.route ? 'route' : 'ax_query',
-            verified: false,
-            error: err instanceof Error ? err.message : String(err),
-          };
-        }
+      // For until=count without postcondition, synthesise a "no-op verified"
+      // postcondition so the ladder driver short-circuits after `count`
+      // successful dispatches.
+      const effectivePost: PostconditionSpec =
+        postSpec ?? { identifier: '__opensafari_pop_until_count_synthetic__' };
+      const result = await runNativeFallback({
+        deviceId,
+        target,
+        postSpec: effectivePost,
+        maxAttempts,
+        interAttemptDelayMs,
+      });
+
+      if (result.noBackend) {
+        return respondWithStructuredError(
+          ErrorCode.POP_UNTIL_NO_FALLBACK_AVAILABLE,
+          `No native input backend available: ${result.noBackend}`,
+          { target, attempts: result.attempts, postcondition: { requested: true } },
+        );
+      }
+
+      const okFromDispatch =
+        target.until === 'count' && !postSpec && result.attempts.filter((a) => a.ok).length >= target.count;
+
+      const overallOk = okFromDispatch || result.ok;
+
+      if (!overallOk && result.exhausted) {
+        return respondWithStructuredError(
+          ErrorCode.POP_UNTIL_EXHAUSTED,
+          'Fallback ladder exhausted before postcondition verified',
+          {
+            target,
+            strategy: result.strategy,
+            attempts: result.attempts,
+            postcondition: result.postcondition,
+          },
+        );
       }
 
       const body = {
-        ok: postSpec ? postcondition.verified === true : true,
-        status: 'ok',
-        popped,
+        ok: overallOk,
+        status: overallOk ? 'ok' : 'unverified',
+        popped: target.until === 'count' ? result.attempts.filter((a) => a.ok).length : undefined,
         target,
-        strategy: 'flutter_vm',
-        attempts,
-        postcondition,
+        strategy: result.strategy,
+        attempts: result.attempts,
+        postcondition: postSpec ? result.postcondition : { requested: false },
       };
-
-      const isError = postSpec ? postcondition.verified !== true : false;
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(body) }],
-        ...(isError ? { isError: true as const } : {}),
+        ...(overallOk ? {} : { isError: true as const }),
       };
     },
   );
@@ -502,4 +800,7 @@ export const __forTests = {
   verifyAxPostcondition,
   verifyRoutePostcondition,
   buildRoutePostconditionExpression,
+  dispatchNativeBack,
+  findBackAffordance,
+  runNativeFallback,
 };

--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -168,6 +168,28 @@ function parsePostcondition(raw: unknown): PostconditionSpec | null {
   return spec;
 }
 
+function hasAxPostconditionSignal(spec: PostconditionSpec | null): spec is PostconditionSpec {
+  return !!(spec?.identifier || spec?.label || spec?.text || spec?.role);
+}
+
+function nativePostconditionForVmState(
+  spec: PostconditionSpec | null,
+  vmConnected: boolean,
+): { postSpec: PostconditionSpec | null; error?: string } {
+  if (!spec) return { postSpec: null };
+  if (vmConnected || !spec.route) return { postSpec: spec };
+  if (!hasAxPostconditionSignal(spec)) {
+    return {
+      postSpec: null,
+      error:
+        'Native fallback without Flutter VM cannot verify a route-only postcondition; provide identifier, label, text, or role.',
+    };
+  }
+  const axSpec = { ...spec };
+  delete axSpec.route;
+  return { postSpec: axSpec };
+}
+
 async function verifyAxPostcondition(
   deviceId: string,
   spec: PostconditionSpec,
@@ -721,18 +743,23 @@ export function registerAppPopUntilTool(server: MCPServer): void {
       }
 
       // ── Native fallback path ────────────────────────────────────────────
-      // Native fallback for until=first/route REQUIRES a postcondition —
-      // without it we have no signal that "we landed on the right screen".
-      if (target.until !== 'count' && !postSpec) {
+      const nativePost = nativePostconditionForVmState(postSpec, vmConnected);
+
+      // Native fallback for until=first/route REQUIRES a verifiable
+      // postcondition — without it we have no signal that "we landed on
+      // the right screen". Route-only verification still requires VM; in
+      // non-VM contexts callers must provide an AX signal.
+      if (target.until !== 'count' && (!nativePost.postSpec || nativePost.error)) {
         return respondWithStructuredError(
           ErrorCode.MISSING_POSTCONDITION,
-          'Native fallback for until=first/route requires a postcondition (route or AX query).',
+          nativePost.error
+            ?? 'Native fallback for until=first/route requires a postcondition (route or AX query).',
           {
             target,
             vmConnected,
             hint: vmConnected
               ? 'forceFallback was true; supply a postcondition or remove forceFallback.'
-              : 'Connect Flutter VM via flutter_connect, or supply a postcondition for AX verification.',
+              : 'Connect Flutter VM via flutter_connect, or supply identifier, label, text, or role for AX verification.',
           },
         );
       }
@@ -741,7 +768,7 @@ export function registerAppPopUntilTool(server: MCPServer): void {
       // postcondition so the ladder driver short-circuits after `count`
       // successful dispatches.
       const effectivePost: PostconditionSpec =
-        postSpec ?? { identifier: '__opensafari_pop_until_count_synthetic__' };
+        nativePost.postSpec ?? { identifier: '__opensafari_pop_until_count_synthetic__' };
       const result = await runNativeFallback({
         deviceId,
         target,
@@ -797,6 +824,8 @@ export const __forTests = {
   buildExpression,
   parsePopResult,
   parsePostcondition,
+  hasAxPostconditionSignal,
+  nativePostconditionForVmState,
   verifyAxPostcondition,
   verifyRoutePostcondition,
   buildRoutePostconditionExpression,

--- a/tests/unit/app-pop-until-native-fallback.test.ts
+++ b/tests/unit/app-pop-until-native-fallback.test.ts
@@ -1,0 +1,264 @@
+/**
+ * #801 PR2 — app_pop_until native fallback ladder tests.
+ *
+ * The ladder driver (`runNativeFallback`) and the per-step dispatcher
+ * (`dispatchNativeBack`) are exercised against in-memory stubs of the
+ * input backend and AX bridge so we can pin attempt-history shape,
+ * strategy selection, and postcondition short-circuiting without a
+ * real simulator.
+ */
+
+import { __forTests } from '../../src/tools/app-pop-until';
+
+const { findBackAffordance, dispatchNativeBack, runNativeFallback } = __forTests;
+
+function mockBridge(matchesByQuery: Array<{ q: Record<string, unknown>; matches: unknown[] }>) {
+  return {
+    query: jest.fn(async (q: Record<string, unknown>) => {
+      const entry = matchesByQuery.find((m) =>
+        Object.entries(m.q).every(([k, v]) => q[k] === v),
+      );
+      return { matches: entry ? entry.matches : [], total: entry?.matches.length ?? 0, query: q, ambiguous: false };
+    }),
+  };
+}
+
+function mockBackend(opts?: { failSwipe?: boolean; failKey?: boolean; tapImpl?: jest.Mock }) {
+  return {
+    tap: opts?.tapImpl ?? jest.fn(async () => undefined),
+    swipe: jest.fn(async () => {
+      if (opts?.failSwipe) throw new Error('swipe unavailable');
+    }),
+    sendKey: jest.fn(async () => {
+      if (opts?.failKey) throw new Error('key unavailable');
+    }),
+    typeText: jest.fn(async () => undefined),
+  };
+}
+
+describe('app_pop_until findBackAffordance (#801 PR2)', () => {
+  it('returns the centre of the first identifier-hint match', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () =>
+        mockBridge([
+          {
+            q: { identifier: 'back' },
+            matches: [
+              { role: 'AXButton', visible: true, enabled: true, frame: { x: 10, y: 50, width: 40, height: 40 } },
+            ],
+          },
+        ]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const target = await reimported.findBackAffordance('DEV-1');
+    expect(target).toEqual({ x: 30, y: 70, via: 'identifier=back' });
+    jest.dontMock('../../src/native');
+  });
+
+  it('falls through identifier hints to label hints when none match', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () =>
+        mockBridge([
+          {
+            q: { label: 'back' },
+            matches: [
+              { role: 'AXButton', visible: true, enabled: true, frame: { x: 0, y: 100, width: 60, height: 40 } },
+              { role: 'AXStaticText', visible: true, enabled: true, frame: { x: 0, y: 90, width: 60, height: 20 } },
+            ],
+          },
+        ]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const target = await reimported.findBackAffordance('DEV-1');
+    // Should pick the AXButton over the AXStaticText.
+    expect(target?.via).toBe('label=back');
+    expect(target?.x).toBe(30);
+    expect(target?.y).toBe(120);
+    jest.dontMock('../../src/native');
+  });
+
+  it('returns null when nothing matches', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const target = await reimported.findBackAffordance('DEV-1');
+    expect(target).toBeNull();
+    jest.dontMock('../../src/native');
+  });
+});
+
+describe('app_pop_until dispatchNativeBack (#801 PR2)', () => {
+  it('taps the back affordance when AX finds one', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () =>
+        mockBridge([
+          {
+            q: { identifier: 'back' },
+            matches: [{ role: 'AXButton', visible: true, enabled: true, frame: { x: 0, y: 0, width: 40, height: 40 } }],
+          },
+        ]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const backend = mockBackend();
+    const result = await reimported.dispatchNativeBack('DEV-1', backend as never);
+    expect(result.strategy).toBe('native_back');
+    expect(backend.tap).toHaveBeenCalledWith('DEV-1', 20, 20);
+    expect(backend.swipe).not.toHaveBeenCalled();
+    jest.dontMock('../../src/native');
+  });
+
+  it('falls through to edge_swipe when no back affordance is found', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const backend = mockBackend();
+    const result = await reimported.dispatchNativeBack('DEV-1', backend as never);
+    expect(result.strategy).toBe('edge_swipe');
+    expect(backend.swipe).toHaveBeenCalled();
+    expect(backend.tap).not.toHaveBeenCalled();
+    jest.dontMock('../../src/native');
+  });
+
+  it('falls through to escape_key when swipe throws', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const backend = mockBackend({ failSwipe: true });
+    const result = await reimported.dispatchNativeBack('DEV-1', backend as never);
+    expect(result.strategy).toBe('escape_key');
+    expect(backend.sendKey).toHaveBeenCalledWith('DEV-1', 'Escape');
+    jest.dontMock('../../src/native');
+  });
+
+  it('throws when every native strategy fails', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const backend = mockBackend({ failSwipe: true, failKey: true });
+    await expect(
+      reimported.dispatchNativeBack('DEV-1', backend as never),
+    ).rejects.toThrow(/all native strategies failed/);
+    jest.dontMock('../../src/native');
+  });
+});
+
+describe('app_pop_until runNativeFallback (#801 PR2)', () => {
+  it('short-circuits when postcondition verifies after the first dispatch', async () => {
+    jest.resetModules();
+    // Single mock so both findBackAffordance and the postcondition poll
+    // resolve through the same AX bridge.
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => ({
+        query: jest.fn(async (q: Record<string, unknown>) => {
+          if (q.identifier === 'back') {
+            return {
+              matches: [{ role: 'AXButton', visible: true, enabled: true, frame: { x: 0, y: 0, width: 40, height: 40 } }],
+              total: 1,
+              query: q,
+              ambiguous: false,
+            };
+          }
+          if (q.identifier === 'home_tab') {
+            return { matches: [{ id: 'home' }], total: 1, query: q, ambiguous: false };
+          }
+          return { matches: [], total: 0, query: q, ambiguous: false };
+        }),
+      }),
+    }));
+    jest.doMock('../../src/tools/native-input-utils', () => ({
+      getInputBackend: jest.fn(async () => mockBackend()),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const result = await reimported.runNativeFallback({
+      deviceId: 'DEV-1',
+      target: { until: 'first' },
+      postSpec: { identifier: 'home_tab', timeoutMs: 500 },
+      maxAttempts: 6,
+      interAttemptDelayMs: 10,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.attempts.length).toBe(1);
+    expect(result.attempts[0].ok).toBe(true);
+    expect(result.postcondition.verified).toBe(true);
+    jest.dontMock('../../src/native');
+    jest.dontMock('../../src/tools/native-input-utils');
+  });
+
+  it('exhausts attempts when postcondition never verifies', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    jest.doMock('../../src/tools/native-input-utils', () => ({
+      getInputBackend: jest.fn(async () => mockBackend()),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const result = await reimported.runNativeFallback({
+      deviceId: 'DEV-1',
+      target: { until: 'first' },
+      postSpec: { identifier: 'never', timeoutMs: 50 },
+      maxAttempts: 3,
+      interAttemptDelayMs: 5,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.exhausted).toBe(true);
+    expect(result.attempts.length).toBe(3);
+    jest.dontMock('../../src/native');
+    jest.dontMock('../../src/tools/native-input-utils');
+  });
+
+  it('reports noBackend when getInputBackend throws', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/tools/native-input-utils', () => ({
+      getInputBackend: jest.fn(async () => {
+        throw new Error('headless input unavailable');
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const result = await reimported.runNativeFallback({
+      deviceId: 'DEV-1',
+      target: { until: 'first' },
+      postSpec: { identifier: 'home', timeoutMs: 50 },
+      maxAttempts: 2,
+      interAttemptDelayMs: 5,
+    });
+    expect(result.noBackend).toMatch(/headless input unavailable/);
+    expect(result.attempts).toEqual([]);
+    jest.dontMock('../../src/tools/native-input-utils');
+  });
+
+  it('caps attempts by count when target.until === "count"', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    jest.doMock('../../src/tools/native-input-utils', () => ({
+      getInputBackend: jest.fn(async () => mockBackend()),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const result = await reimported.runNativeFallback({
+      deviceId: 'DEV-1',
+      target: { until: 'count', count: 2 },
+      // Synthetic postcondition (matches the public handler's behavior when
+      // no postcondition is supplied for until=count). It will never verify,
+      // but the cap kicks in at count=2 anyway.
+      postSpec: { identifier: '__opensafari_pop_until_count_synthetic__', timeoutMs: 30 },
+      maxAttempts: 10,
+      interAttemptDelayMs: 5,
+    });
+    expect(result.attempts.length).toBe(2);
+    jest.dontMock('../../src/native');
+    jest.dontMock('../../src/tools/native-input-utils');
+  });
+});

--- a/tests/unit/app-pop-until-native-fallback.test.ts
+++ b/tests/unit/app-pop-until-native-fallback.test.ts
@@ -10,7 +10,7 @@
 
 import { __forTests } from '../../src/tools/app-pop-until';
 
-const { findBackAffordance, dispatchNativeBack, runNativeFallback } = __forTests;
+const { nativePostconditionForVmState } = __forTests;
 
 function mockBridge(matchesByQuery: Array<{ q: Record<string, unknown>; matches: unknown[] }>) {
   return {
@@ -35,6 +35,27 @@ function mockBackend(opts?: { failSwipe?: boolean; failKey?: boolean; tapImpl?: 
     typeText: jest.fn(async () => undefined),
   };
 }
+
+
+describe('app_pop_until native postcondition normalization (#801 PR2)', () => {
+  it('rejects route-only postconditions when the Flutter VM is unavailable', () => {
+    const result = nativePostconditionForVmState({ route: '/home' }, false);
+    expect(result.postSpec).toBeNull();
+    expect(result.error).toMatch(/route-only/);
+  });
+
+  it('uses AX signals and drops route verification when VM is unavailable', () => {
+    const result = nativePostconditionForVmState({ route: '/home', identifier: 'home_tab' }, false);
+    expect(result.error).toBeUndefined();
+    expect(result.postSpec).toEqual({ identifier: 'home_tab' });
+  });
+
+  it('keeps route verification available when VM is connected during forceFallback', () => {
+    const result = nativePostconditionForVmState({ route: '/home' }, true);
+    expect(result.error).toBeUndefined();
+    expect(result.postSpec).toEqual({ route: '/home' });
+  });
+});
 
 describe('app_pop_until findBackAffordance (#801 PR2)', () => {
   it('returns the centre of the first identifier-hint match', async () => {


### PR DESCRIPTION
Closes #801 once merged. Depends on #806 (\`app_pop_until\` contract extension).

## Summary
When the Flutter VM service is not connected (release builds, UIKit / SwiftUI apps), \`app_pop_until\` now dispatches a native back step and verifies the caller-supplied postcondition before considering the attempt successful.

### Per-attempt ladder
1. **AX-identified back affordance** — identifier sweep (\`back\`, \`chevron.left\`, \`navigation-back\`), then label sweep (\`Back\` / \`chevron.left\` / \`<\` / \`←\`). Picks the AXButton-role match closest to the top.
2. **iOS interactive-pop edge swipe** — x=2 → x=220 at y=420.
3. **Escape key** — modal sheets / custom navigators.

The ladder short-circuits as soon as the postcondition verifies, and bails with \`POP_UNTIL_EXHAUSTED\` once \`maxAttempts\` is reached.

## Contract guards
- Native fallback for \`until: 'first' | 'route'\` **requires** a postcondition (route or AX query). Emits \`MISSING_POSTCONDITION\` otherwise.
- \`until: 'count'\` without postcondition synthesises a never-matching probe so the cap behaves like the VM path: stop after \`count\` successful dispatches.
- \`POP_UNTIL_NO_FALLBACK_AVAILABLE\` when \`getInputBackend\` throws.
- \`forceFallback: true\` bypasses the VM path for testing.

## Response shape
- \`strategy\` is now one of \`flutter_vm | native_back | edge_swipe | escape_key\`.
- \`isError\` is set when the postcondition is requested but does not verify, or when the ladder exhausts.

## Test
- \`npx jest tests/unit/app-pop-until.test.ts tests/unit/app-pop-until-contract.test.ts tests/unit/app-pop-until-native-fallback.test.ts --runInBand\` — 28 passing
- \`npx tsc --noEmit\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)