### PR TITLE
fix(ci): make publish workflow honest-green (idempotent + auth preflight)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,69 @@ jobs:
           test -f dist/index.js
           test -f dist/cli/index.js
           node dist/cli/index.js --help
-      - run: npm publish --provenance --access public
+
+      - name: Resolve package identity
+        id: pkg
+        run: |
+          set -euo pipefail
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved $NAME@$VERSION"
+
+      - name: Check if version already published (idempotency)
+        id: published
+        run: |
+          set -euo pipefail
+          # A tag re-push, a manual local publish, or a re-run must not fail the
+          # job: if the exact version is already on the registry, publishing is a
+          # no-op and the job should report honest green instead of npm's
+          # confusing E404 ("not in this registry") on the duplicate PUT.
+          if npm view "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}" version >/dev/null 2>&1; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }} is already published — skipping npm publish."
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+            echo "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }} not on registry yet — will publish."
+          fi
+
+      - name: Verify npm auth (preflight)
+        if: steps.published.outputs.already == 'false'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          # npm masks authorization failures on publish as an E404 ("not in this
+          # registry"), which previously made a broken/expired NPM_TOKEN look
+          # like a missing package. Fail here with an actionable message instead.
+          if ! WHO=$(npm whoami 2>/dev/null); then
+            echo "::error::NPM_TOKEN failed authentication (npm whoami). Rotate it: the secret must be an automation token with publish rights to ${{ steps.pkg.outputs.name }}."
+            exit 1
+          fi
+          echo "Authenticated to npm as ${WHO}"
+
+      - name: Publish to npm
+        if: steps.published.outputs.already == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+  notify:
+    # Surface publish failures the same way the sentinels do, so a broken
+    # release pipeline (e.g. an expired NPM_TOKEN) cannot sit red unnoticed.
+    needs: publish
+    if: failure()
+    uses: ./.github/workflows/_sentinel-notify.yml
+    with:
+      title: 'npm publish failed'
+      runner: 'macos-latest'
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      body: |
+        The Publish workflow failed for a pushed v* tag.
+        Common cause: NPM_TOKEN expired or lacks publish rights (npm reports
+        this as a misleading E404). Check the "Verify npm auth (preflight)"
+        and "Publish to npm" steps on the workflow run.
+      channel: ${{ vars.SENTINEL_CHANNEL || '#opensafari-sentinels' }}
+    secrets:
+      webhook-url: ${{ secrets.SENTINEL_WEBHOOK_URL }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Publish workflow honest-green** — the `Publish` workflow has reported `failure` on every release since v0.6.0 even though each version reached npm, because `npm publish --provenance` returns a misleading `E404 … not in this registry` when the version already exists or the `NPM_TOKEN` lacks publish rights. `publish.yml` now (a) skips publishing with a success status when the exact `name@version` is already on the registry (idempotent re-runs / re-pushed tags), (b) runs an `npm whoami` auth preflight that fails with an actionable message instead of the masked E404, and (c) fans a failure out through the existing `_sentinel-notify` reusable workflow so a broken release pipeline cannot sit red unnoticed. NOTE: a genuinely-new version still requires a valid publish-scoped `NPM_TOKEN`.
+
 ## [0.6.3] - 2026-05-29
 
 **OpenSafari 0.6.3 is a portability and reliability patch release.** It lands the structured-error rollout across every agent-facing MCP tool, introduces the `debug_bundle_collect` MCP tool with automatic attachment on recoverable failures, and unblocks the scheduled Headless Smoke Tests run on `main` that has been red since 2026-05-22 because the `sim-hid-bridge` smoke probe was timing out before the wrapper's own probe-context flow could complete on GitHub-hosted runners.


### PR DESCRIPTION
## Summary
The `Publish` workflow has reported **failure on every release since v0.6.0** (v0.6.0/0.6.1/0.6.2/0.6.3) even though each version reached npm. Root cause: `npm publish --provenance` returns a misleading `E404 … 'opensafari-mcp@x.y.z' is not in this registry` both when (a) the version already exists and (b) `NPM_TOKEN` lacks publish rights — npm masks auth failures as 404.

This makes the release pipeline's red/green signal meaningless and directly contradicts the project's reliability pillar (SSOT #795 / P0).

## Changes (`publish.yml`)
- **Idempotency** — resolve `name@version` from package.json, and if it's already on the registry, **skip publish with a success status** (handles re-pushed tags, manual/local publishes, and re-runs).
- **Auth preflight** — `npm whoami` before publish; fails with an actionable "rotate NPM_TOKEN" message instead of the masked E404.
- **Failure notify** — a `notify` job fans publish failures through the existing `_sentinel-notify` reusable workflow (no-op if `SENTINEL_WEBHOOK_URL` is unset), so a broken release pipeline can't sit red unnoticed.

## Verification
- YAML validates.
- Idempotency logic simulated against the live registry: `opensafari-mcp@0.6.3` → `already=true` → publish would **skip (honest green)**.

## Out of scope (needs maintainer)
- Rotating/scoping the `NPM_TOKEN` secret so genuinely-new versions publish from CI (Action plan A1/A2). This PR makes the failure mode honest; it does not grant the token rights.

Part of the reliability action plan (Workstream A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)