### PR TITLE
refactor(errors): catalog-code the two most common recoverable throws (device/flutter-vm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Catalog-coded the two most common recoverable failure conditions so MCP clients receive a specific error code plus `recoverable` flag and `suggestion` instead of the generic `APP_STATE_UNKNOWN` fallback. "No device specified and no active device" (28 sites across `src/tools/**` and the canonical `resolveDeviceId` in `src/native/accessibility.ts`) now throws `StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, …)`, and "Not connected to Flutter VM Service. Run flutter_connect first." (12 sites) now throws `StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, …)`. Each site preserves its original message string. The error envelope was already structured via the MCP server catch-all; this upgrades specificity (enabling client-side auto-recovery) for the highest-frequency cases.
+
 ## [0.6.3] - 2026-05-29
 
 **OpenSafari 0.6.3 is a portability and reliability patch release.** It lands the structured-error rollout across every agent-facing MCP tool, introduces the `debug_bundle_collect` MCP tool with automatic attachment on recoverable failures, and unblocks the scheduled Headless Smoke Tests run on `main` that has been red since 2026-05-22 because the `sim-hid-bridge` smoke probe was timing out before the wrapper's own probe-context flow could complete on GitHub-hosted runners.

--- a/src/native/accessibility.ts
+++ b/src/native/accessibility.ts
@@ -1,4 +1,5 @@
 import { getSessionManager } from '../session-manager';
+import { ErrorCode, StructuredErrorException } from '../errors';
 
 /**
  * Native iOS Accessibility Tree — Query Engine & Utilities
@@ -48,9 +49,7 @@ export function resolveDeviceId(explicit?: string): string {
   if (explicit) return explicit;
   const active = getSessionManager().getSoleDeviceId();
   if (!active) {
-    throw new Error(
-      'No device specified and no active device found. Boot a simulator first with device_boot.',
-    );
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device found. Boot a simulator first with device_boot.');
   }
   return active;
 }

--- a/src/tools/app-assert-element.ts
+++ b/src/tools/app-assert-element.ts
@@ -15,7 +15,7 @@ import {
   createContextMismatchError,
   NativeContextMeta,
 } from './native-app-context';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 type AssertCondition = 'exists' | 'not_exists' | 'visible' | 'enabled' | 'disabled' | 'has_text';
 
@@ -86,9 +86,7 @@ export function registerAppAssertElementTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error(
-            'No device specified and no active device. Boot a simulator first with device_boot.',
-          );
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first with device_boot.');
         }
 
         const condition = (params.assert as AssertCondition | undefined) ?? 'exists';

--- a/src/tools/app-wait-for.ts
+++ b/src/tools/app-wait-for.ts
@@ -11,7 +11,7 @@ import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
 import { getInputBackend } from './native-input-utils';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 import {
   activateAndClassify,
   createContextMismatchError,
@@ -154,9 +154,7 @@ export function registerAppWaitForNativeTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error(
-            'No device specified and no active device. Boot a simulator first with device_boot.',
-          );
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first with device_boot.');
         }
 
         const condition = (params.condition as WaitCondition | undefined) ?? 'exists';

--- a/src/tools/flutter-breakpoints.ts
+++ b/src/tools/flutter-breakpoints.ts
@@ -26,7 +26,7 @@ import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient, FlutterVMError } from '../flutter';
 import { getSessionManager } from '../session-manager';
 import type { VMServiceEvent } from '../flutter/flutter-types';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 type FlutterEvent = VMServiceEvent['params']['event'];
 
@@ -180,11 +180,11 @@ async function resolveClient(paramDeviceId: unknown) {
     (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
     getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error('No device specified and no active device. Boot a simulator first.');
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
   }
   const client = getFlutterVMClient(deviceId);
   if (!client.isConnected()) {
-    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+    throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
   }
   return { deviceId, client };
 }

--- a/src/tools/flutter-build-mode.ts
+++ b/src/tools/flutter-build-mode.ts
@@ -12,7 +12,7 @@ import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { discoverVMServiceUrl } from '../flutter/vm-service-discovery';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 export type FlutterBuildMode = 'debug' | 'profile' | 'release' | 'unknown';
 
@@ -161,7 +161,7 @@ export function registerFlutterBuildModeTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device. Boot a simulator first.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
         }
 
         const probe = await detectBuildMode(deviceId, {

--- a/src/tools/flutter-connect.ts
+++ b/src/tools/flutter-connect.ts
@@ -8,7 +8,7 @@
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 export function registerFlutterConnectTool(server: MCPServer): void {
   server.registerTool(
@@ -48,7 +48,7 @@ export function registerFlutterConnectTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device. Boot a simulator first.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
         }
 
         const client = getFlutterVMClient(deviceId);

--- a/src/tools/flutter-cpu-profile.ts
+++ b/src/tools/flutter-cpu-profile.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient, FlutterVMError } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 const MAX_DURATION_MS = 120_000; // 2 minutes — longer windows balloon response size
 
@@ -30,11 +30,11 @@ async function resolveClient(paramDeviceId: unknown) {
     (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
     getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error('No device specified and no active device. Boot a simulator first.');
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
   }
   const client = getFlutterVMClient(deviceId);
   if (!client.isConnected()) {
-    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+    throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
   }
   return { deviceId, client };
 }

--- a/src/tools/flutter-debug-paint.ts
+++ b/src/tools/flutter-debug-paint.ts
@@ -18,7 +18,7 @@
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 export type DebugPaintMode =
   | 'size'
@@ -78,12 +78,12 @@ export function registerFlutterDebugPaintTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device. Boot a simulator first.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
         }
 
         const client = getFlutterVMClient(deviceId);
         if (!client.isConnected()) {
-          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+          throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
         }
 
         type Applied = { extension: string; params: Record<string, unknown>; ok: true };

--- a/src/tools/flutter-evaluate.ts
+++ b/src/tools/flutter-evaluate.ts
@@ -18,7 +18,7 @@
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 type EvalScope = 'root' | 'frame';
 
@@ -90,12 +90,12 @@ export function registerFlutterEvaluateTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device. Boot a simulator first.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
         }
 
         const client = getFlutterVMClient(deviceId);
         if (!client.isConnected()) {
-          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+          throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
         }
 
         const raw =

--- a/src/tools/flutter-hot-reload.ts
+++ b/src/tools/flutter-hot-reload.ts
@@ -5,7 +5,7 @@
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 export function registerFlutterHotReloadTool(server: MCPServer): void {
   server.registerTool(
@@ -37,12 +37,12 @@ export function registerFlutterHotReloadTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const client = getFlutterVMClient(deviceId);
         if (!client.isConnected()) {
-          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+          throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
         }
 
         const mode = (params.mode as string | undefined) ?? 'reload';

--- a/src/tools/flutter-inspector.ts
+++ b/src/tools/flutter-inspector.ts
@@ -17,7 +17,7 @@
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -26,11 +26,11 @@ async function resolveClient(paramDeviceId: unknown): Promise<{ deviceId: string
     (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
     getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error('No device specified and no active device. Boot a simulator first.');
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
   }
   const client = getFlutterVMClient(deviceId);
   if (!client.isConnected()) {
-    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+    throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
   }
   return { deviceId, client };
 }

--- a/src/tools/flutter-logs.ts
+++ b/src/tools/flutter-logs.ts
@@ -8,7 +8,7 @@
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 interface LogEntry {
   timestamp: number;
@@ -60,12 +60,12 @@ export function registerFlutterLogsTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const client = getFlutterVMClient(deviceId);
         if (!client.isConnected()) {
-          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+          throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
         }
 
         const action = (params.action as string | undefined) ?? 'get';

--- a/src/tools/flutter-memory-profile.ts
+++ b/src/tools/flutter-memory-profile.ts
@@ -18,7 +18,7 @@ import { Buffer } from 'buffer';
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient, FlutterVMError } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -27,11 +27,11 @@ async function resolveClient(paramDeviceId: unknown) {
     (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
     getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error('No device specified and no active device. Boot a simulator first.');
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
   }
   const client = getFlutterVMClient(deviceId);
   if (!client.isConnected()) {
-    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+    throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
   }
   return { deviceId, client };
 }

--- a/src/tools/flutter-network.ts
+++ b/src/tools/flutter-network.ts
@@ -13,7 +13,7 @@ import * as url from 'url';
 import { MCPServer } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
 import { SimctlExecutor } from '../simulator/simctl';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 interface NetworkEntry {
   id: number;
@@ -95,7 +95,7 @@ export function registerFlutterNetworkTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const action = (params.action as string | undefined) ?? 'log';

--- a/src/tools/flutter-service-extensions.ts
+++ b/src/tools/flutter-service-extensions.ts
@@ -14,18 +14,18 @@
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 async function resolveClient(paramDeviceId: unknown) {
   const deviceId =
     (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
     getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error('No device specified and no active device. Boot a simulator first.');
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
   }
   const client = getFlutterVMClient(deviceId);
   if (!client.isConnected()) {
-    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+    throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
   }
   return { deviceId, client };
 }

--- a/src/tools/flutter-track-rebuilds.ts
+++ b/src/tools/flutter-track-rebuilds.ts
@@ -19,7 +19,7 @@ import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
 import type { VMServiceEvent } from '../flutter/flutter-types';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 // ── Per-device tracking state ───────────────────────────────────────────────
 
@@ -292,12 +292,12 @@ export function registerFlutterTrackRebuildsTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device. Boot a simulator first.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
         }
 
         const client = getFlutterVMClient(deviceId);
         if (!client.isConnected()) {
-          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+          throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
         }
 
         if (action === 'start') {

--- a/src/tools/flutter-widget-at-point.ts
+++ b/src/tools/flutter-widget-at-point.ts
@@ -29,7 +29,7 @@ import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
 import { summariseNode, type WidgetSummary } from './flutter-inspector';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -41,11 +41,11 @@ async function resolveClient(paramDeviceId: unknown): Promise<{
     (typeof paramDeviceId === 'string' ? paramDeviceId : undefined) ??
     getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error('No device specified and no active device. Boot a simulator first.');
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first.');
   }
   const client = getFlutterVMClient(deviceId);
   if (!client.isConnected()) {
-    throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+    throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
   }
   return { deviceId, client };
 }

--- a/src/tools/flutter-widget-tree.ts
+++ b/src/tools/flutter-widget-tree.ts
@@ -8,7 +8,7 @@
 import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 
 export function registerFlutterWidgetTreeTool(server: MCPServer): void {
   server.registerTool(
@@ -40,12 +40,12 @@ export function registerFlutterWidgetTreeTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const client = getFlutterVMClient(deviceId);
         if (!client.isConnected()) {
-          throw new Error('Not connected to Flutter VM Service. Run flutter_connect first.');
+          throw StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, 'Not connected to Flutter VM Service. Run flutter_connect first.');
         }
 
         const treeType = (params.tree_type as string | undefined) ?? 'widget';

--- a/src/tools/native-app-helpers.ts
+++ b/src/tools/native-app-helpers.ts
@@ -1,4 +1,5 @@
 import { getSessionManager } from '../session-manager';
+import { ErrorCode, StructuredErrorException } from '../errors';
 
 /**
  * Resolve device ID from params or fall back to the active device.
@@ -7,7 +8,7 @@ import { getSessionManager } from '../session-manager';
 export function resolveDeviceId(params: Record<string, unknown>): string {
   const deviceId = (params.deviceId as string) || getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error('No device specified and no active device. Boot a simulator first with device_boot.');
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first with device_boot.');
   }
   return deviceId;
 }

--- a/src/tools/native-app-utils.ts
+++ b/src/tools/native-app-utils.ts
@@ -1,4 +1,5 @@
 import { getSessionManager } from '../session-manager';
+import { ErrorCode, StructuredErrorException } from '../errors';
 
 /**
  * Resolve a device ID from tool params or fall back to the active device.
@@ -7,9 +8,7 @@ import { getSessionManager } from '../session-manager';
 export function resolveDeviceId(params: Record<string, unknown>): string {
   const deviceId = (params.deviceId as string) || getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error(
-      'No device specified and no active device. Boot a simulator first with device_boot.',
-    );
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first with device_boot.');
   }
   return deviceId;
 }

--- a/src/tools/native-input-utils.ts
+++ b/src/tools/native-input-utils.ts
@@ -14,6 +14,7 @@ import {
   isMemoryMetaEnabled,
   type InputTelemetryEvent,
 } from '../metrics/input-telemetry';
+import { ErrorCode, StructuredErrorException } from '../errors';
 
 // Re-export input backend for tool files
 export {
@@ -140,9 +141,7 @@ export function resolveDeviceId(params: Record<string, unknown>): string {
     (params.deviceId as string | undefined) ||
     getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error(
-      'No device specified and no active device. Boot a simulator first with device_boot.',
-    );
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first with device_boot.');
   }
   return deviceId;
 }

--- a/src/tools/native-observability-utils.ts
+++ b/src/tools/native-observability-utils.ts
@@ -6,6 +6,7 @@ import { getSessionManager } from '../session-manager';
 import * as os from 'os';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
+import { ErrorCode, StructuredErrorException } from '../errors';
 
 /**
  * Resolve device ID from params or the active device in the session.
@@ -14,7 +15,7 @@ import { randomUUID } from 'crypto';
 export function resolveDeviceId(params: Record<string, unknown>): string {
   const deviceId = (params.deviceId as string) || getSessionManager().getSoleDeviceId();
   if (!deviceId) {
-    throw new Error('No device specified and no active device. Boot a simulator first with device_boot.');
+    throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device. Boot a simulator first with device_boot.');
   }
   return deviceId;
 }

--- a/src/tools/qa-flutter-dark-mode.ts
+++ b/src/tools/qa-flutter-dark-mode.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 import { getAccessibilityBridge } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
@@ -74,7 +74,7 @@ export function registerQaFlutterDarkModeTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
         deviceIdForRestore = deviceId;
 

--- a/src/tools/qa-flutter-full-audit.ts
+++ b/src/tools/qa-flutter-full-audit.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 import { getAccessibilityBridge } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
@@ -316,7 +316,7 @@ export function registerQaFlutterFullAuditTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const minSize = (params.min_size as number | undefined) ?? DEFAULT_MIN_SIZE;

--- a/src/tools/qa-flutter-keyboard-overlap.ts
+++ b/src/tools/qa-flutter-keyboard-overlap.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 import { getAccessibilityBridge } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
@@ -94,7 +94,7 @@ export function registerQaFlutterKeyboardOverlapTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const keyboardHeight =

--- a/src/tools/qa-flutter-orientation.ts
+++ b/src/tools/qa-flutter-orientation.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 import { getAccessibilityBridge } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
@@ -59,7 +59,7 @@ export function registerQaFlutterOrientationTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const bridge = getAccessibilityBridge();

--- a/src/tools/qa-flutter-semantics.ts
+++ b/src/tools/qa-flutter-semantics.ts
@@ -6,7 +6,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 import { getAccessibilityBridge } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
@@ -52,7 +52,7 @@ export function registerQaFlutterSemanticsTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const minCoverage = (params.min_coverage as number | undefined) ?? 80;

--- a/src/tools/qa-flutter-touch-targets.ts
+++ b/src/tools/qa-flutter-touch-targets.ts
@@ -6,7 +6,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { ErrorCode, respondWithStructuredError } from '../errors';
+import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
 import { getAccessibilityBridge } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
@@ -55,7 +55,7 @@ export function registerQaFlutterTouchTargetsTool(server: MCPServer): void {
           (params.device_id as string | undefined) ??
           getSessionManager().getSoleDeviceId();
         if (!deviceId) {
-          throw new Error('No device specified and no active device.');
+          throw StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, 'No device specified and no active device.');
         }
 
         const minSize = (params.min_size as number | undefined) ?? DEFAULT_MIN_SIZE;


### PR DESCRIPTION
## Summary

Upgrade the two highest-frequency recoverable error conditions from raw `throw new Error(...)` to the project's structured-error catalog, so MCP clients receive a specific error code + `recoverable` flag + `suggestion` (enabling client-side auto-recovery) instead of the generic `APP_STATE_UNKNOWN` fallback applied by the MCP server catch-all (`src/mcp-server.ts:426`).

- **`No device specified and no active device…`** — 28 sites across `src/tools/**` plus the canonical `resolveDeviceId` in `src/native/accessibility.ts` now throw `StructuredErrorException.fromCode(ErrorCode.DEVICE_NOT_BOOTED, …)`.
- **`Not connected to Flutter VM Service. Run flutter_connect first.`** — 12 sites across `src/tools/**` now throw `StructuredErrorException.fromCode(ErrorCode.FLUTTER_VM_NOT_CONNECTED, …)`.

Each call site **preserves its original message string** (wording varies per site). No other throws were touched — input validation, state conflicts, and external-helper errors are out of scope. `ErrorCode.DEVICE_NOT_BOOTED` (recoverable, suggests `device_boot`) and `ErrorCode.FLUTTER_VM_NOT_CONNECTED` (recoverable, suggests `flutter_connect`) already exist in the catalog. The envelope was already structured via the server catch-all; this upgrades specificity for the highest-frequency cases.

29 files changed (28 source + `CHANGELOG.md`), 72 insertions / 73 deletions.

## Test plan

- [x] `npm run build` — exit 0, zero TypeScript errors
- [x] `npm test` — 202 suites / 2853 tests passed, 0 failed
- [x] `npm run check:error-envelopes` — OK, no raw error envelopes in migrated files
- [x] No test files needed updating (none asserted the exact migrated message strings; tests inspecting structured codes already expected `DEVICE_NOT_BOOTED` / `FLUTTER_VM_NOT_CONNECTED`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)