### PR TITLE
ci(headless-smoke): gate Tier-0 thesis with a blocking Flutter step

### DIFF
--- a/.github/workflows/headless-smoke.yml
+++ b/.github/workflows/headless-smoke.yml
@@ -513,23 +513,27 @@ jobs:
           echo "::error::DDS VM service websocket did not accept getVM within warmup window"
           exit 1
 
-      - name: Run Flutter VM headless input live test
-        continue-on-error: true  # tap/typeText verification reads app state via ax-bridge, which needs TCC Accessibility unavailable on GitHub-hosted runners (same limitation as the webview-smoke job)
+      # Split into two steps so the headless Tier-0 thesis is actually gated.
+      #
+      # BLOCKING — the ax-independent assertions that prove the product claim
+      # "Tier-0 FlutterVMInputBackend is selected and dispatches gestures
+      # headless, no focus steal": backend selection + swipe gesture dispatch.
+      # These never touch the ax-bridge, so a regression here is a real product
+      # regression and must fail the job.
+      - name: Run Flutter VM Tier-0 routing + dispatch (blocking)
         env:
           OPENSAFARI_LIVE_VM: '1'
           OSF_DEVICE_ID: ${{ env.SIMULATOR_UDID }}
           JEST_JUNIT_OUTPUT_DIR: test-results
-          JEST_JUNIT_OUTPUT_NAME: flutter-smoke.junit.xml
+          JEST_JUNIT_OUTPUT_NAME: flutter-smoke-blocking.junit.xml
           JEST_JUNIT_CLASSNAME: '{filepath}'
-          JEST_JUNIT_SUITE_NAME: 'Flutter VM headless smoke'
+          JEST_JUNIT_SUITE_NAME: 'Flutter VM headless smoke (Tier-0 blocking)'
         run: |
           set -euo pipefail
           mkdir -p test-results
           # --forceExit: the live FlutterVMInputBackend holds an open VM Service
-          # WebSocket + heartbeat interval that this suite does not tear down,
-          # so jest would otherwise hang past the test run ("Jest did not exit
-          # one second after the test run has completed") and burn the full
-          # 35-minute job budget on every scheduled run.
+          # WebSocket + heartbeat interval, so jest would otherwise hang past
+          # the test run and burn the full job budget.
           node scripts/run-with-cursor-monitor.js -- \
           npx jest \
             --config jest.config.js \
@@ -538,6 +542,36 @@ jobs:
             --runInBand \
             --forceExit \
             --runTestsByPath tests/integration/flutter-vm-input.live.test.ts \
+            -t 'selects Tier 0|swipe produces multiple move' \
+            --reporters=default \
+            --reporters=jest-junit
+
+      # NON-BLOCKING — tap/typeText verification reads app state back through the
+      # ax-bridge, which needs Simulator.app + TCC Accessibility that
+      # GitHub-hosted runners do not grant (same limitation as the webview-smoke
+      # job). Kept advisory until the result-readback is reworked off the
+      # ax-bridge (e.g. via the VM Service widget tree) — tracked separately.
+      - name: Run Flutter VM ax-verified tap/type (advisory)
+        continue-on-error: true
+        env:
+          OPENSAFARI_LIVE_VM: '1'
+          OSF_DEVICE_ID: ${{ env.SIMULATOR_UDID }}
+          JEST_JUNIT_OUTPUT_DIR: test-results
+          JEST_JUNIT_OUTPUT_NAME: flutter-smoke-advisory.junit.xml
+          JEST_JUNIT_CLASSNAME: '{filepath}'
+          JEST_JUNIT_SUITE_NAME: 'Flutter VM headless smoke (ax-verified advisory)'
+        run: |
+          set -euo pipefail
+          mkdir -p test-results
+          node scripts/run-with-cursor-monitor.js -- \
+          npx jest \
+            --config jest.config.js \
+            --testPathIgnorePatterns='/node_modules/' \
+            --testTimeout=180000 \
+            --runInBand \
+            --forceExit \
+            --runTestsByPath tests/integration/flutter-vm-input.live.test.ts \
+            -t 'tap on Login|typeText into focused' \
             --reporters=default \
             --reporters=jest-junit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Headless Smoke `Flutter` job now gates the Tier-0 thesis** — the Flutter VM-Service live suite was entirely `continue-on-error` (advisory) after the #816 hang fix, so even a regression in headless Tier-0 routing or gesture dispatch would not fail CI. The step is now split: the ax-independent assertions (`getInputBackend()` selects `FlutterVMInputBackend`, and `swipe` dispatches gesture-arena events) run as a **blocking** step, while only the `tap`/`typeText` assertions — which verify their effect through the ax-bridge (needs Simulator.app + TCC Accessibility, unavailable on GitHub-hosted runners) — remain advisory. The load-bearing headless claim is verified on every run; the ax-dependent readback stays advisory until it is reworked off the ax-bridge. Documented in `docs/headless-architecture.md`.
+
 ## [0.6.3] - 2026-05-29
 
 **OpenSafari 0.6.3 is a portability and reliability patch release.** It lands the structured-error rollout across every agent-facing MCP tool, introduces the `debug_bundle_collect` MCP tool with automatic attachment on recoverable failures, and unblocks the scheduled Headless Smoke Tests run on `main` that has been red since 2026-05-22 because the `sim-hid-bridge` smoke probe was timing out before the wrapper's own probe-context flow could complete on GitHub-hosted runners.

--- a/docs/headless-architecture.md
+++ b/docs/headless-architecture.md
@@ -439,6 +439,28 @@ probe latency.
 Status: **Production** (Tier 0). Shipped in
 [#481 / #486](https://github.com/shaun0927/opensafari/pull/486).
 
+#### CI verification posture (Headless Smoke `Flutter` job)
+
+The live suite `tests/integration/flutter-vm-input.live.test.ts` runs on the
+daily Headless Smoke workflow, split into two steps with different gating
+because the assertions have different infrastructure requirements:
+
+| Assertion | Reads back via | CI gate |
+|---|---|---|
+| `getInputBackend()` selects Tier-0 `FlutterVMInputBackend` | none (backend selection) | **blocking** |
+| `swipe` dispatches gesture-arena move events | none (VM dispatch only) | **blocking** |
+| `tap` on Login changes status | **ax-bridge** (Simulator.app + TCC) | advisory (`continue-on-error`) |
+| `typeText` fires `onChanged` | **ax-bridge** (Simulator.app + TCC) | advisory (`continue-on-error`) |
+
+The blocking step proves the load-bearing headless claim — that the Tier-0 VM
+backend is selected and dispatches input without focus steal — on every run.
+The tap/type assertions verify their *effect* by reading app state back through
+the native ax-bridge, which needs Simulator.app foregrounded and TCC
+Accessibility that GitHub-hosted runners do not grant; they are advisory until
+the result-readback is reworked off the ax-bridge (candidate: parse the live
+`Status:` Text node from the VM Service widget summary tree, so the readback
+uses the same transport as the input — tracked as a follow-up).
+
 ---
 
 ## 5. Environment Variables


### PR DESCRIPTION
## Summary
After #816 fixed the 35-min hang, the entire Flutter VM-Service live suite was left `continue-on-error` (advisory). That means a regression in the **load-bearing headless claim** — that Tier-0 `FlutterVMInputBackend` is selected and dispatches input without focus steal — would no longer fail CI. This restores a real blocking gate.

## Change
Split the single Flutter step into two:
- **Blocking** — ax-independent assertions that prove the thesis: `getInputBackend()` selects `FlutterVMInputBackend`, and `swipe` dispatches gesture-arena move events. No ax-bridge, no TCC needed → a regression here fails the job.
- **Advisory** (`continue-on-error`) — `tap`/`typeText`, which verify their *effect* by reading app state back through the ax-bridge (needs Simulator.app + TCC Accessibility, unavailable on GitHub-hosted runners).

Both keep `--forceExit` (the #816 hang fix).

Documented the verification matrix in `docs/headless-architecture.md`.

## Why not fully fix the ax-dependent readback now
Reading tap/type *effects* without the ax-bridge needs reworking the readback onto the VM Service widget tree (parse the live `Status:` Text node). That requires live-simulator iteration and is tracked as a follow-up — landing it blind would risk a half-working gate. This PR delivers the safe, high-confidence improvement (the ax-independent core becomes blocking) now.

## Verification
- YAML validates; `-t` filters match the four test names exactly.
- This PR touches `headless-smoke.yml`, so the **Headless Smoke workflow runs on the PR** — the new blocking step must come back green (these assertions already passed in prior runs).

Part of the reliability action plan (Workstream C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)