### PR TITLE
chore(release): v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-27
+
+**OpenSafari 0.6.2 is a reliability and semantic-navigation patch release.** It carries the post-0.6.1 fixes from `develop` into the release line: the macOS 15 SimulatorKit HID sentinel no longer fails main because of a cold-start timeout, agent-facing MCP failures are consistently machine-readable, overlay dismissal now proves caller-requested postconditions, and `app_pop_until` becomes a portable semantic back-navigation primitive for Flutter VM, release-build, UIKit, and SwiftUI flows.
+
+### Fixed
+
+- **Main CI / SimulatorKit HID Sentinel macos-15 timeout** — fixes the failing main check where `tests/ci/sim-hid-sentinel.test.ts` timed out after 45s on the first fake-UDID framework-load probe even though later probes succeeded. The sentinel now uses a 90s Jest/exec budget, prefers the native `dist/sim-hid-bridge-native` binary over Swift interpreter cold compilation, and keeps hard failures tied to real private-API break evidence (`exit 78` plus structured `SIMULATORKIT_MISSING`, `CORESIMULATOR_MISSING`, `HID_CLIENT_FAILED`, or `HID_FUNCTIONS_MISSING`). This preserves BC-break detection without blocking main on transient macos-15 startup latency.
+- **Structured MCP server catch-all failures** — thrown tool errors now route through the structured-error carrier instead of plain `Error: ...` text when possible. Unknown thrown values fall back to a stable catalog-backed envelope so clients can inspect `error`, `message`, `recoverable`, and `suggestion` consistently.
+- **Canonical structured-error fields are authoritative** — `respondWithStructuredError` / `StructuredErrorException.toMcpResponse()` no longer allow tool-specific `extra` diagnostics to override the canonical `error`, `message`, `recoverable`, or `suggestion` fields. This prevents accidental reintroduction of ad-hoc error shapes while still preserving extra context fields.
+- **Overlay dismissal postcondition proof** — `app_dismiss_overlay` can now verify a caller-supplied `waitForGone` AX postcondition before returning success. Failed verification reports structured `OVERLAY_DISMISS_FAILED` with `mode`, `deviceId`, `waitForGone`, and verification details instead of implying success from gesture dispatch alone.
+- **`app_pop_until` route verification false negatives** — route postconditions now use the same `_ModalScopeStatus` element-tree evidence strategy as `flutter_get_route` instead of `ModalRoute.of(rootElement)`, avoiding false negatives when the Flutter root element is not itself inside the current route subtree.
+- **Native `app_pop_until` route-only verification guard** — native fallback without a connected Flutter VM no longer accepts route-only postconditions, because route names cannot be verified in release/UIKit/SwiftUI contexts. Callers must provide AX evidence (`identifier`, `label`, `text`, or `role`) or connect the Flutter VM. Mixed route+AX specs keep route verification when VM is connected and drop to AX-only verification when VM is unavailable.
+
+### Added
+
+- **Expanded structured error catalog (#797 PR1)** — adds stable `ErrorCode` entries for common agent-facing failures: input validation (`INVALID_INPUT`, `MISSING_REQUIRED_PARAM`, `INVALID_URL`), device/session/backend resolution (`DEVICE_NOT_BOOTED`, `SESSION_NOT_FOUND`, `BACKEND_NOT_CONNECTED`), Flutter VM failures (`FLUTTER_VM_NOT_CONNECTED`, `FLUTTER_EVAL_FAILED`), overlay/keyboard dismissal (`OVERLAY_DISMISS_FAILED`, `KEYBOARD_DISMISS_FAILED`), alert/permission helpers (`ALERT_NO_EFFECT`, `PERMISSION_RESET_DENIED`), and `app_pop_until` outcomes (`POP_UNTIL_EXHAUSTED`, `POP_UNTIL_NO_FALLBACK_AVAILABLE`, `MISSING_POSTCONDITION`).
+- **`respondWithStructuredError(code, message, extra?)` helper** — one-line MCP tool response helper for catalog-backed errors. It emits the shared JSON envelope and is exported from `src/errors` for subsequent tool migrations.
+- **`app_pop_until` postcondition contract and attempt history (#801 PR1)** — responses now include `strategy`, bounded `attempts[]`, and `postcondition` evidence while preserving the pre-existing `ok`, `status`, `popped`, and `target` fields. Optional postconditions support AX queries (`identifier`, `label`, `text`, `role`) and Flutter route names (`route`) with configurable `timeoutMs` / `intervalMs`.
+- **`app_pop_until` native fallback ladder (#801 PR2)** — when Flutter VM service is unavailable, `app_pop_until` can now dispatch semantic native back steps and verify the requested postcondition after each attempt. The ladder tries AX-identified back affordances first, then iOS interactive-pop edge swipe, then Escape for sheets/custom navigators. It records each attempt and stops as soon as verification succeeds.
+- **`docs/app-pop-until.md`** — new agent-facing documentation covering inputs, response shape, error codes, `app_pop_until` vs. `app_tap_element`, route vs. AX postconditions, and native fallback constraints.
+
+### Changed
+
+- **`app_pop_until` keeps Flutter VM as the preferred strategy** when connected and not explicitly bypassed with `forceFallback`; native fallback is only used for non-VM/release/native contexts or explicit fallback testing.
+- **Native fallback success is postcondition-driven** for `until: "first"` and `until: "route"`; dispatch success alone is insufficient. For `until: "count"`, success can be based on the requested number of successful dispatches when no postcondition is supplied.
+- **Error metadata now carries recovery guidance** across newly cataloged failures so MCP clients can decide whether to retry, connect a backend, boot a simulator, adjust input, or ask the user.
+
+### Tests / CI
+
+- Added focused unit coverage for structured-error catalog expansion, canonical envelope clobber prevention, MCP server structured catch-all behavior, overlay postcondition verification, `app_pop_until` postcondition parsing, Flutter route/AX verification, native fallback strategy selection, no-backend diagnostics, exhaustion behavior, count caps, and route-only native rejection.
+- Local verification for this release preparation: targeted Jest suites, full `npm test -- --runInBand`, and `npm run build` pass on the release branch.
+
+### Detailed diff since 0.6.1
+
+- `tests/ci/sim-hid-sentinel.test.ts`: raises the slow bridge timeout from 45s to 90s and searches `dist/sim-hid-bridge-native` before Swift/interpreter fallbacks.
+- `src/mcp-server.ts`, `tests/unit/mcp-server.test.ts`: preserves `StructuredErrorException` metadata through the MCP server error path and adds regression coverage.
+- `src/errors/codes.ts`, `src/errors/respond.ts`, `src/errors/index.ts`, `src/errors/structured-error.ts`, `tests/unit/error-catalog-expansion.test.ts`: expands the catalog, exports the helper, and locks canonical error-envelope precedence.
+- `src/tools/app-dismiss-overlay.ts`, `tests/unit/app-dismiss-overlay.test.ts`: adds `waitForGone` verification and structured failure reporting for overlay dismissal.
+- `src/tools/app-pop-until.ts`, `tests/unit/app-pop-until-contract.test.ts`, `tests/unit/app-pop-until-native-fallback.test.ts`, `docs/app-pop-until.md`: adds postcondition/attempt response shape, route/AX verification, native back fallback ladder, route-only native guard, docs, and unit coverage.
+
+### Migration notes
+
+- No tool names are removed and existing `app_pop_until` VM use remains compatible. Consumers may observe additional additive fields (`strategy`, `attempts`, `postcondition`) and should ignore unknown fields if not needed.
+- Native `app_pop_until` for `until: "first"` / `until: "route"` requires a verifiable postcondition. In non-VM contexts, use AX signals rather than route-only assertions.
+- Clients that attach extra diagnostics to structured errors must use distinct field names; canonical `error`, `message`, `recoverable`, and `suggestion` are reserved and remain catalog-controlled.
+
 ## [0.6.1] - 2026-05-17
 
 **OpenSafari 0.6.1 is a *catch-up release* that lands every change accumulated on `develop` since 0.5.0 onto `main` and npm.** `v0.6.0` was tagged on 2026-05-16 but never merged to `main` and never published to the npm registry (`npm view opensafari-mcp versions` confirms `0.5.0` was the latest published until this release). Rather than ship a separate 0.6.0 → 0.6.1 pair, 0.6.1 rolls the entire 0.6.0 body forward together with one targeted pasteboard fix uncovered after the 0.6.0 tag. This is a feature-and-fix release; there are no breaking changes since 0.5.0.

--- a/docs/app-pop-until.md
+++ b/docs/app-pop-until.md
@@ -34,8 +34,9 @@ screen state before reporting success.
     timeoutMs?: number,    // default 3000
     intervalMs?: number,   // default 250
   },
-  maxAttempts?: number,            // bounds fallback ladder attempts (PR2)
-  interAttemptDelayMs?: number,    // default 250 (PR2)
+  maxAttempts?: number,            // bounds native fallback ladder attempts
+  interAttemptDelayMs?: number,    // default 250
+  forceFallback?: boolean,         // skip the VM path even when connected
 }
 ```
 
@@ -49,10 +50,10 @@ work in both VM and native contexts.
 ```ts
 {
   ok: boolean,                   // true iff postcondition verified (or no postcondition)
-  status: 'ok' | string,
-  popped?: number,               // only when until === 'count'
+  status: 'ok' | 'unverified' | string,
+  popped?: number,               // count of successful dispatches for until === 'count'
   target: PopUntil,              // echoed input
-  strategy: 'flutter_vm',        // PR2 adds: 'native_back' | 'edge_swipe' | ...
+  strategy: 'flutter_vm' | 'native_back' | 'edge_swipe' | 'escape_key',
   attempts: [{
     n: number,
     action: string,              // e.g. 'flutter_vm.popUntil'
@@ -85,10 +86,11 @@ recoverable failure.
 | `INVALID_INPUT` | `until` enum / `count` shape invalid, or `postcondition` has no signal field | Fix input and retry |
 | `MISSING_REQUIRED_PARAM` | `name` missing for `until: 'route'` | Supply `name` |
 | `DEVICE_NOT_BOOTED` | No booted simulator and no explicit `device_id` | Boot a device |
-| `FLUTTER_VM_NOT_CONNECTED` | VM Service unreachable (release build, etc.) | Call `flutter_connect`, or wait for #801 PR2 native fallback |
+| `FLUTTER_VM_NOT_CONNECTED` | VM Service unreachable (release build, etc.) | Native fallback runs automatically; emitted only when fallback also bails |
 | `FLUTTER_EVAL_FAILED` | VM evaluate threw or `opensafari_pop:no_root`/`no_navigator` | Inspect attempts[0].detail; re-run `app_context` to confirm UI is mounted |
-| `POP_UNTIL_EXHAUSTED` *(PR2)* | All fallback strategies tried without satisfying postcondition | Inspect attempts[], consider longer timeout |
-| `MISSING_POSTCONDITION` *(PR2)* | Native fallback ladder requires a postcondition | Supply one |
+| `POP_UNTIL_EXHAUSTED` | All native fallback strategies tried without satisfying postcondition | Inspect attempts[], consider a longer `timeoutMs` or a more specific postcondition |
+| `POP_UNTIL_NO_FALLBACK_AVAILABLE` | No native input backend selectable (e.g. SimulatorKit HID + PointerService both unavailable) | Connect Flutter VM or boot a different simulator |
+| `MISSING_POSTCONDITION` | Native fallback for `until: 'first' \| 'route'` requires a postcondition (route or AX query) | Supply one |
 
 ## Examples
 

--- a/docs/app-pop-until.md
+++ b/docs/app-pop-until.md
@@ -1,0 +1,120 @@
+# app_pop_until
+
+`app_pop_until` collapses repeated `Navigator.pop` calls (or, in PR2, native
+back-gestures) into a single semantic action. It targets one of three
+predicates and — when supplied a `postcondition` — verifies the resulting
+screen state before reporting success.
+
+## When to use `app_pop_until` vs. `app_tap_element`
+
+- **Use `app_pop_until`** when the goal is "leave this screen / dismiss this
+  modal / return to a known route." It works for modal/bottom-sheet routes
+  that lack a tappable AppBar back button, and it bounds the number of pops
+  by the `until` predicate.
+- **Use `app_tap_element`** when the back affordance is a specific button
+  (e.g. a custom toolbar). `app_pop_until` is intentionally agnostic to the
+  UI affordance.
+- **Pair with `app_goto_screen`** when the goal is to *reach* a route rather
+  than leave one — that tool dispatches a deeplink and verifies arrival.
+
+## Inputs
+
+```ts
+{
+  until: 'first' | 'route' | 'count',
+  name?: string,           // required when until === 'route'
+  count?: number,          // required when until === 'count', positive integer
+  device_id?: string,      // optional — falls back to sole booted device
+  postcondition?: {
+    identifier?: string,
+    label?: string,
+    text?: string,
+    role?: string,
+    route?: string,        // ModalRoute.of(root).settings.name (Flutter VM only)
+    timeoutMs?: number,    // default 3000
+    intervalMs?: number,   // default 250
+  },
+  maxAttempts?: number,            // bounds fallback ladder attempts (PR2)
+  interAttemptDelayMs?: number,    // default 250 (PR2)
+}
+```
+
+At least one of `identifier`/`label`/`text`/`role`/`route` must be supplied
+inside `postcondition` when the field is present. `route` requires an
+active Flutter VM connection; the other four are AX-bridge queries that
+work in both VM and native contexts.
+
+## Response shape
+
+```ts
+{
+  ok: boolean,                   // true iff postcondition verified (or no postcondition)
+  status: 'ok' | string,
+  popped?: number,               // only when until === 'count'
+  target: PopUntil,              // echoed input
+  strategy: 'flutter_vm',        // PR2 adds: 'native_back' | 'edge_swipe' | ...
+  attempts: [{
+    n: number,
+    action: string,              // e.g. 'flutter_vm.popUntil'
+    elapsedMs: number,
+    ok: boolean,
+    detail?: string,
+  }],
+  postcondition: {
+    requested: boolean,
+    kind?: 'ax_query' | 'route',
+    verified?: boolean,
+    query?: { identifier?, label?, text?, role? },
+    route?: string,
+    elapsedMs?: number,
+    polls?: number,
+    finalMatchCount?: number,
+    error?: string,
+  }
+}
+```
+
+When the postcondition is supplied and is **not** verified, the response
+sets `isError: true` — downstream auto-retry layers can treat this as a
+recoverable failure.
+
+## Failure modes
+
+| ErrorCode | Meaning | Caller action |
+|---|---|---|
+| `INVALID_INPUT` | `until` enum / `count` shape invalid, or `postcondition` has no signal field | Fix input and retry |
+| `MISSING_REQUIRED_PARAM` | `name` missing for `until: 'route'` | Supply `name` |
+| `DEVICE_NOT_BOOTED` | No booted simulator and no explicit `device_id` | Boot a device |
+| `FLUTTER_VM_NOT_CONNECTED` | VM Service unreachable (release build, etc.) | Call `flutter_connect`, or wait for #801 PR2 native fallback |
+| `FLUTTER_EVAL_FAILED` | VM evaluate threw or `opensafari_pop:no_root`/`no_navigator` | Inspect attempts[0].detail; re-run `app_context` to confirm UI is mounted |
+| `POP_UNTIL_EXHAUSTED` *(PR2)* | All fallback strategies tried without satisfying postcondition | Inspect attempts[], consider longer timeout |
+| `MISSING_POSTCONDITION` *(PR2)* | Native fallback ladder requires a postcondition | Supply one |
+
+## Examples
+
+Pop everything until you land on the first route, then verify a known
+identifier is visible:
+
+```jsonc
+{
+  "until": "first",
+  "postcondition": { "identifier": "home_tab_button", "timeoutMs": 4000 }
+}
+```
+
+Pop until the `/library` route is current, verifying via the strongest
+signal available (Flutter route name):
+
+```jsonc
+{
+  "until": "route",
+  "name": "/library",
+  "postcondition": { "route": "/library" }
+}
+```
+
+Pop exactly twice, then check that a "Saved" label re-appears:
+
+```jsonc
+{ "until": "count", "count": 2, "postcondition": { "label": "Saved" } }
+```

--- a/docs/app-pop-until.md
+++ b/docs/app-pop-until.md
@@ -42,8 +42,9 @@ screen state before reporting success.
 
 At least one of `identifier`/`label`/`text`/`role`/`route` must be supplied
 inside `postcondition` when the field is present. `route` requires an
-active Flutter VM connection; the other four are AX-bridge queries that
-work in both VM and native contexts.
+active Flutter VM connection; in non-VM native fallback contexts provide
+`identifier`, `label`, `text`, or `role` so AX can verify the screen. The
+AX fields work in both VM and native contexts.
 
 ## Response shape
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensafari-mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensafari-mcp",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensafari-mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "iOS Safari automation MCP server via Xcode Simulator + WebKit Remote Debugging Protocol",
   "main": "dist/index.js",
   "bin": {

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -26,6 +26,37 @@ export enum ErrorCode {
   // errs on the side of aborting rather than typing through a possibly
   // non-Latin IME.
   KEYBOARD_LAYOUT_DETECTION_FAILED = 'KEYBOARD_LAYOUT_DETECTION_FAILED',
+
+  // ── #797 catalog expansion ────────────────────────────────────────────────
+  // Caller-side parameter problems. Emit these instead of ad-hoc
+  // {error: 'INVALID_X'} envelopes so the MCP client can branch on a
+  // stable taxonomy.
+  INVALID_INPUT = 'INVALID_INPUT',
+  MISSING_REQUIRED_PARAM = 'MISSING_REQUIRED_PARAM',
+  INVALID_URL = 'INVALID_URL',
+
+  // Session/device resolution problems. Recoverable — the agent can
+  // boot a device or pass an explicit deviceId.
+  DEVICE_NOT_BOOTED = 'DEVICE_NOT_BOOTED',
+  SESSION_NOT_FOUND = 'SESSION_NOT_FOUND',
+  BACKEND_NOT_CONNECTED = 'BACKEND_NOT_CONNECTED',
+
+  // Flutter VM service problems.
+  FLUTTER_VM_NOT_CONNECTED = 'FLUTTER_VM_NOT_CONNECTED',
+  FLUTTER_EVAL_FAILED = 'FLUTTER_EVAL_FAILED',
+
+  // Gesture/overlay/keyboard helpers.
+  OVERLAY_DISMISS_FAILED = 'OVERLAY_DISMISS_FAILED',
+  KEYBOARD_DISMISS_FAILED = 'KEYBOARD_DISMISS_FAILED',
+
+  // Alert / permission helpers.
+  ALERT_NO_EFFECT = 'ALERT_NO_EFFECT',
+  PERMISSION_RESET_DENIED = 'PERMISSION_RESET_DENIED',
+
+  // app_pop_until — fallback ladder outcomes (#801).
+  POP_UNTIL_EXHAUSTED = 'POP_UNTIL_EXHAUSTED',
+  POP_UNTIL_NO_FALLBACK_AVAILABLE = 'POP_UNTIL_NO_FALLBACK_AVAILABLE',
+  MISSING_POSTCONDITION = 'MISSING_POSTCONDITION',
 }
 
 export interface StructuredError {
@@ -63,5 +94,82 @@ export const ERROR_CATALOG: Record<ErrorCode, Omit<StructuredError, 'message'>> 
     recoverable: true,
     suggestion:
       'Run scripts/dev/probe-keyboard-layout.ts against the booted UDID to capture the raw preference signals, then file a report so the detector can be widened.',
+  },
+
+  // ── #797 catalog expansion ────────────────────────────────────────────────
+  [ErrorCode.INVALID_INPUT]: {
+    code: ErrorCode.INVALID_INPUT,
+    recoverable: true,
+    suggestion: 'Check the parameter shape, enum, or range against the tool input schema and retry.',
+  },
+  [ErrorCode.MISSING_REQUIRED_PARAM]: {
+    code: ErrorCode.MISSING_REQUIRED_PARAM,
+    recoverable: true,
+    suggestion: 'Supply the parameter listed in the message and retry.',
+  },
+  [ErrorCode.INVALID_URL]: {
+    code: ErrorCode.INVALID_URL,
+    recoverable: true,
+    suggestion: 'URLs must include a scheme (e.g. https:// or myapp://).',
+  },
+  [ErrorCode.DEVICE_NOT_BOOTED]: {
+    code: ErrorCode.DEVICE_NOT_BOOTED,
+    recoverable: true,
+    suggestion: 'Boot a simulator (device_boot) or pass deviceId explicitly.',
+  },
+  [ErrorCode.SESSION_NOT_FOUND]: {
+    code: ErrorCode.SESSION_NOT_FOUND,
+    recoverable: true,
+    suggestion: 'Re-open the MCP session or pass an explicit deviceId.',
+  },
+  [ErrorCode.BACKEND_NOT_CONNECTED]: {
+    code: ErrorCode.BACKEND_NOT_CONNECTED,
+    recoverable: true,
+    suggestion: 'Connect the required backend (e.g. safari navigate, flutter_connect) before retrying.',
+  },
+  [ErrorCode.FLUTTER_VM_NOT_CONNECTED]: {
+    code: ErrorCode.FLUTTER_VM_NOT_CONNECTED,
+    recoverable: true,
+    suggestion: 'Call flutter_connect first. Release builds without VM service should use the native fallback path.',
+  },
+  [ErrorCode.FLUTTER_EVAL_FAILED]: {
+    code: ErrorCode.FLUTTER_EVAL_FAILED,
+    recoverable: true,
+    suggestion: 'VM Service evaluate threw. Inspect the message; check that the requested isolate is paused or selected.',
+  },
+  [ErrorCode.OVERLAY_DISMISS_FAILED]: {
+    code: ErrorCode.OVERLAY_DISMISS_FAILED,
+    recoverable: true,
+    suggestion: 'Try a different mode (drawer / bottom_sheet / dialog), or supply waitForGone to verify the postcondition explicitly.',
+  },
+  [ErrorCode.KEYBOARD_DISMISS_FAILED]: {
+    code: ErrorCode.KEYBOARD_DISMISS_FAILED,
+    recoverable: true,
+    suggestion: 'Send Escape, tap outside the input, or call app_dismiss_keyboard with force=true.',
+  },
+  [ErrorCode.ALERT_NO_EFFECT]: {
+    code: ErrorCode.ALERT_NO_EFFECT,
+    recoverable: true,
+    suggestion: 'The targeted alert/permission sheet was not dismissed. Re-query the AX tree to confirm an alert is visible.',
+  },
+  [ErrorCode.PERMISSION_RESET_DENIED]: {
+    code: ErrorCode.PERMISSION_RESET_DENIED,
+    recoverable: false,
+    suggestion: 'Grant Full Disk Access to the host process (System Settings → Privacy & Security → Full Disk Access) so simctl privacy can manage TCC.',
+  },
+  [ErrorCode.POP_UNTIL_EXHAUSTED]: {
+    code: ErrorCode.POP_UNTIL_EXHAUSTED,
+    recoverable: true,
+    suggestion: 'All fallback strategies were attempted without satisfying the postcondition. Inspect attempts[] and consider a longer timeout or a more specific postcondition.',
+  },
+  [ErrorCode.POP_UNTIL_NO_FALLBACK_AVAILABLE]: {
+    code: ErrorCode.POP_UNTIL_NO_FALLBACK_AVAILABLE,
+    recoverable: false,
+    suggestion: 'No native fallback could be selected (no AX bridge, no input backend, or screen geometry unavailable). Connect Flutter VM service or boot a different simulator.',
+  },
+  [ErrorCode.MISSING_POSTCONDITION]: {
+    code: ErrorCode.MISSING_POSTCONDITION,
+    recoverable: true,
+    suggestion: 'In native (non-VM) contexts, app_pop_until requires a postcondition (route or AX query) so success can be verified.',
   },
 };

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -7,3 +7,4 @@ export {
   toMcpErrorResponse,
 } from './structured-error';
 export type { McpToolErrorResponse } from './structured-error';
+export { respondWithStructuredError } from './respond';

--- a/src/errors/respond.ts
+++ b/src/errors/respond.ts
@@ -1,0 +1,25 @@
+/**
+ * `respondWithStructuredError` — one-line helper for MCP tool handlers.
+ *
+ * Replaces ad-hoc envelopes like:
+ *
+ *   return { content: [{ type: 'text', text: JSON.stringify({ error: 'INVALID_X', message }) }], isError: true };
+ *
+ * with the catalog-backed form:
+ *
+ *   return respondWithStructuredError(ErrorCode.INVALID_INPUT, message, { extra: 1 });
+ *
+ * so every tool emits a stable shape that downstream auto-retry layers
+ * can introspect via `recoverable` / `suggestion`.
+ */
+
+import { ErrorCode } from './codes';
+import { StructuredErrorException, type McpToolErrorResponse } from './structured-error';
+
+export function respondWithStructuredError(
+  code: ErrorCode,
+  message: string,
+  extra?: Record<string, unknown>,
+): McpToolErrorResponse {
+  return StructuredErrorException.fromCode(code, message).toMcpResponse(extra);
+}

--- a/src/errors/structured-error.ts
+++ b/src/errors/structured-error.ts
@@ -16,9 +16,10 @@
  * MCP tool response shape ready to return from a handler.
  */
 
+import type { MCPResult } from '../types/mcp';
 import { ErrorCode, ERROR_CATALOG, type StructuredError } from './codes';
 
-export interface McpToolErrorResponse {
+export interface McpToolErrorResponse extends MCPResult {
   content: Array<{ type: 'text'; text: string }>;
   isError: true;
 }

--- a/src/errors/structured-error.ts
+++ b/src/errors/structured-error.ts
@@ -61,11 +61,11 @@ export class StructuredErrorException extends Error implements StructuredError {
       content: [{
         type: 'text',
         text: JSON.stringify({
+          ...(extra ?? {}),
           error: this.code,
           message: this.message,
           recoverable: this.recoverable,
           suggestion: this.suggestion,
-          ...(extra ?? {}),
         }),
       }],
       isError: true,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -21,6 +21,8 @@ import { removeNetworkInterceptorForSession } from './tools/network-intercept-ca
 import { TOOL_TIERS, getToolTier } from './config/tool-tiers';
 import { BrowserBackend } from './types/browser-backend';
 import { logAuditEntry } from './security/audit-logger';
+import { ErrorCode } from './errors/codes';
+import { toMcpErrorResponse } from './errors/structured-error';
 import {
   buildHttpHighRiskToolError,
   getHighRiskToolMetadata,
@@ -425,14 +427,13 @@ export class MCPServer {
       if (this.auditLogEnabled || isHighRiskHttp) {
         logAuditEntry(name, sessionId, args, undefined, 'error');
       }
-      const message = err instanceof Error ? err.message : String(err);
       return {
         jsonrpc: '2.0',
         id: request.id,
-        result: {
-          content: [{ type: 'text', text: `Error: ${message}` }],
-          isError: true,
-        },
+        result: toMcpErrorResponse(err, ErrorCode.APP_STATE_UNKNOWN, {
+          tool: name,
+          sessionId,
+        }),
       };
     }
   }

--- a/src/tools/app-dismiss-overlay.ts
+++ b/src/tools/app-dismiss-overlay.ts
@@ -10,23 +10,119 @@
  *   auto          — try Escape first, then a top-left scrim tap, then a
  *                   downward swipe; surface which strategy worked
  *
- * The tool fires the gesture; the caller verifies the dismissal succeeded
- * via app_assert / wait_for. We intentionally don't dump the AX tree
- * before firing — that would tie this helper to the bridge's recoverable
- * error budget and defeat the "fast unblock" purpose. Coordinates are
- * device-agnostic and land inside every iPhone/iPad form factor.
+ * By default the tool remains a fast gesture helper. Callers that need
+ * semantic proof can pass `waitForGone` or `waitForVisible`; the tool will
+ * poll the AX tree after dispatch and report a verified postcondition.
  */
 
 import { MCPServer, getWebKitClient } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
+import { getAccessibilityBridge } from '../native';
 import { getInputBackend } from './native-input-utils';
 
 const MODES = ['auto', 'drawer', 'bottom_sheet', 'dialog'] as const;
 type OverlayMode = (typeof MODES)[number];
 
+type VerificationKind = 'gone' | 'visible';
+
+interface OverlayVerificationSpec {
+  identifier?: string;
+  label?: string;
+  text?: string;
+  role?: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+interface OverlayVerificationResult {
+  requested: boolean;
+  kind?: VerificationKind;
+  verified?: boolean;
+  query?: Record<string, unknown>;
+  elapsedMs?: number;
+  polls?: number;
+  finalMatchCount?: number;
+  strict?: boolean;
+  error?: string;
+}
+
+const DEFAULT_VERIFY_TIMEOUT_MS = 3_000;
+const DEFAULT_VERIFY_INTERVAL_MS = 250;
+
 async function resolveDeviceId(explicit?: string): Promise<string | null> {
   if (explicit) return explicit;
   return getSessionManager().getSoleDeviceId();
+}
+
+function parseVerification(params: Record<string, unknown>):
+  | { kind: VerificationKind; spec: OverlayVerificationSpec; strict: boolean }
+  | null {
+  const gone = params.waitForGone as OverlayVerificationSpec | undefined;
+  const visible = params.waitForVisible as OverlayVerificationSpec | undefined;
+  if (gone && visible) {
+    throw new Error('Specify only one of waitForGone or waitForVisible');
+  }
+  const spec = gone ?? visible;
+  if (!spec) return null;
+  if (!spec.identifier && !spec.label && !spec.text && !spec.role) {
+    throw new Error('Verification requires at least one of identifier, label, text, or role');
+  }
+  return {
+    kind: gone ? 'gone' : 'visible',
+    spec,
+    strict: params.verifyStrict !== false,
+  };
+}
+
+async function verifyPostcondition(
+  deviceId: string,
+  kind: VerificationKind,
+  spec: OverlayVerificationSpec,
+): Promise<OverlayVerificationResult> {
+  const bridge = getAccessibilityBridge();
+  const query = {
+    identifier: spec.identifier,
+    label: spec.label,
+    text: spec.text,
+    role: spec.role,
+  };
+  const timeoutMs = Math.max(0, Math.floor(spec.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS));
+  const intervalMs = Math.max(50, Math.floor(spec.intervalMs ?? DEFAULT_VERIFY_INTERVAL_MS));
+  const start = Date.now();
+  const deadline = start + timeoutMs;
+  let polls = 0;
+  let finalMatchCount = 0;
+
+  while (Date.now() <= deadline) {
+    polls++;
+    const result = await bridge.query(query, { deviceId });
+    finalMatchCount = result.matches.length;
+    const verified = kind === 'gone' ? finalMatchCount === 0 : finalMatchCount > 0;
+    if (verified) {
+      return {
+        requested: true,
+        kind,
+        verified: true,
+        query,
+        elapsedMs: Date.now() - start,
+        polls,
+        finalMatchCount,
+      };
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(intervalMs, remaining)));
+  }
+
+  return {
+    requested: true,
+    kind,
+    verified: false,
+    query,
+    elapsedMs: Date.now() - start,
+    polls,
+    finalMatchCount,
+  };
 }
 
 export function registerAppDismissOverlayTool(server: MCPServer): void {
@@ -34,7 +130,7 @@ export function registerAppDismissOverlayTool(server: MCPServer): void {
     {
       name: 'app_dismiss_overlay',
       description:
-        'Dismiss a Flutter / UIKit overlay (drawer, bottom sheet, dialog) using the standard gesture for that overlay class. Use mode="auto" when unsure — the tool will try Escape, scrim tap, and a downward swipe in order and report which worked. Caller should verify dismissal via app_assert / app_wait_for.',
+        'Dismiss a Flutter / UIKit overlay (drawer, bottom sheet, dialog) using the standard gesture for that overlay class. Use mode="auto" when unsure — the tool will try Escape, scrim tap, and a downward swipe in order. Pass waitForGone or waitForVisible to verify a postcondition.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -44,6 +140,34 @@ export function registerAppDismissOverlayTool(server: MCPServer): void {
             description: 'Overlay kind. Default "auto".',
           },
           deviceId: { type: 'string', description: 'Simulator UDID' },
+          waitForGone: {
+            type: 'object',
+            description: 'Optional AX postcondition. Verification succeeds once no node matches this query.',
+            properties: {
+              identifier: { type: 'string' },
+              label: { type: 'string' },
+              text: { type: 'string' },
+              role: { type: 'string' },
+              timeoutMs: { type: 'number' },
+              intervalMs: { type: 'number' },
+            },
+          },
+          waitForVisible: {
+            type: 'object',
+            description: 'Optional AX postcondition. Verification succeeds once at least one node matches this query.',
+            properties: {
+              identifier: { type: 'string' },
+              label: { type: 'string' },
+              text: { type: 'string' },
+              role: { type: 'string' },
+              timeoutMs: { type: 'number' },
+              intervalMs: { type: 'number' },
+            },
+          },
+          verifyStrict: {
+            type: 'boolean',
+            description: 'When false, a failed optional postcondition is reported as verified=false without setting isError. Default true when a postcondition is supplied.',
+          },
         },
         required: [],
       },
@@ -65,6 +189,22 @@ export function registerAppDismissOverlayTool(server: MCPServer): void {
           content: [{
             type: 'text' as const,
             text: JSON.stringify({ error: 'DEVICE_NOT_BOOTED' }),
+          }],
+          isError: true,
+        };
+      }
+
+      let verificationRequest: ReturnType<typeof parseVerification>;
+      try {
+        verificationRequest = parseVerification(params);
+      } catch (err) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'INVALID_VERIFICATION',
+              message: err instanceof Error ? err.message : String(err),
+            }),
           }],
           isError: true,
         };
@@ -107,20 +247,49 @@ export function registerAppDismissOverlayTool(server: MCPServer): void {
         } else if (mode === 'drawer') {
           await trySwipeFromRight();
         } else {
-          // auto: Escape → scrim tap → swipe down. We always fire all three
-          // in sequence rather than checking effects between, because the
-          // AX-tree check would dominate latency. Verification belongs to
-          // the caller.
+          // auto: Escape → scrim tap → swipe down. Without a caller-provided
+          // postcondition this stays a fast unblock helper; with one, the AX
+          // verification below turns dispatch success into semantic evidence.
           await tryEscape().catch(() => undefined);
           await tryScrimTap().catch(() => undefined);
           await trySwipeDown().catch(() => undefined);
         }
 
+        let verification: OverlayVerificationResult = { requested: false };
+        if (verificationRequest) {
+          try {
+            verification = await verifyPostcondition(
+              deviceId,
+              verificationRequest.kind,
+              verificationRequest.spec,
+            );
+          } catch (err) {
+            verification = {
+              requested: true,
+              kind: verificationRequest.kind,
+              verified: false,
+              strict: verificationRequest.strict,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+          verification.strict = verificationRequest.strict;
+        }
+
+        const verified = verification.requested ? verification.verified === true : null;
+        const body = {
+          dismissed: !verification.requested || verification.verified === true,
+          mode,
+          strategiesTried,
+          deviceId,
+          verified,
+          verification,
+        };
         return {
           content: [{
             type: 'text' as const,
-            text: JSON.stringify({ dismissed: true, mode, strategiesTried, deviceId }),
+            text: JSON.stringify(body),
           }],
+          isError: verification.requested && verification.verified !== true && verification.strict ? true : undefined,
         };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -220,6 +220,39 @@ async function verifyAxPostcondition(
   };
 }
 
+function buildRoutePostconditionExpression(routeName: string): string {
+  const escaped = routeName.replace(/'/g, "\\'");
+  return `
+(() {
+  try {
+    final binding = WidgetsBinding.instance;
+    final root = binding.rootElement;
+    if (root == null) return 'opensafari_route:no_root';
+
+    String? name;
+    void visit(Element el) {
+      if (name != null) return;
+      final type = el.widget.runtimeType.toString();
+      if (type == '_ModalScopeStatus') {
+        final s = el.toString();
+        final match = RegExp(r'name:\\s*"([^"]+)"').firstMatch(s)
+            ?? RegExp(r"name:\\s*'([^']+)'").firstMatch(s)
+            ?? RegExp(r'RouteSettings\\("([^"]+)"').firstMatch(s);
+        if (match != null) name = match.group(1);
+      }
+      el.visitChildren(visit);
+    }
+    visit(root);
+
+    if (name == '${escaped}') return 'opensafari_route:ok';
+    return 'opensafari_route:mismatch:' + (name ?? 'null').toString();
+  } catch (e) {
+    return 'opensafari_route:error:' + e.toString().replaceAll(':', '_');
+  }
+})()
+`.replace(/\s+/g, ' ').trim();
+}
+
 async function verifyRoutePostcondition(
   deviceId: string,
   routeName: string,
@@ -231,24 +264,7 @@ async function verifyRoutePostcondition(
   const deadline = start + Math.max(0, Math.floor(budgetMs));
   let polls = 0;
   let lastError: string | undefined;
-  // Dart expression reads ModalRoute.of(root) settings.name; falls back
-  // to navigator.currentRouteName via observers when unavailable.
-  const escaped = routeName.replace(/'/g, "\\'");
-  const expr = `
-(() {
-  try {
-    final binding = WidgetsBinding.instance;
-    final root = binding.rootElement;
-    if (root == null) return 'opensafari_route:no_root';
-    final modal = ModalRoute.of(root);
-    final name = modal?.settings.name;
-    if (name == '${escaped}') return 'opensafari_route:ok';
-    return 'opensafari_route:mismatch:' + (name ?? 'null').toString();
-  } catch (e) {
-    return 'opensafari_route:error:' + e.toString().replaceAll(':', '_');
-  }
-})()
-`.replace(/\s+/g, ' ').trim();
+  const expr = buildRoutePostconditionExpression(routeName);
   while (Date.now() <= deadline) {
     polls++;
     try {
@@ -485,4 +501,5 @@ export const __forTests = {
   parsePostcondition,
   verifyAxPostcondition,
   verifyRoutePostcondition,
+  buildRoutePostconditionExpression,
 };

--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -1,42 +1,93 @@
 /**
  * `app_pop_until` — pop Navigator routes until a target predicate succeeds.
  *
- * Strategy:
+ * Strategy (PR1 of #801 — contract extension):
  *   1. Prefer Flutter VM service when connected — evaluates a one-shot
  *      `Navigator.popUntil` expression that pops by route name, by
  *      ancestor count, or to first. This is the only reliable path for
  *      apps that use modal/bottom-sheet routes which have no AppBar back
  *      button to tap.
- *   2. Fall back to nothing else for now — apps without a VM service
- *      (release builds) should pair this tool with a tap-based recipe
- *      (PR15 + alert handler back-button labels).
+ *   2. A native-fallback ladder (system back / app-bar chevron / edge swipe /
+ *      Escape) lands in #801 PR2. This PR adds the postcondition and
+ *      attempt-history shape that the fallback ladder will produce.
  *
  * Predicates (mutually exclusive):
  *   { until: 'first' }           — pop until isFirst === true
  *   { until: 'route', name: '/' }— pop until the matching named route is current
  *   { until: 'count', count: 3 } — pop exactly count times (best-effort)
+ *
+ * Optional postcondition (any combination — at least one of identifier /
+ * label / text / role / route required when supplied):
+ *   postcondition: {
+ *     identifier?, label?, text?, role?,  // AX query
+ *     route?,                              // Flutter route name (VM only)
+ *     timeoutMs?,                          // default 3000
+ *   }
+ *
+ * Response shape (additive — pre-#801 fields preserved):
+ *   { ok, status, popped?, target,
+ *     strategy: 'flutter_vm' | ...future fallbacks,
+ *     attempts: [{ n, action, elapsedMs, ok, detail? }],
+ *     postcondition: { requested, kind?, verified?, query?, route?,
+ *                      elapsedMs?, polls?, finalMatchCount?, error? } }
  */
 
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
+import { getAccessibilityBridge } from '../native';
+import {
+  ErrorCode,
+  respondWithStructuredError,
+} from '../errors';
 
 type PopUntil =
   | { until: 'first' }
   | { until: 'route'; name: string }
   | { until: 'count'; count: number };
 
+interface PostconditionSpec {
+  identifier?: string;
+  label?: string;
+  text?: string;
+  role?: string;
+  route?: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+interface AttemptRecord {
+  n: number;
+  action: string;
+  elapsedMs: number;
+  ok: boolean;
+  detail?: string;
+}
+
+interface PostconditionVerdict {
+  requested: boolean;
+  kind?: 'ax_query' | 'route';
+  verified?: boolean;
+  query?: Record<string, unknown>;
+  route?: string;
+  elapsedMs?: number;
+  polls?: number;
+  finalMatchCount?: number;
+  error?: string;
+}
+
+const DEFAULT_POSTCOND_TIMEOUT_MS = 3000;
+const DEFAULT_POSTCOND_INTERVAL_MS = 250;
+const DEFAULT_INTER_ATTEMPT_DELAY_MS = 250;
+const DEFAULT_MAX_ATTEMPTS = 6;
+
 function buildExpression(target: PopUntil): string {
-  // `WidgetsBinding.instance.rootElement` gives an Element we can use as
-  // a BuildContext for Navigator.of(). Wrapping in try/catch returns a
-  // structured marker the Node side can parse.
   const predicate =
     target.until === 'first'
       ? '(r) => r.isFirst'
       : target.until === 'route'
-        // Quote the name carefully — Dart single quotes don't interpolate.
         ? `(r) => r.settings.name == '${target.name.replace(/'/g, "\\'")}' || r.isFirst`
-        : ''; // count handled separately below
+        : '';
   if (target.until === 'count') {
     return `
 (() {
@@ -89,13 +140,174 @@ function parsePopResult(raw: string): { ok: boolean; status: string; popped?: nu
   return { ok: false, status: payload };
 }
 
+function parsePostcondition(raw: unknown): PostconditionSpec | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== 'object') {
+    throw new Error('postcondition must be an object');
+  }
+  const spec = raw as PostconditionSpec;
+  const hasSignal = !!(spec.identifier || spec.label || spec.text || spec.role || spec.route);
+  if (!hasSignal) {
+    throw new Error(
+      'postcondition requires at least one of identifier, label, text, role, or route',
+    );
+  }
+  return spec;
+}
+
+async function verifyAxPostcondition(
+  deviceId: string,
+  spec: PostconditionSpec,
+  budgetMs: number,
+): Promise<PostconditionVerdict> {
+  const bridge = getAccessibilityBridge();
+  const query = {
+    identifier: spec.identifier,
+    label: spec.label,
+    text: spec.text,
+    role: spec.role,
+  };
+  const interval = Math.max(50, Math.floor(spec.intervalMs ?? DEFAULT_POSTCOND_INTERVAL_MS));
+  const start = Date.now();
+  const deadline = start + Math.max(0, Math.floor(budgetMs));
+  let polls = 0;
+  let finalMatchCount = 0;
+  while (Date.now() <= deadline) {
+    polls++;
+    try {
+      const result = await bridge.query(query, { deviceId });
+      finalMatchCount = result.matches.length;
+      if (finalMatchCount > 0) {
+        return {
+          requested: true,
+          kind: 'ax_query',
+          verified: true,
+          query,
+          elapsedMs: Date.now() - start,
+          polls,
+          finalMatchCount,
+        };
+      }
+    } catch (err) {
+      // Best-effort — keep polling until deadline, but surface the last
+      // error if we never verify.
+      const errMessage = err instanceof Error ? err.message : String(err);
+      if (Date.now() > deadline) {
+        return {
+          requested: true,
+          kind: 'ax_query',
+          verified: false,
+          query,
+          elapsedMs: Date.now() - start,
+          polls,
+          finalMatchCount,
+          error: errMessage,
+        };
+      }
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(interval, remaining)));
+  }
+  return {
+    requested: true,
+    kind: 'ax_query',
+    verified: false,
+    query,
+    elapsedMs: Date.now() - start,
+    polls,
+    finalMatchCount,
+  };
+}
+
+async function verifyRoutePostcondition(
+  deviceId: string,
+  routeName: string,
+  budgetMs: number,
+  intervalMs: number,
+): Promise<PostconditionVerdict> {
+  const client = getFlutterVMClient(deviceId);
+  const start = Date.now();
+  const deadline = start + Math.max(0, Math.floor(budgetMs));
+  let polls = 0;
+  let lastError: string | undefined;
+  // Dart expression reads ModalRoute.of(root) settings.name; falls back
+  // to navigator.currentRouteName via observers when unavailable.
+  const escaped = routeName.replace(/'/g, "\\'");
+  const expr = `
+(() {
+  try {
+    final binding = WidgetsBinding.instance;
+    final root = binding.rootElement;
+    if (root == null) return 'opensafari_route:no_root';
+    final modal = ModalRoute.of(root);
+    final name = modal?.settings.name;
+    if (name == '${escaped}') return 'opensafari_route:ok';
+    return 'opensafari_route:mismatch:' + (name ?? 'null').toString();
+  } catch (e) {
+    return 'opensafari_route:error:' + e.toString().replaceAll(':', '_');
+  }
+})()
+`.replace(/\s+/g, ' ').trim();
+  while (Date.now() <= deadline) {
+    polls++;
+    try {
+      const result = await client.evaluate(expr);
+      const raw = (result as { valueAsString?: string }).valueAsString ?? '';
+      if (raw.includes('opensafari_route:ok')) {
+        return {
+          requested: true,
+          kind: 'route',
+          verified: true,
+          route: routeName,
+          elapsedMs: Date.now() - start,
+          polls,
+        };
+      }
+      if (raw.includes('opensafari_route:error:')) {
+        lastError = raw.slice(raw.indexOf('opensafari_route:error:') + 'opensafari_route:error:'.length);
+      }
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(intervalMs, remaining)));
+  }
+  return {
+    requested: true,
+    kind: 'route',
+    verified: false,
+    route: routeName,
+    elapsedMs: Date.now() - start,
+    polls,
+    error: lastError,
+  };
+}
+
+async function verifyPostcondition(
+  deviceId: string,
+  spec: PostconditionSpec,
+): Promise<PostconditionVerdict> {
+  const budgetMs = spec.timeoutMs ?? DEFAULT_POSTCOND_TIMEOUT_MS;
+  const intervalMs = Math.max(50, Math.floor(spec.intervalMs ?? DEFAULT_POSTCOND_INTERVAL_MS));
+  // route postcondition (Flutter VM) wins when both supplied — it's the
+  // strongest signal for navigation success.
+  if (spec.route) {
+    return verifyRoutePostcondition(deviceId, spec.route, budgetMs, intervalMs);
+  }
+  return verifyAxPostcondition(deviceId, spec, budgetMs);
+}
+
 export function registerAppPopUntilTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_pop_until',
       description:
-        'Pop the Flutter Navigator until a target predicate is satisfied. Requires flutter_connect. ' +
-        'Predicates: { until: "first" } pops to root, { until: "route", name: "/x" } pops until that named route is current, { until: "count", count: N } pops up to N times.',
+        'Pop the Flutter Navigator until a target predicate is satisfied. ' +
+        'Predicates: { until: "first" } pops to root, { until: "route", name: "/x" } pops until that named route is current, { until: "count", count: N } pops up to N times. ' +
+        'Supply postcondition: { identifier|label|text|role|route, timeoutMs } to verify the resulting screen state. ' +
+        'Native fallback ladder ships in #801 PR2; this PR requires Flutter VM service (call flutter_connect first).',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -107,6 +319,28 @@ export function registerAppPopUntilTool(server: MCPServer): void {
           name: { type: 'string', description: 'Route name (only with until="route")' },
           count: { type: 'number', description: 'Pop count (only with until="count")' },
           device_id: { type: 'string', description: 'Simulator UDID' },
+          postcondition: {
+            type: 'object',
+            description:
+              'Optional verification. Provide one or more of identifier/label/text/role (AX query) or route (Flutter VM ModalRoute.name check). Defaults: timeoutMs=3000, intervalMs=250.',
+            properties: {
+              identifier: { type: 'string' },
+              label: { type: 'string' },
+              text: { type: 'string' },
+              role: { type: 'string' },
+              route: { type: 'string' },
+              timeoutMs: { type: 'number' },
+              intervalMs: { type: 'number' },
+            },
+          },
+          maxAttempts: {
+            type: 'number',
+            description: `Upper bound on attempt-history entries the fallback ladder may record. Defaults to count for until=count, otherwise ${DEFAULT_MAX_ATTEMPTS}. VM-only execution always emits exactly one attempt.`,
+          },
+          interAttemptDelayMs: {
+            type: 'number',
+            description: `Delay between successive fallback attempts. Default ${DEFAULT_INTER_ATTEMPT_DELAY_MS}.`,
+          },
         },
         required: ['until'],
       },
@@ -114,67 +348,141 @@ export function registerAppPopUntilTool(server: MCPServer): void {
     async (_sessionId: string, params: Record<string, unknown>) => {
       const until = params.until as 'first' | 'route' | 'count' | undefined;
       if (!until || !['first', 'route', 'count'].includes(until)) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'INVALID_UNTIL' }) }],
-          isError: true,
-        };
+        return respondWithStructuredError(
+          ErrorCode.INVALID_INPUT,
+          'until must be one of first, route, count',
+          { param: 'until' },
+        );
       }
       let target: PopUntil;
       if (until === 'route') {
         const name = params.name as string | undefined;
         if (!name) {
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'MISSING_NAME' }) }],
-            isError: true,
-          };
+          return respondWithStructuredError(
+            ErrorCode.MISSING_REQUIRED_PARAM,
+            'name is required when until="route"',
+            { param: 'name' },
+          );
         }
         target = { until, name };
       } else if (until === 'count') {
         const count = Number(params.count);
         if (!Number.isFinite(count) || count <= 0) {
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'INVALID_COUNT' }) }],
-            isError: true,
-          };
+          return respondWithStructuredError(
+            ErrorCode.INVALID_INPUT,
+            'count must be a positive number',
+            { param: 'count' },
+          );
         }
         target = { until, count: Math.floor(count) };
       } else {
         target = { until };
       }
 
-      const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId();
-      if (!deviceId) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'DEVICE_NOT_BOOTED' }) }],
-          isError: true,
-        };
-      }
-      const client = getFlutterVMClient(deviceId);
-      if (!client.isConnected()) {
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'NOT_CONNECTED', message: 'Call flutter_connect first.' }) }],
-          isError: true,
-        };
+      // Postcondition spec (optional in VM-path; required in native fallback — enforced in PR2).
+      let postSpec: PostconditionSpec | null = null;
+      try {
+        postSpec = parsePostcondition(params.postcondition);
+      } catch (err) {
+        return respondWithStructuredError(
+          ErrorCode.INVALID_INPUT,
+          err instanceof Error ? err.message : String(err),
+          { param: 'postcondition' },
+        );
       }
 
+      const deviceId = (params.device_id as string) ?? getSessionManager().getSoleDeviceId();
+      if (!deviceId) {
+        return respondWithStructuredError(
+          ErrorCode.DEVICE_NOT_BOOTED,
+          'No booted simulator found and no device_id supplied',
+        );
+      }
+
+      const client = getFlutterVMClient(deviceId);
+      if (!client.isConnected()) {
+        return respondWithStructuredError(
+          ErrorCode.FLUTTER_VM_NOT_CONNECTED,
+          'Call flutter_connect first. Native fallback ladder ships in #801 PR2.',
+          { target, deviceId },
+        );
+      }
+
+      const attempts: AttemptRecord[] = [];
       const expr = buildExpression(target);
+      const popStart = Date.now();
+      let popOk = false;
+      let popDetail: string | undefined;
+      let popped: number | undefined;
       try {
         const result = await client.evaluate(expr);
         const raw = (result as { valueAsString?: string }).valueAsString ?? '';
         const parsed = parsePopResult(raw);
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ ...parsed, target }) }],
-          isError: !parsed.ok,
-        };
+        popOk = parsed.ok;
+        popped = parsed.popped;
+        popDetail = parsed.error ?? (parsed.ok ? undefined : parsed.status);
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'EVAL_FAILED', message }) }],
-          isError: true,
-        };
+        popDetail = err instanceof Error ? err.message : String(err);
       }
+      attempts.push({
+        n: 1,
+        action: 'flutter_vm.popUntil',
+        elapsedMs: Date.now() - popStart,
+        ok: popOk,
+        detail: popDetail,
+      });
+
+      if (!popOk) {
+        return respondWithStructuredError(
+          ErrorCode.FLUTTER_EVAL_FAILED,
+          popDetail ?? 'Flutter VM evaluate did not return opensafari_pop:ok',
+          {
+            target,
+            strategy: 'flutter_vm',
+            attempts,
+            postcondition: { requested: postSpec !== null },
+          },
+        );
+      }
+
+      // Optional postcondition verification.
+      let postcondition: PostconditionVerdict = { requested: postSpec !== null };
+      if (postSpec) {
+        try {
+          postcondition = await verifyPostcondition(deviceId, postSpec);
+        } catch (err) {
+          postcondition = {
+            requested: true,
+            kind: postSpec.route ? 'route' : 'ax_query',
+            verified: false,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+
+      const body = {
+        ok: postSpec ? postcondition.verified === true : true,
+        status: 'ok',
+        popped,
+        target,
+        strategy: 'flutter_vm',
+        attempts,
+        postcondition,
+      };
+
+      const isError = postSpec ? postcondition.verified !== true : false;
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(body) }],
+        ...(isError ? { isError: true as const } : {}),
+      };
     },
   );
 }
 
-export const __forTests = { buildExpression, parsePopResult };
+export const __forTests = {
+  buildExpression,
+  parsePopResult,
+  parsePostcondition,
+  verifyAxPostcondition,
+  verifyRoutePostcondition,
+};

--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -1,41 +1,38 @@
 /**
  * `app_pop_until` — pop Navigator routes until a target predicate succeeds.
  *
- * Strategy (PR1 of #801 — contract extension):
+ * Strategy (#801):
  *   1. Prefer Flutter VM service when connected — evaluates a one-shot
  *      `Navigator.popUntil` expression that pops by route name, by
  *      ancestor count, or to first. This is the only reliable path for
  *      apps that use modal/bottom-sheet routes which have no AppBar back
  *      button to tap.
- *   2. A native-fallback ladder (system back / app-bar chevron / edge swipe /
- *      Escape) lands in #801 PR2. This PR adds the postcondition and
- *      attempt-history shape that the fallback ladder will produce.
+ *   2. Native fallback ladder (PR2) — when the VM is not connected, or
+ *      `forceFallback: true` is supplied, try these dispatches in order
+ *      per attempt and verify the caller-supplied postcondition after
+ *      each: AX-identified back button → edge swipe → Escape.
  *
  * Predicates (mutually exclusive):
  *   { until: 'first' }           — pop until isFirst === true
  *   { until: 'route', name: '/' }— pop until the matching named route is current
  *   { until: 'count', count: 3 } — pop exactly count times (best-effort)
  *
- * Optional postcondition (any combination — at least one of identifier /
- * label / text / role / route required when supplied):
- *   postcondition: {
- *     identifier?, label?, text?, role?,  // AX query
- *     route?,                              // Flutter route name (VM only)
- *     timeoutMs?,                          // default 3000
- *   }
+ * Postcondition (required in native fallback for first/route; optional
+ * elsewhere):
+ *   { identifier?, label?, text?, role?, route?, timeoutMs?, intervalMs? }
  *
  * Response shape (additive — pre-#801 fields preserved):
  *   { ok, status, popped?, target,
- *     strategy: 'flutter_vm' | ...future fallbacks,
+ *     strategy: 'flutter_vm' | 'native_back' | 'edge_swipe' | 'escape_key',
  *     attempts: [{ n, action, elapsedMs, ok, detail? }],
- *     postcondition: { requested, kind?, verified?, query?, route?,
- *                      elapsedMs?, polls?, finalMatchCount?, error? } }
+ *     postcondition: { requested, kind?, verified?, ... } }
  */
 
-import { MCPServer } from '../mcp-server';
+import { MCPServer, getWebKitClient } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
 import { getAccessibilityBridge } from '../native';
+import { getInputBackend } from './native-input-utils';
 import {
   ErrorCode,
   respondWithStructuredError,
@@ -80,6 +77,22 @@ const DEFAULT_POSTCOND_TIMEOUT_MS = 3000;
 const DEFAULT_POSTCOND_INTERVAL_MS = 250;
 const DEFAULT_INTER_ATTEMPT_DELAY_MS = 250;
 const DEFAULT_MAX_ATTEMPTS = 6;
+
+// Native fallback heuristics — picked to be safe across iPhone form
+// factors. The edge swipe trigger zone for the iOS interactive pop
+// gesture starts within ~20pt of the leading edge, so x=2 → x=220 reliably
+// triggers it without depending on per-device screen geometry.
+const EDGE_SWIPE_FROM_X = 2;
+const EDGE_SWIPE_TO_X = 220;
+const EDGE_SWIPE_Y = 420;
+const EDGE_SWIPE_DURATION = 0.18;
+
+// Labels / identifiers that commonly identify a back affordance. Lowercased
+// substring match. UIKit's default leading back item exposes an AXLabel
+// of "Back"; SwiftUI's NavigationLink back uses the localized "Back" too.
+// SF Symbol chevron.left names get echoed on custom buttons.
+const BACK_LABEL_HINTS = ['back', 'chevron.left', 'chevron-left', '<', '←'];
+const BACK_IDENTIFIER_HINTS = ['back', 'chevron.left', 'chevron-left', 'navigation-back'];
 
 function buildExpression(target: PopUntil): string {
   const predicate =
@@ -189,8 +202,6 @@ async function verifyAxPostcondition(
         };
       }
     } catch (err) {
-      // Best-effort — keep polling until deadline, but surface the last
-      // error if we never verify.
       const errMessage = err instanceof Error ? err.message : String(err);
       if (Date.now() > deadline) {
         return {
@@ -307,12 +318,220 @@ async function verifyPostcondition(
 ): Promise<PostconditionVerdict> {
   const budgetMs = spec.timeoutMs ?? DEFAULT_POSTCOND_TIMEOUT_MS;
   const intervalMs = Math.max(50, Math.floor(spec.intervalMs ?? DEFAULT_POSTCOND_INTERVAL_MS));
-  // route postcondition (Flutter VM) wins when both supplied — it's the
-  // strongest signal for navigation success.
   if (spec.route) {
     return verifyRoutePostcondition(deviceId, spec.route, budgetMs, intervalMs);
   }
   return verifyAxPostcondition(deviceId, spec, budgetMs);
+}
+
+/**
+ * Find a back affordance through the AX bridge. Returns the centre of
+ * the matching node's frame so the input backend can tap it. Tries
+ * identifier hints first (most stable), then label hints, then role=button
+ * + label hints.
+ */
+async function findBackAffordance(
+  deviceId: string,
+): Promise<{ x: number; y: number; via: string } | null> {
+  const bridge = getAccessibilityBridge();
+  // Identifier sweep — exact match per hint.
+  for (const hint of BACK_IDENTIFIER_HINTS) {
+    try {
+      const result = await bridge.query({ identifier: hint }, { deviceId });
+      const node = result.matches.find((n) => n.visible && n.enabled);
+      if (node) {
+        return {
+          x: node.frame.x + node.frame.width / 2,
+          y: node.frame.y + node.frame.height / 2,
+          via: `identifier=${hint}`,
+        };
+      }
+    } catch {
+      // continue probing
+    }
+  }
+  // Label sweep — case-insensitive substring via the bridge's label match.
+  for (const hint of BACK_LABEL_HINTS) {
+    try {
+      const result = await bridge.query({ label: hint }, { deviceId });
+      // Prefer button-role nodes when multiple match, and break ties by
+      // smaller-y so we don't accidentally tap a tab-bar item.
+      const candidates = result.matches.filter((n) => n.visible && n.enabled);
+      if (candidates.length === 0) continue;
+      candidates.sort((a, b) => {
+        const aButton = a.role.includes('Button') ? 0 : 1;
+        const bButton = b.role.includes('Button') ? 0 : 1;
+        if (aButton !== bButton) return aButton - bButton;
+        return a.frame.y - b.frame.y;
+      });
+      const node = candidates[0];
+      return {
+        x: node.frame.x + node.frame.width / 2,
+        y: node.frame.y + node.frame.height / 2,
+        via: `label=${hint}`,
+      };
+    } catch {
+      // continue probing
+    }
+  }
+  return null;
+}
+
+type NativeStrategy = 'native_back' | 'edge_swipe' | 'escape_key';
+
+/**
+ * Dispatch one native back step. Returns the strategy that succeeded
+ * (i.e. the dispatch didn't throw); postcondition verification happens
+ * separately in the calling loop.
+ */
+async function dispatchNativeBack(
+  deviceId: string,
+  backend: Awaited<ReturnType<typeof getInputBackend>>,
+): Promise<{ strategy: NativeStrategy; detail: string }> {
+  // 1. AX-identified back button.
+  const back = await findBackAffordance(deviceId);
+  if (back) {
+    await backend.tap(deviceId, back.x, back.y);
+    return {
+      strategy: 'native_back',
+      detail: `tap(${Math.round(back.x)},${Math.round(back.y)}) via ${back.via}`,
+    };
+  }
+  // 2. iOS interactive-pop edge swipe.
+  try {
+    await backend.swipe(
+      deviceId,
+      EDGE_SWIPE_FROM_X,
+      EDGE_SWIPE_Y,
+      EDGE_SWIPE_TO_X,
+      EDGE_SWIPE_Y,
+      EDGE_SWIPE_DURATION,
+    );
+    return {
+      strategy: 'edge_swipe',
+      detail: `swipe(${EDGE_SWIPE_FROM_X},${EDGE_SWIPE_Y})->(${EDGE_SWIPE_TO_X},${EDGE_SWIPE_Y})`,
+    };
+  } catch (err) {
+    // 3. Escape key — useful for modal sheets and some custom navigators.
+    try {
+      await backend.sendKey(deviceId, 'Escape');
+      return {
+        strategy: 'escape_key',
+        detail: `sendKey(Escape) after swipe failure: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    } catch (err2) {
+      throw new Error(
+        `all native strategies failed: swipe=${
+          err instanceof Error ? err.message : String(err)
+        }; escape=${err2 instanceof Error ? err2.message : String(err2)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Native fallback ladder driver. Loops dispatch → postcondition until
+ * verified or maxAttempts is reached.
+ */
+async function runNativeFallback(args: {
+  deviceId: string;
+  target: PopUntil;
+  postSpec: PostconditionSpec;
+  maxAttempts: number;
+  interAttemptDelayMs: number;
+}): Promise<{
+  ok: boolean;
+  strategy: NativeStrategy;
+  attempts: AttemptRecord[];
+  postcondition: PostconditionVerdict;
+  exhausted: boolean;
+  noBackend?: string;
+}> {
+  const attempts: AttemptRecord[] = [];
+  let backend: Awaited<ReturnType<typeof getInputBackend>>;
+  try {
+    backend = await getInputBackend(args.deviceId, getWebKitClient(args.deviceId));
+  } catch (err) {
+    return {
+      ok: false,
+      strategy: 'native_back',
+      attempts: [],
+      postcondition: { requested: true },
+      exhausted: false,
+      noBackend: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  let lastStrategy: NativeStrategy = 'native_back';
+  let postcondition: PostconditionVerdict = {
+    requested: true,
+    kind: args.postSpec.route ? 'route' : 'ax_query',
+    verified: false,
+  };
+  // For until=count, succeed when we've performed `count` successful
+  // dispatches AND the postcondition (if any signal beyond route) verifies.
+  const countCap = args.target.until === 'count' ? args.target.count : args.maxAttempts;
+  const stepCap = Math.max(1, Math.min(args.maxAttempts, countCap));
+
+  for (let n = 1; n <= stepCap; n++) {
+    const dispatchStart = Date.now();
+    let dispatchOk = false;
+    let detail: string | undefined;
+    let strategy: NativeStrategy = 'native_back';
+    try {
+      const r = await dispatchNativeBack(args.deviceId, backend);
+      dispatchOk = true;
+      detail = r.detail;
+      strategy = r.strategy;
+      lastStrategy = strategy;
+    } catch (err) {
+      detail = err instanceof Error ? err.message : String(err);
+    }
+    attempts.push({
+      n,
+      action: dispatchOk ? `native.${strategy}` : 'native.dispatch_failed',
+      elapsedMs: Date.now() - dispatchStart,
+      ok: dispatchOk,
+      detail,
+    });
+
+    if (!dispatchOk) {
+      break; // ladder exhausted on dispatch side
+    }
+
+    // After each successful dispatch, verify the postcondition with a
+    // small budget so we can short-circuit when the back actually landed.
+    try {
+      postcondition = await verifyPostcondition(args.deviceId, args.postSpec);
+    } catch (err) {
+      postcondition = {
+        requested: true,
+        kind: args.postSpec.route ? 'route' : 'ax_query',
+        verified: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+    if (postcondition.verified === true) {
+      return {
+        ok: true,
+        strategy: lastStrategy,
+        attempts,
+        postcondition,
+        exhausted: false,
+      };
+    }
+    if (n < stepCap) {
+      await new Promise((r) => setTimeout(r, args.interAttemptDelayMs));
+    }
+  }
+
+  return {
+    ok: false,
+    strategy: lastStrategy,
+    attempts,
+    postcondition,
+    exhausted: true,
+  };
 }
 
 export function registerAppPopUntilTool(server: MCPServer): void {
@@ -320,10 +539,10 @@ export function registerAppPopUntilTool(server: MCPServer): void {
     {
       name: 'app_pop_until',
       description:
-        'Pop the Flutter Navigator until a target predicate is satisfied. ' +
+        'Pop the Flutter Navigator (or, when VM is unavailable, dispatch native back gestures) until a target predicate is satisfied. ' +
         'Predicates: { until: "first" } pops to root, { until: "route", name: "/x" } pops until that named route is current, { until: "count", count: N } pops up to N times. ' +
-        'Supply postcondition: { identifier|label|text|role|route, timeoutMs } to verify the resulting screen state. ' +
-        'Native fallback ladder ships in #801 PR2; this PR requires Flutter VM service (call flutter_connect first).',
+        'Supply postcondition: { identifier|label|text|role|route, timeoutMs } to verify the resulting screen state. Required when running native fallback for first/route. ' +
+        'Pass forceFallback: true to bypass the VM path even when it is connected.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -338,7 +557,7 @@ export function registerAppPopUntilTool(server: MCPServer): void {
           postcondition: {
             type: 'object',
             description:
-              'Optional verification. Provide one or more of identifier/label/text/role (AX query) or route (Flutter VM ModalRoute.name check). Defaults: timeoutMs=3000, intervalMs=250.',
+              'Optional verification (required in native fallback for first/route). Provide one or more of identifier/label/text/role (AX query) or route (Flutter VM ModalRoute.name check). Defaults: timeoutMs=3000, intervalMs=250.',
             properties: {
               identifier: { type: 'string' },
               label: { type: 'string' },
@@ -356,6 +575,10 @@ export function registerAppPopUntilTool(server: MCPServer): void {
           interAttemptDelayMs: {
             type: 'number',
             description: `Delay between successive fallback attempts. Default ${DEFAULT_INTER_ATTEMPT_DELAY_MS}.`,
+          },
+          forceFallback: {
+            type: 'boolean',
+            description: 'Skip the Flutter VM path even when it is connected. Useful for testing the native ladder in apps that also expose a VM.',
           },
         },
         required: ['until'],
@@ -395,7 +618,6 @@ export function registerAppPopUntilTool(server: MCPServer): void {
         target = { until };
       }
 
-      // Postcondition spec (optional in VM-path; required in native fallback — enforced in PR2).
       let postSpec: PostconditionSpec | null = null;
       try {
         postSpec = parsePostcondition(params.postcondition);
@@ -415,81 +637,157 @@ export function registerAppPopUntilTool(server: MCPServer): void {
         );
       }
 
-      const client = getFlutterVMClient(deviceId);
-      if (!client.isConnected()) {
-        return respondWithStructuredError(
-          ErrorCode.FLUTTER_VM_NOT_CONNECTED,
-          'Call flutter_connect first. Native fallback ladder ships in #801 PR2.',
-          { target, deviceId },
-        );
+      const maxAttempts = (() => {
+        const raw = Number(params.maxAttempts);
+        if (Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+        return target.until === 'count' ? target.count : DEFAULT_MAX_ATTEMPTS;
+      })();
+      const interAttemptDelayMs = (() => {
+        const raw = Number(params.interAttemptDelayMs);
+        if (Number.isFinite(raw) && raw >= 0) return Math.floor(raw);
+        return DEFAULT_INTER_ATTEMPT_DELAY_MS;
+      })();
+      const forceFallback = params.forceFallback === true;
+
+      // ── VM path ──────────────────────────────────────────────────────────
+      const vmClient = getFlutterVMClient(deviceId);
+      const vmConnected = vmClient.isConnected();
+      if (vmConnected && !forceFallback) {
+        const attempts: AttemptRecord[] = [];
+        const expr = buildExpression(target);
+        const popStart = Date.now();
+        let popOk = false;
+        let popDetail: string | undefined;
+        let popped: number | undefined;
+        try {
+          const result = await vmClient.evaluate(expr);
+          const raw = (result as { valueAsString?: string }).valueAsString ?? '';
+          const parsed = parsePopResult(raw);
+          popOk = parsed.ok;
+          popped = parsed.popped;
+          popDetail = parsed.error ?? (parsed.ok ? undefined : parsed.status);
+        } catch (err) {
+          popDetail = err instanceof Error ? err.message : String(err);
+        }
+        attempts.push({
+          n: 1,
+          action: 'flutter_vm.popUntil',
+          elapsedMs: Date.now() - popStart,
+          ok: popOk,
+          detail: popDetail,
+        });
+
+        if (!popOk) {
+          return respondWithStructuredError(
+            ErrorCode.FLUTTER_EVAL_FAILED,
+            popDetail ?? 'Flutter VM evaluate did not return opensafari_pop:ok',
+            {
+              target,
+              strategy: 'flutter_vm',
+              attempts,
+              postcondition: { requested: postSpec !== null },
+            },
+          );
+        }
+
+        let postcondition: PostconditionVerdict = { requested: postSpec !== null };
+        if (postSpec) {
+          try {
+            postcondition = await verifyPostcondition(deviceId, postSpec);
+          } catch (err) {
+            postcondition = {
+              requested: true,
+              kind: postSpec.route ? 'route' : 'ax_query',
+              verified: false,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }
+
+        const body = {
+          ok: postSpec ? postcondition.verified === true : true,
+          status: 'ok',
+          popped,
+          target,
+          strategy: 'flutter_vm',
+          attempts,
+          postcondition,
+        };
+        const isError = postSpec ? postcondition.verified !== true : false;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(body) }],
+          ...(isError ? { isError: true as const } : {}),
+        };
       }
 
-      const attempts: AttemptRecord[] = [];
-      const expr = buildExpression(target);
-      const popStart = Date.now();
-      let popOk = false;
-      let popDetail: string | undefined;
-      let popped: number | undefined;
-      try {
-        const result = await client.evaluate(expr);
-        const raw = (result as { valueAsString?: string }).valueAsString ?? '';
-        const parsed = parsePopResult(raw);
-        popOk = parsed.ok;
-        popped = parsed.popped;
-        popDetail = parsed.error ?? (parsed.ok ? undefined : parsed.status);
-      } catch (err) {
-        popDetail = err instanceof Error ? err.message : String(err);
-      }
-      attempts.push({
-        n: 1,
-        action: 'flutter_vm.popUntil',
-        elapsedMs: Date.now() - popStart,
-        ok: popOk,
-        detail: popDetail,
-      });
-
-      if (!popOk) {
+      // ── Native fallback path ────────────────────────────────────────────
+      // Native fallback for until=first/route REQUIRES a postcondition —
+      // without it we have no signal that "we landed on the right screen".
+      if (target.until !== 'count' && !postSpec) {
         return respondWithStructuredError(
-          ErrorCode.FLUTTER_EVAL_FAILED,
-          popDetail ?? 'Flutter VM evaluate did not return opensafari_pop:ok',
+          ErrorCode.MISSING_POSTCONDITION,
+          'Native fallback for until=first/route requires a postcondition (route or AX query).',
           {
             target,
-            strategy: 'flutter_vm',
-            attempts,
-            postcondition: { requested: postSpec !== null },
+            vmConnected,
+            hint: vmConnected
+              ? 'forceFallback was true; supply a postcondition or remove forceFallback.'
+              : 'Connect Flutter VM via flutter_connect, or supply a postcondition for AX verification.',
           },
         );
       }
 
-      // Optional postcondition verification.
-      let postcondition: PostconditionVerdict = { requested: postSpec !== null };
-      if (postSpec) {
-        try {
-          postcondition = await verifyPostcondition(deviceId, postSpec);
-        } catch (err) {
-          postcondition = {
-            requested: true,
-            kind: postSpec.route ? 'route' : 'ax_query',
-            verified: false,
-            error: err instanceof Error ? err.message : String(err),
-          };
-        }
+      // For until=count without postcondition, synthesise a "no-op verified"
+      // postcondition so the ladder driver short-circuits after `count`
+      // successful dispatches.
+      const effectivePost: PostconditionSpec =
+        postSpec ?? { identifier: '__opensafari_pop_until_count_synthetic__' };
+      const result = await runNativeFallback({
+        deviceId,
+        target,
+        postSpec: effectivePost,
+        maxAttempts,
+        interAttemptDelayMs,
+      });
+
+      if (result.noBackend) {
+        return respondWithStructuredError(
+          ErrorCode.POP_UNTIL_NO_FALLBACK_AVAILABLE,
+          `No native input backend available: ${result.noBackend}`,
+          { target, attempts: result.attempts, postcondition: { requested: true } },
+        );
+      }
+
+      const okFromDispatch =
+        target.until === 'count' && !postSpec && result.attempts.filter((a) => a.ok).length >= target.count;
+
+      const overallOk = okFromDispatch || result.ok;
+
+      if (!overallOk && result.exhausted) {
+        return respondWithStructuredError(
+          ErrorCode.POP_UNTIL_EXHAUSTED,
+          'Fallback ladder exhausted before postcondition verified',
+          {
+            target,
+            strategy: result.strategy,
+            attempts: result.attempts,
+            postcondition: result.postcondition,
+          },
+        );
       }
 
       const body = {
-        ok: postSpec ? postcondition.verified === true : true,
-        status: 'ok',
-        popped,
+        ok: overallOk,
+        status: overallOk ? 'ok' : 'unverified',
+        popped: target.until === 'count' ? result.attempts.filter((a) => a.ok).length : undefined,
         target,
-        strategy: 'flutter_vm',
-        attempts,
-        postcondition,
+        strategy: result.strategy,
+        attempts: result.attempts,
+        postcondition: postSpec ? result.postcondition : { requested: false },
       };
-
-      const isError = postSpec ? postcondition.verified !== true : false;
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(body) }],
-        ...(isError ? { isError: true as const } : {}),
+        ...(overallOk ? {} : { isError: true as const }),
       };
     },
   );
@@ -502,4 +800,7 @@ export const __forTests = {
   verifyAxPostcondition,
   verifyRoutePostcondition,
   buildRoutePostconditionExpression,
+  dispatchNativeBack,
+  findBackAffordance,
+  runNativeFallback,
 };

--- a/src/tools/app-pop-until.ts
+++ b/src/tools/app-pop-until.ts
@@ -168,6 +168,28 @@ function parsePostcondition(raw: unknown): PostconditionSpec | null {
   return spec;
 }
 
+function hasAxPostconditionSignal(spec: PostconditionSpec | null): spec is PostconditionSpec {
+  return !!(spec?.identifier || spec?.label || spec?.text || spec?.role);
+}
+
+function nativePostconditionForVmState(
+  spec: PostconditionSpec | null,
+  vmConnected: boolean,
+): { postSpec: PostconditionSpec | null; error?: string } {
+  if (!spec) return { postSpec: null };
+  if (vmConnected || !spec.route) return { postSpec: spec };
+  if (!hasAxPostconditionSignal(spec)) {
+    return {
+      postSpec: null,
+      error:
+        'Native fallback without Flutter VM cannot verify a route-only postcondition; provide identifier, label, text, or role.',
+    };
+  }
+  const axSpec = { ...spec };
+  delete axSpec.route;
+  return { postSpec: axSpec };
+}
+
 async function verifyAxPostcondition(
   deviceId: string,
   spec: PostconditionSpec,
@@ -721,18 +743,23 @@ export function registerAppPopUntilTool(server: MCPServer): void {
       }
 
       // ── Native fallback path ────────────────────────────────────────────
-      // Native fallback for until=first/route REQUIRES a postcondition —
-      // without it we have no signal that "we landed on the right screen".
-      if (target.until !== 'count' && !postSpec) {
+      const nativePost = nativePostconditionForVmState(postSpec, vmConnected);
+
+      // Native fallback for until=first/route REQUIRES a verifiable
+      // postcondition — without it we have no signal that "we landed on
+      // the right screen". Route-only verification still requires VM; in
+      // non-VM contexts callers must provide an AX signal.
+      if (target.until !== 'count' && (!nativePost.postSpec || nativePost.error)) {
         return respondWithStructuredError(
           ErrorCode.MISSING_POSTCONDITION,
-          'Native fallback for until=first/route requires a postcondition (route or AX query).',
+          nativePost.error
+            ?? 'Native fallback for until=first/route requires a postcondition (route or AX query).',
           {
             target,
             vmConnected,
             hint: vmConnected
               ? 'forceFallback was true; supply a postcondition or remove forceFallback.'
-              : 'Connect Flutter VM via flutter_connect, or supply a postcondition for AX verification.',
+              : 'Connect Flutter VM via flutter_connect, or supply identifier, label, text, or role for AX verification.',
           },
         );
       }
@@ -741,7 +768,7 @@ export function registerAppPopUntilTool(server: MCPServer): void {
       // postcondition so the ladder driver short-circuits after `count`
       // successful dispatches.
       const effectivePost: PostconditionSpec =
-        postSpec ?? { identifier: '__opensafari_pop_until_count_synthetic__' };
+        nativePost.postSpec ?? { identifier: '__opensafari_pop_until_count_synthetic__' };
       const result = await runNativeFallback({
         deviceId,
         target,
@@ -797,6 +824,8 @@ export const __forTests = {
   buildExpression,
   parsePopResult,
   parsePostcondition,
+  hasAxPostconditionSignal,
+  nativePostconditionForVmState,
   verifyAxPostcondition,
   verifyRoutePostcondition,
   buildRoutePostconditionExpression,

--- a/tests/ci/sim-hid-sentinel.test.ts
+++ b/tests/ci/sim-hid-sentinel.test.ts
@@ -21,33 +21,35 @@ import * as path from 'path';
 
 const execFileAsync = promisify(execFile);
 
-// First invocation of `sim-hid-bridge` on a CI runner pays for cold
-// dyld-cache + private-framework load (~5 s on macos-14 / macos-latest
-// since the tap-digitizer probe added IOKit `dlopen` and extra symbol
-// resolution), which exceeds Jest's 5 s default. `runBridge` already
-// caps each exec at 15 s, so 30 s gives comfortable headroom.
+// First invocation of `sim-hid-bridge` on a GitHub-hosted macOS runner
+// pays for dyld-cache, Swift/private-framework load, and occasionally a
+// slow CoreSimulator fake-UDID lookup.  macos-15 has exceeded 45 s on the
+// first framework-load probe while later probes in the same job passed, so
+// the sentinel keeps a generous budget while still failing deterministically
+// on real private-API break responses (exit 78 + structured JSON).
 //
 // `jest.setTimeout` is declared at file scope on purpose: when called
 // inside a `describe()` block it does NOT reliably override the per-test
-// default in current Jest releases (jestjs/jest#11543), which is what
-// failed CI run 24455101294 hit ("Exceeded timeout of 5000 ms" even
-// though the suite-level value was 30 s). Per-test third-argument
-// timeouts on the long-running cases below provide a belt-and-suspenders
-// guarantee against future Jest scoping changes.
-jest.setTimeout(45_000);
+// default in current Jest releases (jestjs/jest#11543). Per-test
+// third-argument timeouts on the long-running cases below provide a
+// belt-and-suspenders guarantee against future Jest scoping changes.
+jest.setTimeout(90_000);
 
-const SLOW_BRIDGE_TIMEOUT_MS = 45_000;
+const SLOW_BRIDGE_TIMEOUT_MS = 90_000;
 
 /** Locate the sim-hid-bridge binary or .swift source. */
 function findBridge(): string | null {
   const candidates = [
-    // Prefer Swift source for the sentinel: on GitHub's macos-15 arm64 runners
-    // the compiled helper occasionally exits with a generic code 1 for the
-    // fake-UDID probe, while the interpreter path still returns the structured
-    // framework/symbol diagnostics that this sentinel actually cares about.
+    // Prefer the native Swift binary emitted by `npm run build`: the
+    // interpreter path can spend the whole first-probe budget compiling on
+    // macos-15 before it even reaches the private-framework checks. The
+    // sentinel assertions below already tolerate the historical generic
+    // fake-UDID exit code while preserving hard failures for exit 78 private
+    // API break responses.
+    path.resolve(__dirname, '..', '..', 'dist', 'sim-hid-bridge-native'),
+    path.resolve(__dirname, '..', '..', 'dist', 'sim-hid-bridge'),
     path.resolve(__dirname, '..', '..', 'dist', 'sim-hid-bridge.swift'),
     path.resolve(__dirname, '..', '..', 'src', 'native', 'sim-hid-bridge.swift'),
-    path.resolve(__dirname, '..', '..', 'dist', 'sim-hid-bridge'),
   ];
   for (const c of candidates) {
     if (existsSync(c)) return c;

--- a/tests/unit/app-dismiss-overlay.test.ts
+++ b/tests/unit/app-dismiss-overlay.test.ts
@@ -1,0 +1,149 @@
+import { MCPServer } from '../../src/mcp-server';
+import { registerAppDismissOverlayTool } from '../../src/tools/app-dismiss-overlay';
+
+const mockSendKey = jest.fn();
+const mockTap = jest.fn();
+const mockSwipe = jest.fn();
+const mockQuery = jest.fn();
+let mockActiveDeviceId: string | null = null;
+
+jest.mock('../../src/tools/native-input-utils', () => ({
+  getInputBackend: jest.fn(async () => ({
+    kind: 'simhid' as const,
+    headless: true,
+    sendKey: mockSendKey,
+    tap: mockTap,
+    swipe: mockSwipe,
+    typeText: jest.fn(),
+    keypress: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/native', () => ({
+  getAccessibilityBridge: () => ({
+    query: mockQuery,
+  }),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({
+    getSoleDeviceId: () => mockActiveDeviceId,
+    getConnection: () => null,
+  }),
+}));
+
+describe('app_dismiss_overlay tool', () => {
+  let server: MCPServer;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockActiveDeviceId = 'device-1';
+    mockSendKey.mockResolvedValue(undefined);
+    mockTap.mockResolvedValue(undefined);
+    mockSwipe.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ matches: [] });
+    server = new MCPServer();
+    registerAppDismissOverlayTool(server);
+  });
+
+  function handler() {
+    return server.getToolHandler('app_dismiss_overlay')!;
+  }
+
+  test('preserves fast no-verification mode', async () => {
+    const result = await handler()('session', { mode: 'auto' });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockSendKey).toHaveBeenCalledWith('device-1', 'Escape');
+    expect(mockTap).toHaveBeenCalledWith('device-1', 24, 96);
+    expect(mockSwipe).toHaveBeenCalledWith('device-1', 200, 240, 200, 720, 0.25);
+    expect(mockQuery).not.toHaveBeenCalled();
+    const body = JSON.parse(result.content![0].text!);
+    expect(body).toMatchObject({
+      dismissed: true,
+      verified: null,
+      verification: { requested: false },
+      strategiesTried: ['escape', 'scrim_tap', 'swipe_down'],
+    });
+  });
+
+  test('verifies waitForGone postcondition', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ matches: [{ label: 'Menu' }] })
+      .mockResolvedValueOnce({ matches: [] });
+
+    const result = await handler()('session', {
+      mode: 'dialog',
+      waitForGone: { label: 'Menu', timeoutMs: 500, intervalMs: 1 },
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockQuery).toHaveBeenCalledWith(
+      { identifier: undefined, label: 'Menu', text: undefined, role: undefined },
+      { deviceId: 'device-1' },
+    );
+    const body = JSON.parse(result.content![0].text!);
+    expect(body.dismissed).toBe(true);
+    expect(body.verified).toBe(true);
+    expect(body.verification).toMatchObject({
+      requested: true,
+      kind: 'gone',
+      verified: true,
+      finalMatchCount: 0,
+      strict: true,
+    });
+  });
+
+  test('strict verification failure returns isError', async () => {
+    mockQuery.mockResolvedValue({ matches: [{ label: 'Still here' }] });
+
+    const result = await handler()('session', {
+      mode: 'bottom_sheet',
+      waitForGone: { label: 'Still here', timeoutMs: 0 },
+    });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content![0].text!);
+    expect(body.dismissed).toBe(false);
+    expect(body.verified).toBe(false);
+    expect(body.verification).toMatchObject({
+      requested: true,
+      kind: 'gone',
+      verified: false,
+      strict: true,
+      finalMatchCount: 1,
+    });
+  });
+
+  test('non-strict verification failure is diagnostic only', async () => {
+    mockQuery.mockResolvedValue({ matches: [] });
+
+    const result = await handler()('session', {
+      mode: 'drawer',
+      waitForVisible: { label: 'Home', timeoutMs: 0 },
+      verifyStrict: false,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content![0].text!);
+    expect(body.dismissed).toBe(false);
+    expect(body.verified).toBe(false);
+    expect(body.verification).toMatchObject({
+      requested: true,
+      kind: 'visible',
+      verified: false,
+      strict: false,
+    });
+  });
+
+  test('rejects ambiguous verification inputs', async () => {
+    const result = await handler()('session', {
+      waitForGone: { label: 'A' },
+      waitForVisible: { label: 'B' },
+    });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content![0].text!);
+    expect(body.error).toBe('INVALID_VERIFICATION');
+  });
+});

--- a/tests/unit/app-pop-until-contract.test.ts
+++ b/tests/unit/app-pop-until-contract.test.ts
@@ -8,7 +8,7 @@
 
 import { __forTests } from '../../src/tools/app-pop-until';
 
-const { parsePostcondition } = __forTests;
+const { parsePostcondition, buildRoutePostconditionExpression } = __forTests;
 
 describe('app_pop_until parsePostcondition (#801 PR1)', () => {
   it('returns null when no postcondition is supplied', () => {
@@ -35,8 +35,6 @@ describe('app_pop_until parsePostcondition (#801 PR1)', () => {
 });
 
 describe('app_pop_until VM path verifyRoutePostcondition (#801 PR1)', () => {
-  const { verifyRoutePostcondition } = __forTests;
-
   it('returns verified=true when ModalRoute name matches', async () => {
     // We can exercise the VM helper directly with a stubbed flutter client.
     // The helper resolves the client via getFlutterVMClient, so we wire a
@@ -70,6 +68,14 @@ describe('app_pop_until VM path verifyRoutePostcondition (#801 PR1)', () => {
     jest.dontMock('../../src/flutter');
   });
 
+
+  it('uses the route tree-walk marker rather than ModalRoute.of(rootElement)', () => {
+    const expr = buildRoutePostconditionExpression('/home');
+    expect(expr).toContain('_ModalScopeStatus');
+    expect(expr).toContain('visit(root)');
+    expect(expr).not.toContain('ModalRoute.of(root)');
+  });
+
   it('surfaces VM evaluate errors in the last error field', async () => {
     jest.resetModules();
     jest.doMock('../../src/flutter', () => ({
@@ -88,8 +94,6 @@ describe('app_pop_until VM path verifyRoutePostcondition (#801 PR1)', () => {
 });
 
 describe('app_pop_until VM path verifyAxPostcondition (#801 PR1)', () => {
-  const { verifyAxPostcondition } = __forTests;
-
   it('reports verified=true on first non-empty AX match', async () => {
     jest.resetModules();
     jest.doMock('../../src/native', () => ({

--- a/tests/unit/app-pop-until-contract.test.ts
+++ b/tests/unit/app-pop-until-contract.test.ts
@@ -1,0 +1,130 @@
+/**
+ * #801 PR1 — app_pop_until contract extension tests.
+ *
+ * Pin the new helpers (parsePostcondition, verifyAxPostcondition,
+ * verifyRoutePostcondition) and the response-shape contract that
+ * downstream consumers will rely on.
+ */
+
+import { __forTests } from '../../src/tools/app-pop-until';
+
+const { parsePostcondition } = __forTests;
+
+describe('app_pop_until parsePostcondition (#801 PR1)', () => {
+  it('returns null when no postcondition is supplied', () => {
+    expect(parsePostcondition(undefined)).toBeNull();
+    expect(parsePostcondition(null)).toBeNull();
+  });
+
+  it('accepts a spec with at least one signal field', () => {
+    expect(parsePostcondition({ identifier: 'home_tab' })).toEqual({ identifier: 'home_tab' });
+    expect(parsePostcondition({ label: 'Home' })).toEqual({ label: 'Home' });
+    expect(parsePostcondition({ route: '/home' })).toEqual({ route: '/home' });
+    expect(parsePostcondition({ role: 'button' })).toEqual({ role: 'button' });
+  });
+
+  it('rejects a spec with no signal fields', () => {
+    expect(() => parsePostcondition({})).toThrow(/at least one/);
+    expect(() => parsePostcondition({ timeoutMs: 1000 })).toThrow(/at least one/);
+  });
+
+  it('rejects non-object specs', () => {
+    expect(() => parsePostcondition('home_tab')).toThrow(/object/);
+    expect(() => parsePostcondition(42)).toThrow(/object/);
+  });
+});
+
+describe('app_pop_until VM path verifyRoutePostcondition (#801 PR1)', () => {
+  const { verifyRoutePostcondition } = __forTests;
+
+  it('returns verified=true when ModalRoute name matches', async () => {
+    // We can exercise the VM helper directly with a stubbed flutter client.
+    // The helper resolves the client via getFlutterVMClient, so we wire a
+    // module-level stub for this test.
+    jest.resetModules();
+    jest.doMock('../../src/flutter', () => ({
+      getFlutterVMClient: () => ({
+        evaluate: async () => ({ valueAsString: 'opensafari_route:ok' }),
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyRoutePostcondition('DEV-1', '/home', 1000, 50);
+    expect(verdict.verified).toBe(true);
+    expect(verdict.route).toBe('/home');
+    expect(verdict.kind).toBe('route');
+    jest.dontMock('../../src/flutter');
+  });
+
+  it('returns verified=false with a finite poll count when the deadline expires', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/flutter', () => ({
+      getFlutterVMClient: () => ({
+        evaluate: async () => ({ valueAsString: 'opensafari_route:mismatch:/other' }),
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyRoutePostcondition('DEV-1', '/home', 200, 50);
+    expect(verdict.verified).toBe(false);
+    expect(verdict.kind).toBe('route');
+    expect((verdict.polls ?? 0)).toBeGreaterThanOrEqual(1);
+    jest.dontMock('../../src/flutter');
+  });
+
+  it('surfaces VM evaluate errors in the last error field', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/flutter', () => ({
+      getFlutterVMClient: () => ({
+        evaluate: async () => {
+          throw new Error('isolate paused');
+        },
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyRoutePostcondition('DEV-1', '/home', 100, 50);
+    expect(verdict.verified).toBe(false);
+    expect(verdict.error).toMatch(/isolate paused/);
+    jest.dontMock('../../src/flutter');
+  });
+});
+
+describe('app_pop_until VM path verifyAxPostcondition (#801 PR1)', () => {
+  const { verifyAxPostcondition } = __forTests;
+
+  it('reports verified=true on first non-empty AX match', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => ({
+        query: async () => ({ matches: [{ id: 'home_tab' }] }),
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyAxPostcondition(
+      'DEV-1',
+      { identifier: 'home_tab' },
+      1000,
+    );
+    expect(verdict.verified).toBe(true);
+    expect(verdict.kind).toBe('ax_query');
+    expect(verdict.finalMatchCount).toBe(1);
+    jest.dontMock('../../src/native');
+  });
+
+  it('returns verified=false with finalMatchCount=0 when AX never matches', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => ({
+        query: async () => ({ matches: [] }),
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const verdict = await reimported.verifyAxPostcondition(
+      'DEV-1',
+      { identifier: 'never_matches' },
+      150,
+    );
+    expect(verdict.verified).toBe(false);
+    expect(verdict.finalMatchCount).toBe(0);
+    expect((verdict.polls ?? 0)).toBeGreaterThanOrEqual(1);
+    jest.dontMock('../../src/native');
+  });
+});

--- a/tests/unit/app-pop-until-native-fallback.test.ts
+++ b/tests/unit/app-pop-until-native-fallback.test.ts
@@ -1,0 +1,264 @@
+/**
+ * #801 PR2 — app_pop_until native fallback ladder tests.
+ *
+ * The ladder driver (`runNativeFallback`) and the per-step dispatcher
+ * (`dispatchNativeBack`) are exercised against in-memory stubs of the
+ * input backend and AX bridge so we can pin attempt-history shape,
+ * strategy selection, and postcondition short-circuiting without a
+ * real simulator.
+ */
+
+import { __forTests } from '../../src/tools/app-pop-until';
+
+const { findBackAffordance, dispatchNativeBack, runNativeFallback } = __forTests;
+
+function mockBridge(matchesByQuery: Array<{ q: Record<string, unknown>; matches: unknown[] }>) {
+  return {
+    query: jest.fn(async (q: Record<string, unknown>) => {
+      const entry = matchesByQuery.find((m) =>
+        Object.entries(m.q).every(([k, v]) => q[k] === v),
+      );
+      return { matches: entry ? entry.matches : [], total: entry?.matches.length ?? 0, query: q, ambiguous: false };
+    }),
+  };
+}
+
+function mockBackend(opts?: { failSwipe?: boolean; failKey?: boolean; tapImpl?: jest.Mock }) {
+  return {
+    tap: opts?.tapImpl ?? jest.fn(async () => undefined),
+    swipe: jest.fn(async () => {
+      if (opts?.failSwipe) throw new Error('swipe unavailable');
+    }),
+    sendKey: jest.fn(async () => {
+      if (opts?.failKey) throw new Error('key unavailable');
+    }),
+    typeText: jest.fn(async () => undefined),
+  };
+}
+
+describe('app_pop_until findBackAffordance (#801 PR2)', () => {
+  it('returns the centre of the first identifier-hint match', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () =>
+        mockBridge([
+          {
+            q: { identifier: 'back' },
+            matches: [
+              { role: 'AXButton', visible: true, enabled: true, frame: { x: 10, y: 50, width: 40, height: 40 } },
+            ],
+          },
+        ]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const target = await reimported.findBackAffordance('DEV-1');
+    expect(target).toEqual({ x: 30, y: 70, via: 'identifier=back' });
+    jest.dontMock('../../src/native');
+  });
+
+  it('falls through identifier hints to label hints when none match', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () =>
+        mockBridge([
+          {
+            q: { label: 'back' },
+            matches: [
+              { role: 'AXButton', visible: true, enabled: true, frame: { x: 0, y: 100, width: 60, height: 40 } },
+              { role: 'AXStaticText', visible: true, enabled: true, frame: { x: 0, y: 90, width: 60, height: 20 } },
+            ],
+          },
+        ]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const target = await reimported.findBackAffordance('DEV-1');
+    // Should pick the AXButton over the AXStaticText.
+    expect(target?.via).toBe('label=back');
+    expect(target?.x).toBe(30);
+    expect(target?.y).toBe(120);
+    jest.dontMock('../../src/native');
+  });
+
+  it('returns null when nothing matches', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const target = await reimported.findBackAffordance('DEV-1');
+    expect(target).toBeNull();
+    jest.dontMock('../../src/native');
+  });
+});
+
+describe('app_pop_until dispatchNativeBack (#801 PR2)', () => {
+  it('taps the back affordance when AX finds one', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () =>
+        mockBridge([
+          {
+            q: { identifier: 'back' },
+            matches: [{ role: 'AXButton', visible: true, enabled: true, frame: { x: 0, y: 0, width: 40, height: 40 } }],
+          },
+        ]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const backend = mockBackend();
+    const result = await reimported.dispatchNativeBack('DEV-1', backend as never);
+    expect(result.strategy).toBe('native_back');
+    expect(backend.tap).toHaveBeenCalledWith('DEV-1', 20, 20);
+    expect(backend.swipe).not.toHaveBeenCalled();
+    jest.dontMock('../../src/native');
+  });
+
+  it('falls through to edge_swipe when no back affordance is found', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const backend = mockBackend();
+    const result = await reimported.dispatchNativeBack('DEV-1', backend as never);
+    expect(result.strategy).toBe('edge_swipe');
+    expect(backend.swipe).toHaveBeenCalled();
+    expect(backend.tap).not.toHaveBeenCalled();
+    jest.dontMock('../../src/native');
+  });
+
+  it('falls through to escape_key when swipe throws', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const backend = mockBackend({ failSwipe: true });
+    const result = await reimported.dispatchNativeBack('DEV-1', backend as never);
+    expect(result.strategy).toBe('escape_key');
+    expect(backend.sendKey).toHaveBeenCalledWith('DEV-1', 'Escape');
+    jest.dontMock('../../src/native');
+  });
+
+  it('throws when every native strategy fails', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const backend = mockBackend({ failSwipe: true, failKey: true });
+    await expect(
+      reimported.dispatchNativeBack('DEV-1', backend as never),
+    ).rejects.toThrow(/all native strategies failed/);
+    jest.dontMock('../../src/native');
+  });
+});
+
+describe('app_pop_until runNativeFallback (#801 PR2)', () => {
+  it('short-circuits when postcondition verifies after the first dispatch', async () => {
+    jest.resetModules();
+    // Single mock so both findBackAffordance and the postcondition poll
+    // resolve through the same AX bridge.
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => ({
+        query: jest.fn(async (q: Record<string, unknown>) => {
+          if (q.identifier === 'back') {
+            return {
+              matches: [{ role: 'AXButton', visible: true, enabled: true, frame: { x: 0, y: 0, width: 40, height: 40 } }],
+              total: 1,
+              query: q,
+              ambiguous: false,
+            };
+          }
+          if (q.identifier === 'home_tab') {
+            return { matches: [{ id: 'home' }], total: 1, query: q, ambiguous: false };
+          }
+          return { matches: [], total: 0, query: q, ambiguous: false };
+        }),
+      }),
+    }));
+    jest.doMock('../../src/tools/native-input-utils', () => ({
+      getInputBackend: jest.fn(async () => mockBackend()),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const result = await reimported.runNativeFallback({
+      deviceId: 'DEV-1',
+      target: { until: 'first' },
+      postSpec: { identifier: 'home_tab', timeoutMs: 500 },
+      maxAttempts: 6,
+      interAttemptDelayMs: 10,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.attempts.length).toBe(1);
+    expect(result.attempts[0].ok).toBe(true);
+    expect(result.postcondition.verified).toBe(true);
+    jest.dontMock('../../src/native');
+    jest.dontMock('../../src/tools/native-input-utils');
+  });
+
+  it('exhausts attempts when postcondition never verifies', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    jest.doMock('../../src/tools/native-input-utils', () => ({
+      getInputBackend: jest.fn(async () => mockBackend()),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const result = await reimported.runNativeFallback({
+      deviceId: 'DEV-1',
+      target: { until: 'first' },
+      postSpec: { identifier: 'never', timeoutMs: 50 },
+      maxAttempts: 3,
+      interAttemptDelayMs: 5,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.exhausted).toBe(true);
+    expect(result.attempts.length).toBe(3);
+    jest.dontMock('../../src/native');
+    jest.dontMock('../../src/tools/native-input-utils');
+  });
+
+  it('reports noBackend when getInputBackend throws', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/tools/native-input-utils', () => ({
+      getInputBackend: jest.fn(async () => {
+        throw new Error('headless input unavailable');
+      }),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const result = await reimported.runNativeFallback({
+      deviceId: 'DEV-1',
+      target: { until: 'first' },
+      postSpec: { identifier: 'home', timeoutMs: 50 },
+      maxAttempts: 2,
+      interAttemptDelayMs: 5,
+    });
+    expect(result.noBackend).toMatch(/headless input unavailable/);
+    expect(result.attempts).toEqual([]);
+    jest.dontMock('../../src/tools/native-input-utils');
+  });
+
+  it('caps attempts by count when target.until === "count"', async () => {
+    jest.resetModules();
+    jest.doMock('../../src/native', () => ({
+      getAccessibilityBridge: () => mockBridge([]),
+    }));
+    jest.doMock('../../src/tools/native-input-utils', () => ({
+      getInputBackend: jest.fn(async () => mockBackend()),
+    }));
+    const { __forTests: reimported } = await import('../../src/tools/app-pop-until');
+    const result = await reimported.runNativeFallback({
+      deviceId: 'DEV-1',
+      target: { until: 'count', count: 2 },
+      // Synthetic postcondition (matches the public handler's behavior when
+      // no postcondition is supplied for until=count). It will never verify,
+      // but the cap kicks in at count=2 anyway.
+      postSpec: { identifier: '__opensafari_pop_until_count_synthetic__', timeoutMs: 30 },
+      maxAttempts: 10,
+      interAttemptDelayMs: 5,
+    });
+    expect(result.attempts.length).toBe(2);
+    jest.dontMock('../../src/native');
+    jest.dontMock('../../src/tools/native-input-utils');
+  });
+});

--- a/tests/unit/app-pop-until-native-fallback.test.ts
+++ b/tests/unit/app-pop-until-native-fallback.test.ts
@@ -10,7 +10,7 @@
 
 import { __forTests } from '../../src/tools/app-pop-until';
 
-const { findBackAffordance, dispatchNativeBack, runNativeFallback } = __forTests;
+const { nativePostconditionForVmState } = __forTests;
 
 function mockBridge(matchesByQuery: Array<{ q: Record<string, unknown>; matches: unknown[] }>) {
   return {
@@ -35,6 +35,27 @@ function mockBackend(opts?: { failSwipe?: boolean; failKey?: boolean; tapImpl?: 
     typeText: jest.fn(async () => undefined),
   };
 }
+
+
+describe('app_pop_until native postcondition normalization (#801 PR2)', () => {
+  it('rejects route-only postconditions when the Flutter VM is unavailable', () => {
+    const result = nativePostconditionForVmState({ route: '/home' }, false);
+    expect(result.postSpec).toBeNull();
+    expect(result.error).toMatch(/route-only/);
+  });
+
+  it('uses AX signals and drops route verification when VM is unavailable', () => {
+    const result = nativePostconditionForVmState({ route: '/home', identifier: 'home_tab' }, false);
+    expect(result.error).toBeUndefined();
+    expect(result.postSpec).toEqual({ identifier: 'home_tab' });
+  });
+
+  it('keeps route verification available when VM is connected during forceFallback', () => {
+    const result = nativePostconditionForVmState({ route: '/home' }, true);
+    expect(result.error).toBeUndefined();
+    expect(result.postSpec).toEqual({ route: '/home' });
+  });
+});
 
 describe('app_pop_until findBackAffordance (#801 PR2)', () => {
   it('returns the centre of the first identifier-hint match', async () => {

--- a/tests/unit/error-catalog-expansion.test.ts
+++ b/tests/unit/error-catalog-expansion.test.ts
@@ -96,13 +96,21 @@ describe('respondWithStructuredError helper (#797 PR1)', () => {
     const response = respondWithStructuredError(
       ErrorCode.MISSING_REQUIRED_PARAM,
       'name is required',
-      // toMcpResponse spreads extras AFTER canonical keys, so extras win —
-      // this is intentional (lets tools enrich) but we still pin the
-      // typical case where no override is provided.
-      { context: 'app_pop_until' },
+      {
+        error: 'AD_HOC_ERROR',
+        message: 'wrong message',
+        recoverable: false,
+        suggestion: 'wrong suggestion',
+        context: 'app_pop_until',
+      },
     );
     const payload = JSON.parse(response.content[0].text);
-    expect(payload.error).toBe(ErrorCode.MISSING_REQUIRED_PARAM);
-    expect(payload.context).toBe('app_pop_until');
+    expect(payload).toMatchObject({
+      error: ErrorCode.MISSING_REQUIRED_PARAM,
+      message: 'name is required',
+      recoverable: true,
+      suggestion: ERROR_CATALOG[ErrorCode.MISSING_REQUIRED_PARAM].suggestion,
+      context: 'app_pop_until',
+    });
   });
 });

--- a/tests/unit/error-catalog-expansion.test.ts
+++ b/tests/unit/error-catalog-expansion.test.ts
@@ -1,0 +1,108 @@
+/**
+ * #797 PR1 — catalog expansion + respondWithStructuredError helper.
+ *
+ * Verifies the new ErrorCode entries are reachable through the catalog
+ * and that the helper produces the canonical 5-key envelope plus any
+ * tool-specific extras the caller supplies.
+ */
+
+import {
+  ErrorCode,
+  ERROR_CATALOG,
+  StructuredErrorException,
+  respondWithStructuredError,
+} from '../../src/errors';
+
+describe('error catalog expansion (#797 PR1)', () => {
+  const NEW_CODES: ErrorCode[] = [
+    ErrorCode.INVALID_INPUT,
+    ErrorCode.MISSING_REQUIRED_PARAM,
+    ErrorCode.INVALID_URL,
+    ErrorCode.DEVICE_NOT_BOOTED,
+    ErrorCode.SESSION_NOT_FOUND,
+    ErrorCode.BACKEND_NOT_CONNECTED,
+    ErrorCode.FLUTTER_VM_NOT_CONNECTED,
+    ErrorCode.FLUTTER_EVAL_FAILED,
+    ErrorCode.OVERLAY_DISMISS_FAILED,
+    ErrorCode.KEYBOARD_DISMISS_FAILED,
+    ErrorCode.ALERT_NO_EFFECT,
+    ErrorCode.PERMISSION_RESET_DENIED,
+    ErrorCode.POP_UNTIL_EXHAUSTED,
+    ErrorCode.POP_UNTIL_NO_FALLBACK_AVAILABLE,
+    ErrorCode.MISSING_POSTCONDITION,
+  ];
+
+  it.each(NEW_CODES)('catalog entry exists for %s', (code) => {
+    const entry = ERROR_CATALOG[code];
+    expect(entry).toBeDefined();
+    expect(entry.code).toBe(code);
+    expect(typeof entry.recoverable).toBe('boolean');
+    expect(typeof entry.suggestion).toBe('string');
+    expect(entry.suggestion.length).toBeGreaterThan(0);
+  });
+
+  it('fromCode pulls metadata for newly-added codes', () => {
+    const err = StructuredErrorException.fromCode(
+      ErrorCode.DEVICE_NOT_BOOTED,
+      'no booted simulator',
+    );
+    expect(err.code).toBe(ErrorCode.DEVICE_NOT_BOOTED);
+    expect(err.recoverable).toBe(true);
+    expect(err.suggestion).toMatch(/device_boot|deviceId/);
+  });
+
+  it('PERMISSION_RESET_DENIED is marked non-recoverable (host TCC boundary)', () => {
+    expect(ERROR_CATALOG[ErrorCode.PERMISSION_RESET_DENIED].recoverable).toBe(false);
+  });
+
+  it('POP_UNTIL_NO_FALLBACK_AVAILABLE is marked non-recoverable', () => {
+    expect(ERROR_CATALOG[ErrorCode.POP_UNTIL_NO_FALLBACK_AVAILABLE].recoverable).toBe(false);
+  });
+});
+
+describe('respondWithStructuredError helper (#797 PR1)', () => {
+  it('produces the canonical envelope shape', () => {
+    const response = respondWithStructuredError(
+      ErrorCode.INVALID_INPUT,
+      'until must be one of first/route/count',
+    );
+    expect(response.isError).toBe(true);
+    expect(response.content).toHaveLength(1);
+    expect(response.content[0].type).toBe('text');
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload.error).toBe(ErrorCode.INVALID_INPUT);
+    expect(payload.message).toBe('until must be one of first/route/count');
+    expect(payload.recoverable).toBe(true);
+    expect(typeof payload.suggestion).toBe('string');
+  });
+
+  it('preserves tool-specific extras alongside the canonical fields', () => {
+    const response = respondWithStructuredError(
+      ErrorCode.FLUTTER_VM_NOT_CONNECTED,
+      'Call flutter_connect first.',
+      { deviceId: 'DEV-1', target: { until: 'first' } },
+    );
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload).toMatchObject({
+      error: ErrorCode.FLUTTER_VM_NOT_CONNECTED,
+      message: 'Call flutter_connect first.',
+      deviceId: 'DEV-1',
+      target: { until: 'first' },
+    });
+    expect(payload.recoverable).toBe(true);
+  });
+
+  it('extras cannot accidentally clobber the canonical error/recoverable/suggestion keys', () => {
+    const response = respondWithStructuredError(
+      ErrorCode.MISSING_REQUIRED_PARAM,
+      'name is required',
+      // toMcpResponse spreads extras AFTER canonical keys, so extras win —
+      // this is intentional (lets tools enrich) but we still pin the
+      // typical case where no override is provided.
+      { context: 'app_pop_until' },
+    );
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload.error).toBe(ErrorCode.MISSING_REQUIRED_PARAM);
+    expect(payload.context).toBe('app_pop_until');
+  });
+});

--- a/tests/unit/mcp-server.test.ts
+++ b/tests/unit/mcp-server.test.ts
@@ -1,5 +1,7 @@
 import http from 'http';
 import { MCPServer } from '../../src/mcp-server';
+import { ErrorCode } from '../../src/errors/codes';
+import { StructuredErrorException } from '../../src/errors/structured-error';
 import { toolRegistry, defineToolEntry } from '../../src/tools/registry';
 import * as auditLogger from '../../src/security/audit-logger';
 
@@ -59,6 +61,10 @@ describe('MCPServer — JSON-RPC protocol', () => {
       { name: 'fail', description: 'Always fails', inputSchema: { type: 'object' as const, properties: {}, required: [] } },
       async () => { throw new Error('intentional failure'); },
     );
+    server.registerTool(
+      { name: 'structured_fail', description: 'Fails with structured metadata', inputSchema: { type: 'object' as const, properties: {}, required: [] } },
+      async () => { throw StructuredErrorException.fromCode(ErrorCode.APP_NOT_INSTALLED, 'missing test bundle'); },
+    );
     server.setTier(3);
     await server.start({ transport: 'http', port: PORT, httpInsecure: true });
   });
@@ -94,6 +100,7 @@ describe('MCPServer — JSON-RPC protocol', () => {
     const names = tools.map((t) => t.name);
     expect(names).toContain('echo');
     expect(names).toContain('fail');
+    expect(names).toContain('structured_fail');
   });
 
   test('tools/list respects tier filtering', async () => {
@@ -138,7 +145,7 @@ describe('MCPServer — JSON-RPC protocol', () => {
     expect(error.message).toContain('requires params.name');
   });
 
-  test('tools/call handler exception returns error result', async () => {
+  test('tools/call handler exception returns structured fallback error result', async () => {
     const res = await mcpPost(PORT, {
       jsonrpc: '2.0', id: 7, method: 'tools/call',
       params: { name: 'fail', arguments: {} },
@@ -146,7 +153,32 @@ describe('MCPServer — JSON-RPC protocol', () => {
     const result = res.body.result as Record<string, unknown>;
     expect(result.isError).toBe(true);
     const content = result.content as Array<Record<string, unknown>>;
-    expect(content[0].text).toContain('intentional failure');
+    const body = JSON.parse(content[0].text as string) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      error: 'APP_STATE_UNKNOWN',
+      message: 'intentional failure',
+      recoverable: true,
+      tool: 'fail',
+    });
+    expect(typeof body.suggestion).toBe('string');
+  });
+
+  test('tools/call preserves StructuredErrorException metadata', async () => {
+    const res = await mcpPost(PORT, {
+      jsonrpc: '2.0', id: 701, method: 'tools/call',
+      params: { name: 'structured_fail', arguments: {} },
+    });
+    const result = res.body.result as Record<string, unknown>;
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<Record<string, unknown>>;
+    const body = JSON.parse(content[0].text as string) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      error: 'APP_NOT_INSTALLED',
+      message: 'missing test bundle',
+      recoverable: false,
+      suggestion: 'Install the app on the simulator first (e.g. simctl install)',
+      tool: 'structured_fail',
+    });
   });
 
   // ── error cases ──


### PR DESCRIPTION
## Summary

Prepare OpenSafari `0.6.2` for publish and carry the post-0.6.1 reliability fixes onto `main`.

## Main CI fix

The latest failing `main` check is `SimulatorKit HID Sentinel` on `macos-15`, where the first fake-UDID framework-load probe timed out at 45s. This release includes the existing develop fix that:

- raises the sentinel bridge budget to 90s;
- prefers `dist/sim-hid-bridge-native` before Swift interpreter fallback;
- keeps failures tied to real private-API break responses (`exit 78` + structured diagnostic code).

## Release notes

- Adds detailed English `CHANGELOG.md` notes for `0.6.2`, including a file-level diff since `0.6.1`.
- Bumps `package.json` and `package-lock.json` to `0.6.2`.

## Verification

- `npm test -- --runInBand tests/ci/sim-hid-sentinel.test.ts --runTestsByPath --testPathIgnorePatterns=/node_modules/`
- `npm test -- --runInBand tests/unit/error-catalog-expansion.test.ts tests/unit/app-pop-until-contract.test.ts tests/unit/app-pop-until-native-fallback.test.ts tests/unit/app-dismiss-overlay.test.ts tests/unit/mcp-server.test.ts`
- `npm test -- --runInBand`
- `npm run build`
- `npm run lint -- --quiet`

## Publish

Not published. The maintainer will publish from terminal separately.
