### PR TITLE
fix(ci): make publish workflow honest-green on main (idempotent + auth preflight)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,69 @@ jobs:
           test -f dist/index.js
           test -f dist/cli/index.js
           node dist/cli/index.js --help
-      - run: npm publish --provenance --access public
+
+      - name: Resolve package identity
+        id: pkg
+        run: |
+          set -euo pipefail
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved $NAME@$VERSION"
+
+      - name: Check if version already published (idempotency)
+        id: published
+        run: |
+          set -euo pipefail
+          # A tag re-push, a manual local publish, or a re-run must not fail the
+          # job: if the exact version is already on the registry, publishing is a
+          # no-op and the job should report honest green instead of npm's
+          # confusing E404 ("not in this registry") on the duplicate PUT.
+          if npm view "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}" version >/dev/null 2>&1; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }} is already published — skipping npm publish."
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+            echo "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }} not on registry yet — will publish."
+          fi
+
+      - name: Verify npm auth (preflight)
+        if: steps.published.outputs.already == 'false'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          # npm masks authorization failures on publish as an E404 ("not in this
+          # registry"), which previously made a broken/expired NPM_TOKEN look
+          # like a missing package. Fail here with an actionable message instead.
+          if ! WHO=$(npm whoami 2>/dev/null); then
+            echo "::error::NPM_TOKEN failed authentication (npm whoami). Rotate it: the secret must be an automation token with publish rights to ${{ steps.pkg.outputs.name }}."
+            exit 1
+          fi
+          echo "Authenticated to npm as ${WHO}"
+
+      - name: Publish to npm
+        if: steps.published.outputs.already == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+  notify:
+    # Surface publish failures the same way the sentinels do, so a broken
+    # release pipeline (e.g. an expired NPM_TOKEN) cannot sit red unnoticed.
+    needs: publish
+    if: failure()
+    uses: ./.github/workflows/_sentinel-notify.yml
+    with:
+      title: 'npm publish failed'
+      runner: 'macos-latest'
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      body: |
+        The Publish workflow failed for a pushed v* tag.
+        Common cause: NPM_TOKEN expired or lacks publish rights (npm reports
+        this as a misleading E404). Check the "Verify npm auth (preflight)"
+        and "Publish to npm" steps on the workflow run.
+      channel: ${{ vars.SENTINEL_CHANNEL || '#opensafari-sentinels' }}
+    secrets:
+      webhook-url: ${{ secrets.SENTINEL_WEBHOOK_URL }}


### PR DESCRIPTION
## Problem

The **Publish** check sits red on `main` (commit `50ba3751`, tag `v0.6.3`) even though `opensafari-mcp@0.6.3` shipped to npm.

Root cause: `0.6.3` was published to the registry at `04:24:16Z`, **before** the tag-triggered Publish run started (`04:25:39Z`). The CI step then issued a duplicate `npm publish`, which npm rejects with a **misleading `E404` ("not in this registry")** — the same code npm uses for auth failures. Every release since v0.6.0 has gone red this way.

## Fix

Port the publish-pipeline fix already on `develop` (`acfc08d3`, PR #817) to `main` so the release branch's own publish runs are honest-green:

- **Idempotency**: skip publish with success when `name@version` is already on the registry (covers re-pushed tags / manual pre-publish).
- **Auth preflight**: `npm whoami` check that fails with an actionable message instead of the masked `E404`.
- **Notify**: fan publish failures out through `_sentinel-notify` so a broken release pipeline can't sit red unnoticed.

Workflow-only change (`.github/workflows/publish.yml`); no product code touched, so `main` stays equal to released `0.6.3`. This is a hotfix directly to `main` because the Publish workflow only runs on `main`'s `v*` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)