### PR TITLE
Add stateful semantic mobile QA runtime foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ void main() {
 
 For debug/profile builds, `flutter_connect` + `flutter_widget_tree` additionally expose the Dart VM Service, which returns the full Flutter widget hierarchy (including render-tree nodes that never reach the native AX bridge).
 
-See [docs/troubleshooting.md](docs/troubleshooting.md) for common failure modes (empty trees, missing labels, Safari shadowing).
+See [docs/troubleshooting.md](docs/troubleshooting.md) for common failure modes (empty trees, missing labels, Safari shadowing). For stateful semantic mobile QA, selector quality, settle policy, and scenario v2 guidance, see [docs/mobile-semantic-qa.md](docs/mobile-semantic-qa.md).
 
 ---
 

--- a/docs/mobile-semantic-qa.md
+++ b/docs/mobile-semantic-qa.md
@@ -1,0 +1,48 @@
+# Mobile semantic QA runtime
+
+OpenSafari's mobile QA direction follows the SSOT in issue #795: portable MCP-native contracts, semantic actions over raw taps/relaunches, structured failures, and compact debugging evidence.
+
+## State snapshot before action
+
+Use `app_state_snapshot` when an agent needs to decide what to do next without mutating app state. The tool is read-only and reports:
+
+- foreground/context classification and confidence
+- expected bundle match
+- visible AX summary and screen fingerprint
+- Flutter VM connection and route hints when connected
+- best-effort WebView hints
+- recovery hints such as `app_switch_app`, `app_wait_for`, or `debug_bundle_collect`
+
+Do not use a relaunch/reset as the first recovery step. If the snapshot is unknown or transitional, wait for a postcondition or collect a debug bundle before destructive recovery.
+
+## Shared settle policy
+
+High-level semantic actions should separate transport success from app-state success. A tap, deeplink, or text injection is only successful when its postcondition is met and, when requested, stable for `stableMs`.
+
+The shared settle policy accepts AX query fields (`identifier`, `label`, `text`, `role`), condition (`exists`, `not_exists`, `visible`, `enabled`), `timeoutMs`, `intervalMs`, and `stableMs`.
+
+## Semantic navigation
+
+`app_goto_screen` now records state before/after, uses an already-on-target check when `waitFor` is supplied, dispatches deeplink navigation, and returns strategy/attempt/verification evidence. Relaunch/reset remains explicit opt-in work for higher-level callers and must not be treated as default navigation.
+
+## Flutter selector quality
+
+`qa_flutter_semantics` includes `selector_quality` by default. The report flags fragile automation selectors:
+
+- missing `Semantics(identifier: ...)` on interactive widgets
+- duplicate identifiers
+- duplicate labels
+- label-only selectors that may break across locales
+- missing role/trait hints
+
+Labels are still valuable for accessibility. The audit classifies risk for automation; it does not require removing human-readable labels.
+
+## Deterministic Flutter VM attach
+
+`flutter_connect` reports attach diagnostics that distinguish explicit URL, environment overrides, cached URL, fixed-port attempts, and log-scan fallback. For fast debug/profile QA sessions, prefer an explicit VM Service URL when available. Fixed-port mode can be used when the app is launched externally with a known VM service port and auth code.
+
+Release builds generally do not expose VM Service and should use native AX semantics plus selector-quality audits.
+
+## Scenario runner v2
+
+`run_scenario` accepts `version: 2` for currently implemented mobile semantic steps: `recordState`, `launchApp`, `gotoScreen`, `tapElement`, `typeElement`, `waitFor`, `assertElement`, and `collectDebugBundle`. V2 results include per-device state, backend hint, verification, timing, and partial-failure data. Existing v1 browser scenarios remain compatible. V2 starts from the current simulator state by design; use an explicit `launchApp` step only when a scenario needs to foreground an app.

--- a/src/orchestration/scenario-runner.ts
+++ b/src/orchestration/scenario-runner.ts
@@ -1,20 +1,36 @@
 import { SimulatorPool, PooledSimulator } from '../simulator/pool';
 import { ActionTraceRecorder } from '../observability/action-trace';
+import { collectAppSessionState } from '../tools/app-state-snapshot';
+import { waitForSettle, type SettlePolicy } from '../tools/settle-policy';
+import { SimulatorManager } from '../simulator';
+import { getAccessibilityBridge } from '../native';
+import { getInputBackend } from '../tools/native-input-utils';
+import { collectDebugBundle } from '../tools/debug-bundle-collect';
 
 export interface TestScenario {
   name: string;
   steps: TestStep[];
+  version?: 1 | 2;
   /** Optional JSON trace artifact path for action-level live-validation evidence. */
   tracePath?: string;
 }
 
 export interface TestStep {
-  action: 'navigate' | 'click' | 'type' | 'scroll' | 'wait' | 'assert' | 'screenshot';
+  action:
+    | 'navigate' | 'click' | 'type' | 'scroll' | 'wait' | 'assert' | 'screenshot'
+    | 'recordState' | 'launchApp' | 'gotoScreen' | 'tapElement' | 'typeElement'
+    | 'waitFor' | 'assertElement' | 'collectDebugBundle';
   target?: string;     // CSS selector
   value?: string;      // input value, URL, or scroll direction
   assertion?: string;  // JS expression for assert steps
   devices?: string[];  // subset of device presets (default: all)
   timeout?: number;    // step timeout in ms
+  bundleId?: string;
+  expectedBundleId?: string;
+  query?: SettlePolicy['query'];
+  settle?: SettlePolicy;
+  condition?: SettlePolicy['condition'];
+  context?: 'native' | 'webview' | 'safari' | 'flutter';
 }
 
 export interface StepResult {
@@ -29,6 +45,11 @@ export interface DeviceStepResult {
   deviceId: string;
   passed: boolean;
   result?: unknown;
+  beforeState?: unknown;
+  afterState?: unknown;
+  selectedBackend?: string;
+  headless?: boolean;
+  verification?: unknown;
   error?: string;
   timing: number;
 }
@@ -52,7 +73,7 @@ export class ScenarioRunner {
 
     for (let i = 0; i < scenario.steps.length; i++) {
       const step = scenario.steps[i];
-      const result = await this.executeStep(i, step);
+      const result = await this.executeStep(i, step, scenario.version === 2);
       for (const device of result.devices) {
         trace?.record({
           action: `${step.action}:${i}`,
@@ -91,7 +112,7 @@ export class ScenarioRunner {
     };
   }
 
-  private async executeStep(index: number, step: TestStep): Promise<StepResult> {
+  private async executeStep(index: number, step: TestStep, scenarioIsV2: boolean): Promise<StepResult> {
     // Get target simulators (filter by step.devices if specified, else all)
     const allSims = this.pool.getAll();
     const sims = step.devices
@@ -99,7 +120,7 @@ export class ScenarioRunner {
       : allSims;
 
     const deviceResults = await Promise.all(
-      sims.map(sim => this.executeOnDevice(sim, step))
+      sims.map(sim => this.executeOnDevice(sim, step, scenarioIsV2))
     );
 
     return {
@@ -110,10 +131,20 @@ export class ScenarioRunner {
     };
   }
 
-  private async executeOnDevice(sim: PooledSimulator, step: TestStep): Promise<DeviceStepResult> {
+  private async executeOnDevice(sim: PooledSimulator, step: TestStep, scenarioIsV2: boolean): Promise<DeviceStepResult> {
     const start = Date.now();
+    let beforeState: unknown;
+    let afterState: unknown;
+    let verification: unknown;
+    const isV2 = isMobileV2Step(step);
     try {
+      if (isV2 && !scenarioIsV2) {
+        throw new Error(`Scenario action "${step.action}" requires scenario.version === 2`);
+      }
       let result: unknown;
+      if (isV2) {
+        beforeState = await safeState(sim.device.udid, step.expectedBundleId ?? step.bundleId);
+      }
       switch (step.action) {
         case 'navigate':
           result = await sim.client.navigate({ url: step.value!, waitUntil: 'load', timeout: step.timeout });
@@ -150,6 +181,113 @@ export class ScenarioRunner {
           result = `screenshot:${buf.length}bytes`;
           break;
         }
+        case 'recordState': {
+          result = beforeState ?? await collectAppSessionState({
+            deviceId: sim.device.udid,
+            expectedBundleId: step.expectedBundleId ?? step.bundleId,
+          });
+          break;
+        }
+        case 'launchApp': {
+          if (!step.bundleId) throw new Error('launchApp requires bundleId');
+          await new SimulatorManager().launchApp(sim.device.udid, step.bundleId);
+          result = { launched: true, bundleId: step.bundleId };
+          break;
+        }
+        case 'gotoScreen': {
+          const postconditionQuery = step.settle?.query ?? step.query;
+          if (!postconditionQuery) {
+            throw new Error('gotoScreen requires a postcondition query');
+          }
+          if (step.value) {
+            await new SimulatorManager().openUrl(sim.device.udid, step.value);
+          }
+          {
+            verification = await waitForSettle(sim.device.udid, {
+              ...(step.settle ?? {}),
+              query: postconditionQuery,
+              condition: step.condition ?? step.settle?.condition ?? 'exists',
+              timeoutMs: step.timeout ?? step.settle?.timeoutMs,
+            });
+            if (!(verification as { met?: boolean }).met) {
+              throw new Error('gotoScreen postcondition was not met');
+            }
+          }
+          result = { strategy: step.value ? 'deeplink_postcondition' : 'state_only', value: step.value };
+          break;
+        }
+        case 'waitFor':
+        case 'assertElement': {
+          verification = await waitForSettle(sim.device.udid, {
+            ...(step.settle ?? {}),
+            query: step.settle?.query ?? step.query,
+            condition: step.condition ?? step.settle?.condition ?? 'exists',
+            timeoutMs: step.timeout ?? step.settle?.timeoutMs,
+          });
+          const met = Boolean((verification as { met?: boolean }).met);
+          if (!met) {
+            return {
+              device: sim.preset,
+              deviceId: sim.device.udid,
+              passed: false,
+              beforeState,
+              afterState: await safeState(sim.device.udid, step.expectedBundleId ?? step.bundleId),
+              selectedBackend: inferStepBackend(step),
+              headless: true,
+              verification,
+              error: `${step.action} postcondition was not met`,
+              timing: Date.now() - start,
+            };
+          }
+          result = verification;
+          break;
+        }
+        case 'tapElement': {
+          if (!step.query) throw new Error('tapElement requires query');
+          const bridge = getAccessibilityBridge();
+          const queryResult = await bridge.query(step.query, { deviceId: sim.device.udid, maxResults: 1 });
+          const match = queryResult.matches[0];
+          if (!match) throw new Error('tapElement query matched no elements');
+          const press = await bridge.press(match.path, sim.device.udid);
+          if (!press.ok) {
+            const backend = await getInputBackend(sim.device.udid, sim.client);
+            await backend.tap(
+              sim.device.udid,
+              match.frame.x + match.frame.width / 2,
+              match.frame.y + match.frame.height / 2,
+            );
+          }
+          if (step.settle?.query) {
+            verification = await waitForSettle(sim.device.udid, step.settle);
+            if (!(verification as { met?: boolean }).met) throw new Error('tapElement postcondition was not met');
+          }
+          result = { tapped: true, path: match.path, backend: press.ok ? 'ax-press' : 'input-backend' };
+          break;
+        }
+        case 'typeElement': {
+          if (!step.query) throw new Error('typeElement requires query');
+          if (step.value === undefined) throw new Error('typeElement requires value');
+          const bridge = getAccessibilityBridge();
+          const queryResult = await bridge.query(step.query, { deviceId: sim.device.udid, maxResults: 1 });
+          const match = queryResult.matches[0];
+          if (!match) throw new Error('typeElement query matched no elements');
+          await bridge.press(match.path, sim.device.udid).catch(() => undefined);
+          const backend = await getInputBackend(sim.device.udid, sim.client);
+          await backend.typeText(sim.device.udid, step.value);
+          if (step.settle?.query) {
+            verification = await waitForSettle(sim.device.udid, step.settle);
+            if (!(verification as { met?: boolean }).met) throw new Error('typeElement postcondition was not met');
+          }
+          result = { typed: true, path: match.path, length: step.value.length, backend: backend.kind };
+          break;
+        }
+        case 'collectDebugBundle': {
+          result = await collectDebugBundle({
+            deviceId: sim.device.udid,
+            bundleId: step.bundleId ?? step.expectedBundleId,
+          });
+          break;
+        }
         default:
           return {
             device: sim.preset,
@@ -159,11 +297,19 @@ export class ScenarioRunner {
             timing: Date.now() - start,
           };
       }
+      if (isV2) {
+        afterState = await safeState(sim.device.udid, step.expectedBundleId ?? step.bundleId);
+      }
       return {
         device: sim.preset,
         deviceId: sim.device.udid,
         passed: true,
         result,
+        beforeState,
+        afterState,
+        selectedBackend: isV2 ? inferStepBackend(step) : undefined,
+        headless: isV2 ? inferStepBackend(step) !== 'applescript' : undefined,
+        verification,
         timing: Date.now() - start,
       };
     } catch (err) {
@@ -171,9 +317,48 @@ export class ScenarioRunner {
         device: sim.preset,
         deviceId: sim.device.udid,
         passed: false,
+        beforeState,
+        afterState: isV2 ? await safeState(sim.device.udid, step.expectedBundleId ?? step.bundleId) : undefined,
+        selectedBackend: isV2 ? inferStepBackend(step) : undefined,
+        headless: isV2 ? inferStepBackend(step) !== 'applescript' : undefined,
+        verification,
         error: err instanceof Error ? err.message : String(err),
         timing: Date.now() - start,
       };
     }
+  }
+}
+
+function isMobileV2Step(step: TestStep): boolean {
+  return [
+    'recordState',
+    'launchApp',
+    'gotoScreen',
+    'tapElement',
+    'typeElement',
+    'waitFor',
+    'assertElement',
+    'collectDebugBundle',
+  ].includes(step.action);
+}
+
+
+function inferStepBackend(step: TestStep): string {
+  if (step.context === 'webview' || step.context === 'safari') return 'webkit';
+  if (step.context === 'flutter') return 'flutter-vm';
+  if (['waitFor', 'assertElement', 'recordState'].includes(step.action)) return 'ax';
+  return 'semantic-mobile';
+}
+
+async function safeState(deviceId: string, expectedBundleId?: string): Promise<unknown> {
+  try {
+    return await collectAppSessionState({
+      deviceId,
+      expectedBundleId,
+      includeFlutter: true,
+      maxVisibleNodes: 10,
+    });
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/orchestration/scenario-runner.ts
+++ b/src/orchestration/scenario-runner.ts
@@ -244,41 +244,51 @@ export class ScenarioRunner {
         }
         case 'tapElement': {
           if (!step.query) throw new Error('tapElement requires query');
+          if (!step.settle?.query) throw new Error('tapElement requires a settle.query postcondition');
           const bridge = getAccessibilityBridge();
           const queryResult = await bridge.query(step.query, { deviceId: sim.device.udid, maxResults: 1 });
           const match = queryResult.matches[0];
           if (!match) throw new Error('tapElement query matched no elements');
-          const press = await bridge.press(match.path, sim.device.udid);
+          let press: { ok: boolean; error?: string };
+          try {
+            press = await bridge.press(match.path, sim.device.udid);
+          } catch (err) {
+            press = { ok: false, error: err instanceof Error ? err.message : String(err) };
+          }
+          let backend = 'ax-press';
           if (!press.ok) {
-            const backend = await getInputBackend(sim.device.udid, sim.client);
-            await backend.tap(
+            const inputBackend = await getInputBackend(sim.device.udid, sim.client);
+            await inputBackend.tap(
               sim.device.udid,
               match.frame.x + match.frame.width / 2,
               match.frame.y + match.frame.height / 2,
             );
+            backend = inputBackend.kind;
           }
-          if (step.settle?.query) {
-            verification = await waitForSettle(sim.device.udid, step.settle);
-            if (!(verification as { met?: boolean }).met) throw new Error('tapElement postcondition was not met');
-          }
-          result = { tapped: true, path: match.path, backend: press.ok ? 'ax-press' : 'input-backend' };
+          verification = await waitForSettle(sim.device.udid, step.settle);
+          if (!(verification as { met?: boolean }).met) throw new Error('tapElement postcondition was not met');
+          result = { tapped: true, path: match.path, backend, axPress: press };
           break;
         }
         case 'typeElement': {
           if (!step.query) throw new Error('typeElement requires query');
           if (step.value === undefined) throw new Error('typeElement requires value');
+          if (!step.settle?.query) throw new Error('typeElement requires a settle.query postcondition');
           const bridge = getAccessibilityBridge();
           const queryResult = await bridge.query(step.query, { deviceId: sim.device.udid, maxResults: 1 });
           const match = queryResult.matches[0];
           if (!match) throw new Error('typeElement query matched no elements');
-          await bridge.press(match.path, sim.device.udid).catch(() => undefined);
+          let focus: { ok: boolean; error?: string };
+          try {
+            focus = await bridge.press(match.path, sim.device.udid);
+          } catch (err) {
+            focus = { ok: false, error: err instanceof Error ? err.message : String(err) };
+          }
           const backend = await getInputBackend(sim.device.udid, sim.client);
           await backend.typeText(sim.device.udid, step.value);
-          if (step.settle?.query) {
-            verification = await waitForSettle(sim.device.udid, step.settle);
-            if (!(verification as { met?: boolean }).met) throw new Error('typeElement postcondition was not met');
-          }
-          result = { typed: true, path: match.path, length: step.value.length, backend: backend.kind };
+          verification = await waitForSettle(sim.device.udid, step.settle);
+          if (!(verification as { met?: boolean }).met) throw new Error('typeElement postcondition was not met');
+          result = { typed: true, path: match.path, length: step.value.length, backend: backend.kind, focus };
           break;
         }
         case 'collectDebugBundle': {

--- a/src/tools/app-goto-screen.ts
+++ b/src/tools/app-goto-screen.ts
@@ -11,8 +11,8 @@
  *                   openurl`. Callers can mint this from
  *                   `app_list_routes` (#779) if they need to discover
  *                   what's supported.
- *   waitFor       — optional. After the openurl succeeds, poll the AX
- *                   tree until an element matching this label /
+ *   waitFor       — required postcondition. After the openurl succeeds,
+ *                   poll the AX tree until an element matching this label /
  *                   identifier appears. Default timeout 5000 ms.
  *
  * On failure the response uses StructuredErrorException's MCP shape so
@@ -25,12 +25,14 @@ import { promisify } from 'util';
 import { MCPServer } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
 import { SimulatorManager } from '../simulator';
-import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import { ensureSemanticsActive } from '../native';
 import { ErrorCode, respondWithStructuredError } from '../errors';
 import {
   wrapHandlerForBundle,
   COLLECT_DEBUG_BUNDLE_ON_FAILURE_SCHEMA,
 } from './debug-bundle-attach';
+import { collectAppSessionState } from './app-state-snapshot';
+import { waitForSettle } from './settle-policy';
 
 const execFileAsync = promisify(execFile);
 
@@ -53,37 +55,7 @@ interface WaitForSpec {
   role?: string;
   text?: string;
   timeoutMs?: number;
-}
-
-async function waitForElement(
-  deviceId: string,
-  spec: WaitForSpec,
-): Promise<{ matched: boolean; elapsedMs: number; matchCount: number }> {
-  const bridge = getAccessibilityBridge();
-  const deadline = Date.now() + (spec.timeoutMs ?? 5000);
-  const start = Date.now();
-  const query = {
-    identifier: spec.identifier,
-    label: spec.label,
-    text: spec.text,
-    role: spec.role,
-  };
-  while (Date.now() < deadline) {
-    try {
-      const result = await bridge.query(query, { deviceId });
-      if (result.matches.length > 0) {
-        return {
-          matched: true,
-          elapsedMs: Date.now() - start,
-          matchCount: result.matches.length,
-        };
-      }
-    } catch {
-      // best-effort; loop will retry until deadline
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  return { matched: false, elapsedMs: Date.now() - start, matchCount: 0 };
+  stableMs?: number;
 }
 
 export function registerAppGotoScreenTool(server: MCPServer): void {
@@ -91,7 +63,7 @@ export function registerAppGotoScreenTool(server: MCPServer): void {
     {
       name: 'app_goto_screen',
       description:
-        'High-level "take me to this screen" macro. Dispatches a deeplink via simctl openurl, then optionally polls the AX tree until a verification element appears. Collapses the common app_deeplink → app_wait_for sequence into a single call.',
+        'High-level "take me to this screen" macro. Dispatches a deeplink via simctl openurl, then requires a waitFor postcondition to verify the target screen before reporting success. Collapses the common app_deeplink → app_wait_for sequence into a single call.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -99,20 +71,21 @@ export function registerAppGotoScreenTool(server: MCPServer): void {
           waitFor: {
             type: 'object',
             description:
-              'Optional post-condition. The tool polls the AX tree until at least one node matches the supplied label / identifier / text / role, or the timeout fires.',
+              'Required postcondition. The tool polls the AX tree until at least one node matches the supplied label / identifier / text / role, or the timeout fires. Dispatch-only deeplink calls are rejected as unverified.',
             properties: {
               label: { type: 'string' },
               identifier: { type: 'string' },
               text: { type: 'string' },
               role: { type: 'string' },
               timeoutMs: { type: 'number', description: 'Poll timeout (default 5000)' },
+              stableMs: { type: 'number', description: 'Require the postcondition to hold continuously for this many ms before success.' },
             },
           },
           bundleId: { type: 'string', description: 'Target app bundle ID (forces ensureSemanticsActive scope)' },
           deviceId: { type: 'string' },
           collectDebugBundleOnFailure: COLLECT_DEBUG_BUNDLE_ON_FAILURE_SCHEMA,
         },
-        required: ['url'],
+        required: ['url', 'waitFor'],
       },
     },
     wrapHandlerForBundle('app_goto_screen', async (_sessionId: string, params: Record<string, unknown>) => {
@@ -121,20 +94,25 @@ export function registerAppGotoScreenTool(server: MCPServer): void {
         return respondWithStructuredError(ErrorCode.INVALID_URL, 'url must include a scheme');
       }
 
+      const waitForSpec = params.waitFor as WaitForSpec | undefined;
+      if (!waitForSpec) {
+        return respondWithStructuredError(
+          ErrorCode.INVALID_INPUT,
+          'waitFor postcondition is required for app_goto_screen success; dispatch-only deeplinks are intentionally unverified',
+          { url },
+        );
+      }
+      if (!hasWaitForSignal(waitForSpec)) {
+        return respondWithStructuredError(
+          ErrorCode.INVALID_INPUT,
+          'waitFor requires at least one of identifier, label, text, or role',
+          { waitFor: waitForSpec },
+        );
+      }
+
       const deviceId = await resolveDeviceId(params.deviceId as string | undefined);
       if (!deviceId) {
         return respondWithStructuredError(ErrorCode.DEVICE_NOT_BOOTED, 'No booted simulator found');
-      }
-
-      // Dispatch the deeplink. We shell out directly rather than calling
-      // the app_deeplink handler so this tool is a pure composition
-      // (no MCP transport indirection).
-      const openedAt = Date.now();
-      try {
-        await execFileAsync('xcrun', ['simctl', 'openurl', deviceId, url]);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return respondWithStructuredError(ErrorCode.FLUTTER_EVAL_FAILED, message, { url, deviceId });
       }
 
       // Make sure semantics are active before we start polling.
@@ -145,36 +123,166 @@ export function registerAppGotoScreenTool(server: MCPServer): void {
         // Continue — the poll loop tolerates AX errors as transient.
       }
 
-      const waitForSpec = params.waitFor as WaitForSpec | undefined;
-      if (!waitForSpec) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              navigated: true,
-              url,
-              deviceId,
-              openedAt: new Date(openedAt).toISOString(),
-              waitFor: null,
-            }),
-          }],
-        };
+      const attempts: Array<{
+        strategy: string;
+        elapsedMs: number;
+        ok: boolean;
+        skipped?: boolean;
+        skipReason?: string;
+        verification?: unknown;
+        error?: string;
+      }> = [];
+
+      let beforeState: unknown;
+      try {
+        beforeState = await collectAppSessionState({
+          deviceId,
+          expectedBundleId: bundleId,
+          includeFlutter: true,
+          maxVisibleNodes: 12,
+        });
+      } catch (err) {
+        attempts.push({
+          strategy: 'state_snapshot',
+          elapsedMs: 0,
+          ok: false,
+          skipped: true,
+          skipReason: err instanceof Error ? err.message : String(err),
+        });
       }
 
-      const verdict = await waitForElement(deviceId, waitForSpec);
+      if (waitForSpec) {
+        const alreadyStart = Date.now();
+        try {
+          const pre = await waitForSettle(deviceId, {
+            query: {
+              identifier: waitForSpec.identifier,
+              label: waitForSpec.label,
+              text: waitForSpec.text,
+              role: waitForSpec.role,
+            },
+            condition: 'exists',
+            timeoutMs: 250,
+            intervalMs: 100,
+            stableMs: 0,
+            allowTransientErrors: true,
+            maxRecoverableRetries: 1,
+          });
+          attempts.push({
+            strategy: 'already_on_target',
+            elapsedMs: Date.now() - alreadyStart,
+            ok: pre.met,
+            verification: pre,
+          });
+          if (pre.met) {
+            return {
+              content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                  navigated: false,
+                  strategy: 'already_on_target',
+                  url,
+                  deviceId,
+                  beforeState,
+                  afterState: beforeState,
+                  attempts,
+                  waitFor: { ...waitForSpec, matched: true, elapsedMs: pre.elapsedMs, matchCount: pre.matchingCount },
+                  verification: pre,
+                }, null, 2),
+              }],
+            };
+          }
+        } catch (err) {
+          attempts.push({
+            strategy: 'already_on_target',
+            elapsedMs: Date.now() - alreadyStart,
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      // Dispatch the deeplink only after the non-mutating already-on-target
+      // check has failed. This preserves the semantic navigation contract:
+      // when the requested postcondition is already true, the tool returns
+      // without perturbing the app state.
+      const openedAt = Date.now();
+      try {
+        await execFileAsync('xcrun', ['simctl', 'openurl', deviceId, url]);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        attempts.push({
+          strategy: 'deeplink',
+          elapsedMs: Date.now() - openedAt,
+          ok: false,
+          error: message,
+        });
+        return respondWithStructuredError(ErrorCode.FLUTTER_EVAL_FAILED, message, {
+          url,
+          deviceId,
+          beforeState,
+          attempts,
+        });
+      }
+
+      const verifyStart = Date.now();
+      let verification: unknown;
+      let verdict: { matched: boolean; elapsedMs: number; matchCount: number };
+      const settle = await waitForSettle(deviceId, {
+        query: {
+          identifier: waitForSpec.identifier,
+          label: waitForSpec.label,
+          text: waitForSpec.text,
+          role: waitForSpec.role,
+        },
+        condition: 'exists',
+        timeoutMs: waitForSpec.timeoutMs ?? 5000,
+        intervalMs: 250,
+        stableMs: waitForSpec.stableMs ?? 0,
+        allowTransientErrors: true,
+        maxRecoverableRetries: 3,
+      });
+      verification = settle;
+      verdict = { matched: settle.met, elapsedMs: settle.elapsedMs, matchCount: settle.matchingCount };
+      attempts.push({
+        strategy: 'deeplink_postcondition',
+        elapsedMs: Date.now() - verifyStart,
+        ok: settle.met,
+        verification: settle,
+      });
+      let afterState: unknown;
+      try {
+        afterState = await collectAppSessionState({
+          deviceId,
+          expectedBundleId: bundleId,
+          includeFlutter: true,
+          maxVisibleNodes: 12,
+        });
+      } catch {
+        afterState = undefined;
+      }
       return {
         content: [{
           type: 'text' as const,
           text: JSON.stringify({
             navigated: true,
+            strategy: 'deeplink',
             url,
             deviceId,
             openedAt: new Date(openedAt).toISOString(),
+            beforeState,
+            afterState,
+            attempts,
             waitFor: { ...waitForSpec, ...verdict },
-          }),
+            verification,
+          }, null, 2),
         }],
         isError: !verdict.matched,
       };
     }),
   );
+}
+
+function hasWaitForSignal(spec: WaitForSpec): boolean {
+  return Boolean(spec.identifier || spec.label || spec.text || spec.role);
 }

--- a/src/tools/app-state-snapshot.ts
+++ b/src/tools/app-state-snapshot.ts
@@ -77,6 +77,16 @@ export interface AppStateSnapshotOptions {
   maxDepth?: number;
 }
 
+export class AppStateSnapshotError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ErrorCode,
+  ) {
+    super(message);
+    this.name = 'AppStateSnapshotError';
+  }
+}
+
 export async function collectAppSessionState(
   options: AppStateSnapshotOptions = {},
 ): Promise<AppSessionState> {
@@ -87,7 +97,10 @@ export async function collectAppSessionState(
     getSessionManager().getSoleDeviceId() ??
     booted[0]?.udid;
   if (!deviceId) {
-    throw new Error('No booted simulator found. Call device_boot first or pass deviceId.');
+    throw new AppStateSnapshotError(
+      'No booted simulator found. Call device_boot first or pass deviceId.',
+      ErrorCode.DEVICE_NOT_BOOTED,
+    );
   }
 
   const device = booted.find((d) => d.udid === deviceId);
@@ -330,8 +343,11 @@ export function registerAppStateSnapshotTool(server: MCPServer): void {
         });
         return { content: [{ type: 'text' as const, text: JSON.stringify(snapshot, null, 2) }] };
       } catch (err) {
+        const code = err instanceof AppStateSnapshotError
+          ? err.code
+          : ErrorCode.APP_STATE_UNKNOWN;
         return respondWithStructuredError(
-          ErrorCode.DEVICE_NOT_BOOTED,
+          code,
           err instanceof Error ? err.message : String(err),
         );
       }

--- a/src/tools/app-state-snapshot.ts
+++ b/src/tools/app-state-snapshot.ts
@@ -1,0 +1,340 @@
+import { MCPServer } from '../mcp-server';
+import { getAccessibilityBridge } from '../native';
+import type { AXNode } from '../native';
+import { getSessionManager } from '../session-manager';
+import { SimulatorManager } from '../simulator';
+import { getFlutterVMClient } from '../flutter';
+import { ErrorCode, respondWithStructuredError } from '../errors';
+import { classifyMobileContext } from './mobile-context';
+import { probeToRawMobileContext, type RawMobileClassification } from './raw-mobile-context';
+
+export interface VisibleNodeSummary {
+  role?: string;
+  label?: string;
+  identifier?: string;
+  text?: string;
+  path?: string;
+}
+
+export interface AppSessionState {
+  schemaVersion: '1';
+  collectedAt: string;
+  device: {
+    id: string;
+    name?: string;
+    booted?: boolean;
+  };
+  app: {
+    expectedBundleId?: string;
+    inferredForegroundBundleId?: string;
+    expectedBundleMatched?: boolean;
+    contextVerified: boolean;
+    classification: RawMobileClassification;
+    reason: string;
+    warnings: string[];
+  };
+  flutter?: {
+    vmConnected: boolean;
+    route?: string | null;
+    routeSource?: string;
+    semanticsActive?: boolean;
+    dartVersion?: string;
+    mainIsolateId?: string;
+  };
+  webview?: {
+    available: boolean;
+    connected?: boolean;
+    targetCount?: number;
+    classificationHint?: string;
+  };
+  ui: {
+    visibleSummary: VisibleNodeSummary[];
+    screenFingerprint?: string;
+    keyboardVisible?: boolean;
+    modalHints: string[];
+    alertHints: string[];
+    overlayHints: string[];
+  };
+  backend?: {
+    selected?: string;
+    headless?: boolean;
+    availableBackends?: string[];
+  };
+  confidence: 'verified' | 'heuristic' | 'unknown';
+  recoveryHints: Array<{
+    action: string;
+    reason: string;
+    destructive: boolean;
+  }>;
+}
+
+export interface AppStateSnapshotOptions {
+  deviceId?: string;
+  expectedBundleId?: string;
+  includeFlutter?: boolean;
+  includeWebView?: boolean;
+  maxVisibleNodes?: number;
+  maxDepth?: number;
+}
+
+export async function collectAppSessionState(
+  options: AppStateSnapshotOptions = {},
+): Promise<AppSessionState> {
+  const manager = new SimulatorManager();
+  const booted = await manager.listBooted();
+  const deviceId =
+    options.deviceId ??
+    getSessionManager().getSoleDeviceId() ??
+    booted[0]?.udid;
+  if (!deviceId) {
+    throw new Error('No booted simulator found. Call device_boot first or pass deviceId.');
+  }
+
+  const device = booted.find((d) => d.udid === deviceId);
+  const bridge = getAccessibilityBridge();
+  const tree = await bridge.dumpTree({
+    deviceId,
+    maxDepth: options.maxDepth ?? 8,
+  });
+  const runningApps = (await manager.listRunningApps(deviceId)).map((app) => ({
+    bundleId: app.label,
+    pid: app.pid,
+  }));
+  const probe = classifyMobileContext({
+    deviceId,
+    tree,
+    runningApps,
+    expectedBundle: options.expectedBundleId,
+  });
+  const raw = probeToRawMobileContext(probe);
+  const visibleSummary = collectVisibleNodes(tree, options.maxVisibleNodes ?? 20);
+  const confidence = confidenceFromProbe(probe.expectedBundleMatchConfidence, raw.verified);
+
+  const state: AppSessionState = {
+    schemaVersion: '1',
+    collectedAt: new Date().toISOString(),
+    device: {
+      id: deviceId,
+      name: device?.name,
+      booted: Boolean(device),
+    },
+    app: {
+      expectedBundleId: options.expectedBundleId,
+      inferredForegroundBundleId: raw.frontmost.bundleId,
+      expectedBundleMatched: raw.expectedBundleMatched,
+      contextVerified: raw.contextVerified,
+      classification: raw.classification,
+      reason: raw.reason,
+      warnings: raw.warnings,
+    },
+    ui: {
+      visibleSummary,
+      screenFingerprint: fingerprintVisibleNodes(visibleSummary),
+      keyboardVisible: visibleSummary.some((n) => /keyboard/i.test(`${n.role ?? ''} ${n.label ?? ''} ${n.identifier ?? ''}`)),
+      modalHints: visibleSummary.filter((n) => /sheet|dialog|modal/i.test(`${n.role ?? ''} ${n.label ?? ''}`)).map(nodeLabel).filter(Boolean),
+      alertHints: visibleSummary.filter((n) => /alert|permission|allow|deny/i.test(`${n.role ?? ''} ${n.label ?? ''}`)).map(nodeLabel).filter(Boolean),
+      overlayHints: visibleSummary.filter((n) => /close|dismiss|cancel|back/i.test(`${n.label ?? ''} ${n.identifier ?? ''}`)).map(nodeLabel).filter(Boolean),
+    },
+    backend: {
+      availableBackends: inferAvailableBackends(options.includeFlutter !== false, deviceId),
+    },
+    confidence,
+    recoveryHints: buildRecoveryHints(raw.classification, raw.expectedBundleMatched),
+  };
+
+  if (options.includeFlutter !== false) {
+    state.flutter = await collectFlutterState(deviceId);
+  }
+
+  if (options.includeWebView) {
+    state.webview = {
+      available: visibleSummary.some((n) => /web/i.test(`${n.role ?? ''} ${n.label ?? ''} ${n.identifier ?? ''}`)),
+      classificationHint: 'best_effort_ax_summary',
+    };
+  }
+
+  return state;
+}
+
+async function collectFlutterState(deviceId: string): Promise<AppSessionState['flutter']> {
+  const client = getFlutterVMClient(deviceId);
+  if (!client.isConnected()) return { vmConnected: false };
+  const state = client.getState();
+  let route: string | null | undefined;
+  let routeSource: string | undefined;
+  try {
+    const raw = await client.evaluate(ROUTE_EXPRESSION);
+    const value = (raw as { valueAsString?: string }).valueAsString ?? '';
+    const parsed = parseRoutePayload(value);
+    route = parsed.name;
+    routeSource = parsed.source;
+  } catch {
+    route = undefined;
+    routeSource = 'unavailable';
+  }
+  return {
+    vmConnected: true,
+    route,
+    routeSource,
+    dartVersion: state?.dartVersionString,
+    mainIsolateId: state?.mainIsolateId,
+  };
+}
+
+function collectVisibleNodes(node: AXNode, limit: number): VisibleNodeSummary[] {
+  const out: VisibleNodeSummary[] = [];
+  function walk(n: AXNode): void {
+    if (out.length >= limit) return;
+    const text = n.value ?? n.label;
+    if (n.visible && (n.role || n.label || n.identifier || text)) {
+      out.push({
+        role: n.role,
+        label: n.label,
+        identifier: n.identifier,
+        text,
+        path: n.path,
+      });
+    }
+    for (const child of n.children ?? []) walk(child);
+  }
+  walk(node);
+  return out;
+}
+
+function fingerprintVisibleNodes(nodes: VisibleNodeSummary[]): string {
+  const basis = nodes
+    .map((n) => `${n.role ?? ''}:${n.identifier ?? ''}:${n.label ?? ''}:${n.text ?? ''}`)
+    .join('|');
+  let hash = 0;
+  for (let i = 0; i < basis.length; i++) {
+    hash = ((hash << 5) - hash + basis.charCodeAt(i)) | 0;
+  }
+  return `ax-${Math.abs(hash).toString(36)}`;
+}
+
+function nodeLabel(node: VisibleNodeSummary): string {
+  return node.identifier ?? node.label ?? node.text ?? node.role ?? '';
+}
+
+function confidenceFromProbe(
+  matchConfidence: 'verified' | 'heuristic' | 'unknown' | undefined,
+  rawVerified: boolean,
+): 'verified' | 'heuristic' | 'unknown' {
+  if (matchConfidence === 'verified' || rawVerified) return 'verified';
+  if (matchConfidence === 'heuristic') return 'heuristic';
+  return 'unknown';
+}
+
+function buildRecoveryHints(
+  classification: RawMobileClassification,
+  expectedBundleMatched?: boolean,
+): AppSessionState['recoveryHints'] {
+  const hints: AppSessionState['recoveryHints'] = [];
+  if (classification === 'SPRINGBOARD_FOREGROUND' || expectedBundleMatched === false) {
+    hints.push({
+      action: 'app_switch_app',
+      reason: 'Expected app is not confidently foregrounded.',
+      destructive: false,
+    });
+  }
+  if (classification === 'TRANSITIONAL_STATE_TIMEOUT' || classification === 'FOREGROUND_CONTEXT_UNAVAILABLE') {
+    hints.push({
+      action: 'app_wait_for',
+      reason: 'Foreground context is unavailable or still transitioning; wait for a stable postcondition.',
+      destructive: false,
+    });
+  }
+  hints.push({
+    action: 'debug_bundle_collect',
+    reason: 'Collect compact local evidence before destructive recovery such as relaunch/reset.',
+    destructive: false,
+  });
+  return hints;
+}
+
+function inferAvailableBackends(includeFlutter: boolean, deviceId: string): string[] {
+  const backends = ['ax'];
+  if (includeFlutter && getFlutterVMClient(deviceId).isConnected()) backends.push('flutter-vm');
+  backends.push('simctl');
+  return backends;
+}
+
+const ROUTE_EXPRESSION = `
+(() {
+  try {
+    final binding = WidgetsBinding.instance;
+    final root = binding.rootElement;
+    if (root == null) return 'opensafari_route:{"name":null,"source":"no_root"}';
+    String? name;
+    void visit(Element el) {
+      if (name != null) return;
+      final type = el.widget.runtimeType.toString();
+      if (type == '_ModalScopeStatus') {
+        final s = el.toString();
+        final match = RegExp(r'name:\\s*"([^"]+)"').firstMatch(s)
+            ?? RegExp(r"name:\\s*'([^']+)'").firstMatch(s)
+            ?? RegExp(r'RouteSettings\\("([^"]+)"').firstMatch(s);
+        if (match != null) name = match.group(1);
+      }
+      el.visitChildren(visit);
+    }
+    visit(root);
+    return name == null
+        ? 'opensafari_route:{"name":null,"source":"unknown"}'
+        : 'opensafari_route:{"name":"' + name! + '","source":"modal_route"}';
+  } catch (e) {
+    return 'opensafari_route:{"name":null,"source":"error"}';
+  }
+})()
+`.replace(/\s+/g, ' ').trim();
+
+function parseRoutePayload(raw: string): { name: string | null; source: string } {
+  const prefix = 'opensafari_route:';
+  const idx = raw.indexOf(prefix);
+  if (idx < 0) return { name: null, source: 'unknown' };
+  try {
+    return JSON.parse(raw.slice(idx + prefix.length)) as { name: string | null; source: string };
+  } catch {
+    return { name: null, source: 'unknown' };
+  }
+}
+
+export function registerAppStateSnapshotTool(server: MCPServer): void {
+  server.registerTool(
+    {
+      name: 'app_state_snapshot',
+      description:
+        'Read-only mobile QA state snapshot: foreground context, visible AX summary, Flutter VM/route hints, confidence, and recovery hints. Does not launch, relaunch, tap, or mutate app state.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          deviceId: { type: 'string', description: 'Simulator UDID (defaults to active/sole booted device)' },
+          expectedBundleId: { type: 'string', description: 'Expected foreground bundle id for match/confidence hints' },
+          includeFlutter: { type: 'boolean', description: 'Include Flutter VM/route hints when connected (default true)' },
+          includeWebView: { type: 'boolean', description: 'Include best-effort WebView availability hints (default false)' },
+          maxVisibleNodes: { type: 'number', description: 'Maximum visible AX nodes in compact summary (default 20)' },
+          maxDepth: { type: 'number', description: 'AX tree dump depth for classification (default 8)' },
+        },
+        required: [],
+      },
+    },
+    async (_sessionId: string, params: Record<string, unknown>) => {
+      try {
+        const snapshot = await collectAppSessionState({
+          deviceId: params.deviceId as string | undefined,
+          expectedBundleId: params.expectedBundleId as string | undefined,
+          includeFlutter: params.includeFlutter as boolean | undefined,
+          includeWebView: params.includeWebView as boolean | undefined,
+          maxVisibleNodes: params.maxVisibleNodes as number | undefined,
+          maxDepth: params.maxDepth as number | undefined,
+        });
+        return { content: [{ type: 'text' as const, text: JSON.stringify(snapshot, null, 2) }] };
+      } catch (err) {
+        return respondWithStructuredError(
+          ErrorCode.DEVICE_NOT_BOOTED,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    },
+  );
+}

--- a/src/tools/flutter-connect.ts
+++ b/src/tools/flutter-connect.ts
@@ -9,6 +9,12 @@ import { MCPServer } from '../mcp-server';
 import { getFlutterVMClient } from '../flutter';
 import { getSessionManager } from '../session-manager';
 import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
+import {
+  getCachedVMServiceUrl,
+  isValidVMServiceUrl,
+  probeVMServiceUrl,
+  wsToHttpUrl,
+} from '../flutter/vm-service-discovery';
 
 export function registerFlutterConnectTool(server: MCPServer): void {
   server.registerTool(
@@ -38,6 +44,14 @@ export function registerFlutterConnectTool(server: MCPServer): void {
             type: 'number',
             description: 'Discovery timeout in ms (default: 10000)',
           },
+          vm_service_port: {
+            type: 'number',
+            description: 'Optional deterministic local VM Service port. Requires vm_service_auth_code when the VM service uses an auth token.',
+          },
+          vm_service_auth_code: {
+            type: 'string',
+            description: 'Optional VM Service auth code for vm_service_port (e.g. abc=).',
+          },
         },
         required: [],
       },
@@ -52,15 +66,25 @@ export function registerFlutterConnectTool(server: MCPServer): void {
         }
 
         const client = getFlutterVMClient(deviceId);
+        const attachDiagnostics = await buildAttachDiagnostics({
+          explicitUrl: params.vm_service_url as string | undefined,
+          port: params.vm_service_port as number | undefined,
+          authCode: params.vm_service_auth_code as string | undefined,
+          deviceId,
+        });
 
         // Disconnect existing connection if any
         if (client.isConnected()) {
           await client.disconnect();
         }
 
+        const vmServiceUrl =
+          (params.vm_service_url as string | undefined) ??
+          attachDiagnostics.fixedPortUrl;
+
         const state = await client.connect({
           deviceId,
-          vmServiceUrl: params.vm_service_url as string | undefined,
+          vmServiceUrl,
           bundleId: params.bundle_id as string | undefined,
           timeout: params.timeout as number | undefined,
         });
@@ -70,9 +94,12 @@ export function registerFlutterConnectTool(server: MCPServer): void {
             type: 'text' as const,
             text: JSON.stringify({
               status: 'connected',
-              vmServiceUrl: state.httpUrl,
-              wsUrl: state.wsUrl,
+              vmServiceUrl: redactVmServiceUrl(state.httpUrl),
+              wsUrl: redactVmServiceUrl(state.wsUrl),
               deviceId: state.deviceId,
+              attachDiagnostics: {
+                attempts: attachDiagnostics.attempts,
+              },
               vm: state.vmInfo ? {
                 name: state.vmInfo.name,
                 version: state.vmInfo.version,
@@ -86,10 +113,130 @@ export function registerFlutterConnectTool(server: MCPServer): void {
           }],
         };
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = redactVmServiceUrl(err instanceof Error ? err.message : String(err)) ?? '';
         console.error(`[flutter_connect] ${message}`);
-        return respondWithStructuredError(ErrorCode.FLUTTER_VM_NOT_CONNECTED, message);
+        return respondWithStructuredError(ErrorCode.FLUTTER_VM_NOT_CONNECTED, message, {
+          attachDiagnostics: buildStaticAttachDiagnostics(params),
+        });
       }
+    },
+  );
+}
+
+interface AttachAttempt {
+  source: 'explicit_url' | 'env_http_url' | 'env_ws_url' | 'cache' | 'fixed_port' | 'log_scan';
+  url?: string;
+  valid?: boolean;
+  reachable?: boolean;
+  selected?: boolean;
+  reason?: string;
+}
+
+async function buildAttachDiagnostics(args: {
+  explicitUrl?: string;
+  port?: number;
+  authCode?: string;
+  deviceId: string;
+}): Promise<{ attempts: AttachAttempt[]; fixedPortUrl?: string; cachedUrl?: string }> {
+  const attempts: AttachAttempt[] = [];
+
+  if (args.explicitUrl) {
+    attempts.push({
+      source: 'explicit_url',
+      url: redactVmServiceUrl(args.explicitUrl),
+      valid: isValidVMServiceUrl(args.explicitUrl),
+      selected: true,
+    });
+  }
+
+  const envHttp = process.env.OPENSAFARI_VM_SERVICE_URL;
+  if (envHttp) {
+    attempts.push({
+      source: 'env_http_url',
+      url: redactVmServiceUrl(envHttp),
+      valid: isValidVMServiceUrl(envHttp),
+      selected: !args.explicitUrl,
+    });
+  }
+
+  const envWs = process.env.OPENSAFARI_VM_SERVICE_WS_URL;
+  if (envWs) {
+    const normalized = wsToHttpUrl(envWs);
+    attempts.push({
+      source: 'env_ws_url',
+      url: redactVmServiceUrl(normalized),
+      valid: isValidVMServiceUrl(normalized),
+      selected: !args.explicitUrl && !envHttp,
+    });
+  }
+
+  const cached = getCachedVMServiceUrl(args.deviceId);
+  if (cached) {
+    attempts.push({
+      source: 'cache',
+      url: redactVmServiceUrl(cached),
+      valid: isValidVMServiceUrl(cached),
+      reachable: await probeVMServiceUrl(cached).catch(() => false),
+      selected: !args.explicitUrl && !envHttp && !envWs,
+    });
+  }
+
+  let fixedPortUrl: string | undefined;
+  if (Number.isFinite(args.port)) {
+    const token = args.authCode ? `${args.authCode.replace(/\/$/, '')}/` : '';
+    fixedPortUrl = `http://127.0.0.1:${Math.floor(args.port as number)}/${token}`;
+    attempts.push({
+      source: 'fixed_port',
+      url: redactVmServiceUrl(fixedPortUrl),
+      valid: isValidVMServiceUrl(fixedPortUrl),
+      reachable: await probeVMServiceUrl(fixedPortUrl).catch(() => false),
+      selected: !args.explicitUrl && !envHttp && !envWs && !cached,
+      reason: args.authCode
+        ? 'Fixed port with caller-supplied auth code.'
+        : 'Fixed port without auth code; valid only when VM Service auth codes are disabled.',
+    });
+  }
+
+  attempts.push({
+    source: 'log_scan',
+    selected: !args.explicitUrl && !envHttp && !envWs && !cached && !fixedPortUrl,
+    reason: 'Fallback simulator log scan.',
+  });
+
+  return { attempts, fixedPortUrl, cachedUrl: cached };
+}
+
+function buildStaticAttachDiagnostics(params: Record<string, unknown>): { attempts: AttachAttempt[] } {
+  const explicit = params.vm_service_url as string | undefined;
+  const port = params.vm_service_port as number | undefined;
+  const attempts: AttachAttempt[] = [];
+  if (explicit) {
+    attempts.push({ source: 'explicit_url', url: redactVmServiceUrl(explicit), valid: isValidVMServiceUrl(explicit), selected: true });
+  }
+  if (process.env.OPENSAFARI_VM_SERVICE_URL) {
+    attempts.push({ source: 'env_http_url', url: redactVmServiceUrl(process.env.OPENSAFARI_VM_SERVICE_URL), valid: isValidVMServiceUrl(process.env.OPENSAFARI_VM_SERVICE_URL) });
+  }
+  if (process.env.OPENSAFARI_VM_SERVICE_WS_URL) {
+    const normalized = wsToHttpUrl(process.env.OPENSAFARI_VM_SERVICE_WS_URL);
+    attempts.push({ source: 'env_ws_url', url: redactVmServiceUrl(normalized), valid: isValidVMServiceUrl(normalized) });
+  }
+  if (Number.isFinite(port)) {
+    const authCode = params.vm_service_auth_code as string | undefined;
+    const token = authCode ? `${authCode.replace(/\/$/, '')}/` : '';
+    const url = `http://127.0.0.1:${Math.floor(port as number)}/${token}`;
+    attempts.push({ source: 'fixed_port', url: redactVmServiceUrl(url), valid: isValidVMServiceUrl(url) });
+  }
+  attempts.push({ source: 'log_scan', reason: 'Fallback simulator log scan.' });
+  return { attempts };
+}
+
+export function redactVmServiceUrl(url: string | undefined): string | undefined {
+  if (!url) return url;
+  return url.replace(
+    /((?:ws|http)s?:\/\/127\.0\.0\.1:\d+\/)([^/?#]+)(\/(?:ws)?\/?)?/,
+    (_match, prefix: string, token: string, suffix: string | undefined) => {
+      if (!token) return `${prefix}${suffix ?? ''}`;
+      return `${prefix}<redacted>${suffix ?? '/'}`;
     },
   );
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -135,6 +135,7 @@ import { registerAppPopUntilTool } from './app-pop-until';
 import { registerDiagnoseTool } from './diagnose';
 import { registerAppGotoScreenTool } from './app-goto-screen';
 import { registerDebugBundleCollectTool } from './debug-bundle-collect';
+import { registerAppStateSnapshotTool } from './app-state-snapshot';
 
 export { setWorkflowEngine } from './orchestration-tools';
 export { setBarrier } from './barrier-tools';
@@ -244,6 +245,7 @@ export function registerAllTools(server: MCPServer): void {
 
   // Tier 2: Native App Inspection
   registerAppContextTool(server);
+  registerAppStateSnapshotTool(server);
   registerAppTreeTool(server);
   registerAppQueryTool(server);
   registerAppInspectTool(server);

--- a/src/tools/qa-flutter-semantics.ts
+++ b/src/tools/qa-flutter-semantics.ts
@@ -10,6 +10,7 @@ import { ErrorCode, respondWithStructuredError, StructuredErrorException } from 
 import { getAccessibilityBridge } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
+import { getFlutterVMClient } from '../flutter';
 
 const INTERACTIVE_ROLES = [
   'AXButton', 'AXLink', 'AXTextField', 'AXTextArea',
@@ -17,11 +18,52 @@ const INTERACTIVE_ROLES = [
   'AXPopUpButton', 'AXMenuItem', 'AXTab', 'AXImage',
 ];
 
+// Selector-quality scoring follows qa_flutter_full_audit's taxonomy:
+// images are semantics-relevant, but not automatically automation targets.
+const SELECTOR_INTERACTIVE_ROLES = INTERACTIVE_ROLES.filter((role) => role !== 'AXImage');
+
 interface SemanticsIssue {
   role: string;
   path: string;
   frame: { x: number; y: number; width: number; height: number };
   issue: string;
+}
+
+export interface SelectorQualityFinding {
+  severity: 'info' | 'warning' | 'error';
+  category:
+    | 'missing_identifier'
+    | 'duplicate_identifier'
+    | 'duplicate_label'
+    | 'label_only_selector'
+    | 'missing_role';
+  node?: {
+    path?: string;
+    role?: string;
+    label?: string;
+    identifier?: string;
+    frame?: AXNode['frame'];
+  };
+  recommendation: string;
+}
+
+export interface FlutterSelectorQualityReport {
+  schemaVersion: '1';
+  summary: {
+    totalNodes: number;
+    interactiveNodes: number;
+    nodesWithIdentifier: number;
+    nodesWithLabelOnly: number;
+    duplicateIdentifiers: number;
+    duplicateLabels: number;
+    fragileSelectorCount: number;
+    automationReadinessScore: number;
+  };
+  findings: SelectorQualityFinding[];
+  enrichment: {
+    flutterVmConnected: boolean;
+    widgetTreeUsed: boolean;
+  };
 }
 
 export function registerQaFlutterSemanticsTool(server: MCPServer): void {
@@ -41,6 +83,10 @@ export function registerQaFlutterSemanticsTool(server: MCPServer): void {
           device_id: {
             type: 'string',
             description: 'Simulator UDID (uses active device if omitted)',
+          },
+          include_selector_quality: {
+            type: 'boolean',
+            description: 'Include Flutter automation selector-quality findings (default true).',
           },
         },
         required: [],
@@ -82,6 +128,9 @@ export function registerQaFlutterSemanticsTool(server: MCPServer): void {
           ? Math.round((withIdentifier / totalInteractive) * 100)
           : 100;
         const passed = coverage >= minCoverage;
+        const selectorQuality = params.include_selector_quality === false
+          ? undefined
+          : analyzeSelectorQuality(tree, { flutterVmConnected: getFlutterVMClient(deviceId).isConnected() });
 
         return {
           content: [{
@@ -97,6 +146,7 @@ export function registerQaFlutterSemanticsTool(server: MCPServer): void {
               with_identifier: withIdentifier,
               issues_count: issues.length,
               issues: issues.slice(0, 20),
+              selector_quality: selectorQuality,
               summary: passed
                 ? `Semantics coverage: ${coverage}% (${labeled}/${totalInteractive} elements labeled). Meets ${minCoverage}% threshold.`
                 : `Semantics coverage: ${coverage}% (${labeled}/${totalInteractive} elements labeled). Below ${minCoverage}% threshold.`,
@@ -169,4 +219,124 @@ function analyzeSemantics(
       analyzeSemantics(child, issues, _stats);
     }
   }
+}
+
+export function analyzeSelectorQuality(
+  tree: AXNode,
+  enrichment: { flutterVmConnected: boolean; widgetTreeUsed?: boolean } = { flutterVmConnected: false },
+): FlutterSelectorQualityReport {
+  const allNodes: AXNode[] = [];
+  const interactive: AXNode[] = [];
+  const identifiers = new Map<string, AXNode[]>();
+  const labels = new Map<string, AXNode[]>();
+
+  function walk(node: AXNode): void {
+    allNodes.push(node);
+    if (isSelectorInteractive(node) && node.visible) {
+      interactive.push(node);
+      if (node.identifier?.trim()) {
+        addToMap(identifiers, node.identifier.trim(), node);
+      }
+      if (node.label?.trim()) {
+        addToMap(labels, node.label.trim(), node);
+      }
+    }
+    for (const child of node.children ?? []) walk(child);
+  }
+  walk(tree);
+
+  const findings: SelectorQualityFinding[] = [];
+  for (const node of interactive) {
+    const hasIdentifier = Boolean(node.identifier?.trim());
+    const hasLabel = Boolean(node.label?.trim());
+    if (!hasIdentifier) {
+      findings.push({
+        severity: hasLabel ? 'warning' : 'error',
+        category: hasLabel ? 'label_only_selector' : 'missing_identifier',
+        node: shapeNode(node),
+        recommendation: hasLabel
+          ? 'Add Semantics(identifier: "...") so automation does not depend on locale/user-visible text.'
+          : 'Add Semantics(identifier: "...", label: "...") or an equivalent accessibility identifier for this interactive widget.',
+      });
+    }
+    if (!node.role?.trim()) {
+      findings.push({
+        severity: 'warning',
+        category: 'missing_role',
+        node: shapeNode(node),
+        recommendation: 'Expose an accessibility role/trait so agents can distinguish buttons, fields, tabs, and custom controls.',
+      });
+    }
+  }
+
+  for (const [identifier, nodes] of identifiers) {
+    if (nodes.length > 1) {
+      findings.push({
+        severity: 'error',
+        category: 'duplicate_identifier',
+        node: shapeNode(nodes[0]),
+        recommendation: `Identifier "${identifier}" appears ${nodes.length} times. Use unique Semantics(identifier:) values for automation targets.`,
+      });
+    }
+  }
+  for (const [label, nodes] of labels) {
+    if (nodes.length > 1) {
+      findings.push({
+        severity: 'warning',
+        category: 'duplicate_label',
+        node: shapeNode(nodes[0]),
+        recommendation: `Label "${label}" appears ${nodes.length} times. Prefer identifiers for disambiguation or include more specific labels.`,
+      });
+    }
+  }
+
+  const nodesWithIdentifier = interactive.filter((n) => Boolean(n.identifier?.trim())).length;
+  const nodesWithLabelOnly = interactive.filter((n) => !n.identifier?.trim() && Boolean(n.label?.trim())).length;
+  const duplicateIdentifiers = [...identifiers.values()].filter((nodes) => nodes.length > 1).length;
+  const duplicateLabels = [...labels.values()].filter((nodes) => nodes.length > 1).length;
+  const fragileSelectorCount = findings.filter((f) => f.severity !== 'info').length;
+  const automationReadinessScore = interactive.length === 0
+    ? 100
+    : Math.max(0, Math.round(100 - (fragileSelectorCount / Math.max(1, interactive.length)) * 100));
+
+  return {
+    schemaVersion: '1',
+    summary: {
+      totalNodes: allNodes.length,
+      interactiveNodes: interactive.length,
+      nodesWithIdentifier,
+      nodesWithLabelOnly,
+      duplicateIdentifiers,
+      duplicateLabels,
+      fragileSelectorCount,
+      automationReadinessScore,
+    },
+    findings,
+    enrichment: {
+      flutterVmConnected: enrichment.flutterVmConnected,
+      widgetTreeUsed: Boolean(enrichment.widgetTreeUsed),
+    },
+  };
+}
+
+function isSelectorInteractive(node: AXNode): boolean {
+  return SELECTOR_INTERACTIVE_ROLES.some(
+    (r) => node.role === r || node.role === r.replace('AX', ''),
+  );
+}
+
+function addToMap(map: Map<string, AXNode[]>, key: string, node: AXNode): void {
+  const existing = map.get(key) ?? [];
+  existing.push(node);
+  map.set(key, existing);
+}
+
+function shapeNode(node: AXNode): SelectorQualityFinding['node'] {
+  return {
+    path: node.path,
+    role: node.role,
+    label: node.label,
+    identifier: node.identifier,
+    frame: node.frame,
+  };
 }

--- a/src/tools/scenario-tools.ts
+++ b/src/tools/scenario-tools.ts
@@ -20,7 +20,7 @@ export function registerScenarioTools(server: MCPServer): void {
   server.registerTool(
     {
       name: 'run_scenario',
-      description: 'Execute a declarative test scenario across devices with per-step, per-device results. Mobile semantic v2 navigation is postcondition-first: gotoScreen requires query or settle.query and never succeeds on deeplink dispatch alone.',
+      description: 'Execute a declarative test scenario across devices with per-step, per-device results. Mobile semantic v2 navigation is postcondition-first: action-specific required fields are enforced in the schema before runtime execution.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -40,14 +40,14 @@ export function registerScenarioTools(server: MCPServer): void {
                   ],
                 },
                 target: { type: 'string', description: 'CSS selector' },
-                value: { type: 'string', description: 'Input value, URL, or scroll direction. For v2 gotoScreen this is an optional deeplink transport; query or settle.query is still required as the postcondition.' },
+                value: { type: 'string', description: 'Input value, URL, or scroll direction. Required for typeElement. For v2 gotoScreen this is an optional deeplink transport; query or settle.query is still required as the postcondition.' },
                 assertion: { type: 'string', description: 'JS expression evaluated in the page context (same as javascript tool). Returns boolean.' },
-                bundleId: { type: 'string', description: 'Bundle id for mobile v2 steps such as launchApp' },
+                bundleId: { type: 'string', description: 'Bundle id for mobile v2 launchApp' },
                 expectedBundleId: { type: 'string', description: 'Expected app bundle for state snapshots and post-step verification' },
                 context: { type: 'string', enum: ['native', 'webview', 'safari', 'flutter'] },
                 query: {
                   type: 'object',
-                  description: 'AX query for mobile v2 wait/assert steps. Required for gotoScreen unless settle.query is supplied; gotoScreen uses it as the success postcondition.',
+                  description: 'AX query for mobile v2 tap/type/wait/assert steps. Required for tapElement and typeElement; required for gotoScreen, waitFor, and assertElement unless settle.query is supplied.',
                   properties: {
                     identifier: { type: 'string' },
                     label: { type: 'string' },
@@ -88,6 +88,42 @@ export function registerScenarioTools(server: MCPServer): void {
               allOf: [
                 {
                   if: { properties: { action: { const: 'gotoScreen' } }, required: ['action'] },
+                  then: {
+                    anyOf: [
+                      { required: ['query'] },
+                      {
+                        required: ['settle'],
+                        properties: { settle: { required: ['query'] } },
+                      },
+                    ],
+                  },
+                },
+                {
+                  if: { properties: { action: { const: 'launchApp' } }, required: ['action'] },
+                  then: { required: ['bundleId'] },
+                },
+                {
+                  if: { properties: { action: { const: 'tapElement' } }, required: ['action'] },
+                  then: { required: ['query'] },
+                },
+                {
+                  if: { properties: { action: { const: 'typeElement' } }, required: ['action'] },
+                  then: { required: ['query', 'value'] },
+                },
+                {
+                  if: { properties: { action: { const: 'waitFor' } }, required: ['action'] },
+                  then: {
+                    anyOf: [
+                      { required: ['query'] },
+                      {
+                        required: ['settle'],
+                        properties: { settle: { required: ['query'] } },
+                      },
+                    ],
+                  },
+                },
+                {
+                  if: { properties: { action: { const: 'assertElement' } }, required: ['action'] },
                   then: {
                     anyOf: [
                       { required: ['query'] },

--- a/src/tools/scenario-tools.ts
+++ b/src/tools/scenario-tools.ts
@@ -20,11 +20,12 @@ export function registerScenarioTools(server: MCPServer): void {
   server.registerTool(
     {
       name: 'run_scenario',
-      description: 'Execute a declarative test scenario across devices with per-step, per-device results',
+      description: 'Execute a declarative test scenario across devices with per-step, per-device results. Mobile semantic v2 navigation is postcondition-first: gotoScreen requires query or settle.query and never succeeds on deeplink dispatch alone.',
       inputSchema: {
         type: 'object' as const,
         properties: {
           name: { type: 'string', description: 'Scenario name' },
+          version: { type: 'number', enum: [1, 2], description: 'Scenario schema version. Version 2 enables mobile semantic steps.' },
           steps: {
             type: 'array',
             items: {
@@ -32,11 +33,50 @@ export function registerScenarioTools(server: MCPServer): void {
               properties: {
                 action: {
                   type: 'string',
-                  enum: ['navigate', 'click', 'type', 'scroll', 'wait', 'assert', 'screenshot'],
+                  enum: [
+                    'navigate', 'click', 'type', 'scroll', 'wait', 'assert', 'screenshot',
+                    'recordState', 'launchApp', 'gotoScreen', 'tapElement', 'typeElement',
+                    'waitFor', 'assertElement', 'collectDebugBundle',
+                  ],
                 },
                 target: { type: 'string', description: 'CSS selector' },
-                value: { type: 'string', description: 'Input value, URL, or scroll direction' },
+                value: { type: 'string', description: 'Input value, URL, or scroll direction. For v2 gotoScreen this is an optional deeplink transport; query or settle.query is still required as the postcondition.' },
                 assertion: { type: 'string', description: 'JS expression evaluated in the page context (same as javascript tool). Returns boolean.' },
+                bundleId: { type: 'string', description: 'Bundle id for mobile v2 steps such as launchApp' },
+                expectedBundleId: { type: 'string', description: 'Expected app bundle for state snapshots and post-step verification' },
+                context: { type: 'string', enum: ['native', 'webview', 'safari', 'flutter'] },
+                query: {
+                  type: 'object',
+                  description: 'AX query for mobile v2 wait/assert steps. Required for gotoScreen unless settle.query is supplied; gotoScreen uses it as the success postcondition.',
+                  properties: {
+                    identifier: { type: 'string' },
+                    label: { type: 'string' },
+                    text: { type: 'string' },
+                    role: { type: 'string' },
+                  },
+                },
+                condition: { type: 'string', enum: ['exists', 'not_exists', 'visible', 'enabled'] },
+                settle: {
+                  type: 'object',
+                  description: 'Shared settle/postcondition policy for mobile v2 steps. For gotoScreen, provide settle.query here or query at the step root; transport-only gotoScreen is invalid.',
+                  properties: {
+                    query: {
+                      type: 'object',
+                      properties: {
+                        identifier: { type: 'string' },
+                        label: { type: 'string' },
+                        text: { type: 'string' },
+                        role: { type: 'string' },
+                      },
+                    },
+                    condition: { type: 'string', enum: ['exists', 'not_exists', 'visible', 'enabled'] },
+                    timeoutMs: { type: 'number' },
+                    intervalMs: { type: 'number' },
+                    stableMs: { type: 'number' },
+                    allowTransientErrors: { type: 'boolean' },
+                    maxRecoverableRetries: { type: 'number' },
+                  },
+                },
                 devices: {
                   type: 'array',
                   items: { type: 'string' },
@@ -45,6 +85,20 @@ export function registerScenarioTools(server: MCPServer): void {
                 timeout: { type: 'number', description: 'Step timeout in ms' },
               },
               required: ['action'],
+              allOf: [
+                {
+                  if: { properties: { action: { const: 'gotoScreen' } }, required: ['action'] },
+                  then: {
+                    anyOf: [
+                      { required: ['query'] },
+                      {
+                        required: ['settle'],
+                        properties: { settle: { required: ['query'] } },
+                      },
+                    ],
+                  },
+                },
+              ],
             },
             description: 'Ordered list of test steps',
           },
@@ -60,6 +114,7 @@ export function registerScenarioTools(server: MCPServer): void {
       const scenario: TestScenario = {
         name: params.name as string,
         steps: params.steps as TestScenario['steps'],
+        version: params.version as TestScenario['version'],
       };
       const result = await runner.run(scenario);
       return jsonResult(result);

--- a/src/tools/scenario-tools.ts
+++ b/src/tools/scenario-tools.ts
@@ -47,7 +47,7 @@ export function registerScenarioTools(server: MCPServer): void {
                 context: { type: 'string', enum: ['native', 'webview', 'safari', 'flutter'] },
                 query: {
                   type: 'object',
-                  description: 'AX query for mobile v2 tap/type/wait/assert steps. Required for tapElement and typeElement; required for gotoScreen, waitFor, and assertElement unless settle.query is supplied.',
+                  description: 'AX query for mobile v2 tap/type/wait/assert steps. Required for tapElement and typeElement as the target selector; gotoScreen, waitFor, and assertElement require query unless settle.query is supplied. Mutating tap/type steps also require settle.query as the success postcondition.',
                   properties: {
                     identifier: { type: 'string' },
                     label: { type: 'string' },
@@ -104,11 +104,17 @@ export function registerScenarioTools(server: MCPServer): void {
                 },
                 {
                   if: { properties: { action: { const: 'tapElement' } }, required: ['action'] },
-                  then: { required: ['query'] },
+                  then: {
+                    required: ['query', 'settle'],
+                    properties: { settle: { required: ['query'] } },
+                  },
                 },
                 {
                   if: { properties: { action: { const: 'typeElement' } }, required: ['action'] },
-                  then: { required: ['query', 'value'] },
+                  then: {
+                    required: ['query', 'value', 'settle'],
+                    properties: { settle: { required: ['query'] } },
+                  },
                 },
                 {
                   if: { properties: { action: { const: 'waitFor' } }, required: ['action'] },

--- a/src/tools/settle-policy.ts
+++ b/src/tools/settle-policy.ts
@@ -1,0 +1,165 @@
+import { getAccessibilityBridge } from '../native';
+import type { AXNode } from '../native';
+
+export type SettleCondition = 'exists' | 'not_exists' | 'visible' | 'enabled';
+
+export interface SettleQuery {
+  identifier?: string;
+  label?: string;
+  text?: string;
+  role?: string;
+}
+
+export interface SettlePolicy {
+  query?: SettleQuery;
+  condition?: SettleCondition;
+  timeoutMs?: number;
+  intervalMs?: number;
+  stableMs?: number;
+  allowTransientErrors?: boolean;
+  maxRecoverableRetries?: number;
+}
+
+export interface SettleSample {
+  role: string;
+  label?: string;
+  identifier?: string;
+  visible?: boolean;
+  enabled?: boolean;
+  frame?: AXNode['frame'];
+  path?: string;
+}
+
+export interface SettleResult {
+  requested: SettlePolicy;
+  met: boolean;
+  stableForMs: number;
+  polls: number;
+  elapsedMs: number;
+  matchingCount: number;
+  lastObserved: SettleSample[];
+  errors: string[];
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_INTERVAL_MS = 250;
+const DEFAULT_SAMPLE_LIMIT = 5;
+
+export function evaluateSettleCondition(
+  matches: AXNode[],
+  condition: SettleCondition = 'exists',
+): boolean {
+  switch (condition) {
+    case 'not_exists':
+      return matches.length === 0;
+    case 'visible':
+      return matches.some((m) => m.visible !== false);
+    case 'enabled':
+      return matches.some((m) => m.enabled !== false);
+    case 'exists':
+    default:
+      return matches.length > 0;
+  }
+}
+
+export function updateStableWindow(
+  conditionMet: boolean,
+  firstMetAtMs: number | null,
+  nowMs: number,
+  stableMs: number,
+): { stable: boolean; firstMetAtMs: number | null; stableForMs: number } {
+  if (!conditionMet) {
+    return { stable: false, firstMetAtMs: null, stableForMs: 0 };
+  }
+  const nextFirstMetAtMs = firstMetAtMs ?? nowMs;
+  const stableForMs = nowMs - nextFirstMetAtMs;
+  return {
+    stable: stableForMs >= Math.max(0, stableMs),
+    firstMetAtMs: nextFirstMetAtMs,
+    stableForMs,
+  };
+}
+
+export function sampleSettleMatches(matches: AXNode[], limit = DEFAULT_SAMPLE_LIMIT): SettleSample[] {
+  return matches.slice(0, Math.max(0, limit)).map((m) => ({
+    role: m.role,
+    label: m.label,
+    identifier: m.identifier,
+    visible: m.visible,
+    enabled: m.enabled,
+    frame: m.frame,
+    path: m.path,
+  }));
+}
+
+export async function waitForSettle(
+  deviceId: string,
+  policy: SettlePolicy,
+  sampleLimit = DEFAULT_SAMPLE_LIMIT,
+): Promise<SettleResult> {
+  if (!policy.query || !hasQuerySignal(policy.query)) {
+    throw new Error('settle policy requires at least one query field');
+  }
+
+  const bridge = getAccessibilityBridge();
+  const timeoutMs = Math.max(0, Math.floor(policy.timeoutMs ?? DEFAULT_TIMEOUT_MS));
+  const intervalMs = Math.max(25, Math.floor(policy.intervalMs ?? DEFAULT_INTERVAL_MS));
+  const stableMs = Math.max(0, Math.floor(policy.stableMs ?? 0));
+  const condition = policy.condition ?? 'exists';
+  const start = Date.now();
+  const deadline = start + timeoutMs;
+  let polls = 0;
+  let firstMetAtMs: number | null = null;
+  let stableForMs = 0;
+  let matchingCount = 0;
+  let lastObserved: SettleSample[] = [];
+  const errors: string[] = [];
+
+  while (Date.now() <= deadline) {
+    polls++;
+    try {
+      const result = await bridge.query(policy.query, { deviceId });
+      matchingCount = result.matches.length;
+      lastObserved = sampleSettleMatches(result.matches, sampleLimit);
+      const met = evaluateSettleCondition(result.matches, condition);
+      const stable = updateStableWindow(met, firstMetAtMs, Date.now(), stableMs);
+      firstMetAtMs = stable.firstMetAtMs;
+      stableForMs = stable.stableForMs;
+      if (stable.stable) {
+        return {
+          requested: policy,
+          met: true,
+          stableForMs,
+          polls,
+          elapsedMs: Date.now() - start,
+          matchingCount,
+          lastObserved,
+          errors,
+        };
+      }
+    } catch (err) {
+      firstMetAtMs = null;
+      stableForMs = 0;
+      errors.push(err instanceof Error ? err.message : String(err));
+      if (!policy.allowTransientErrors && errors.length > (policy.maxRecoverableRetries ?? 0)) {
+        break;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  return {
+    requested: policy,
+    met: false,
+    stableForMs,
+    polls,
+    elapsedMs: Date.now() - start,
+    matchingCount,
+    lastObserved,
+    errors,
+  };
+}
+
+function hasQuerySignal(query: SettleQuery): boolean {
+  return Boolean(query.identifier || query.label || query.text || query.role);
+}

--- a/tests/unit/app-state-snapshot.test.ts
+++ b/tests/unit/app-state-snapshot.test.ts
@@ -1,0 +1,94 @@
+import { MCPServer } from '../../src/mcp-server';
+import { ErrorCode } from '../../src/errors';
+
+const listBootedMock = jest.fn();
+const listRunningAppsMock = jest.fn();
+const dumpTreeMock = jest.fn();
+const getSoleDeviceIdMock = jest.fn();
+
+jest.mock('../../src/simulator', () => ({
+  SimulatorManager: jest.fn().mockImplementation(() => ({
+    listBooted: listBootedMock,
+    listRunningApps: listRunningAppsMock,
+  })),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({ getSoleDeviceId: getSoleDeviceIdMock }),
+}));
+
+jest.mock('../../src/native', () => ({
+  getAccessibilityBridge: () => ({ dumpTree: dumpTreeMock }),
+}));
+
+jest.mock('../../src/flutter', () => ({
+  getFlutterVMClient: () => ({ isConnected: () => false }),
+}));
+
+function axTree() {
+  return {
+    role: 'AXApplication',
+    label: 'Example',
+    identifier: 'com.example.app',
+    value: undefined,
+    frame: { x: 0, y: 0, width: 390, height: 844 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    traits: [],
+    path: '/0',
+    children: [
+      { role: 'AXButton', label: 'Settings', identifier: 'settings_button', value: undefined, frame: { x: 1, y: 1, width: 44, height: 44 }, visible: true, enabled: true, focused: false, traits: [], path: '/0/1', children: [] },
+    ],
+  };
+}
+
+function parseToolError(result: { isError?: boolean; content?: Array<{ text?: string }> }) {
+  expect(result.isError).toBe(true);
+  return JSON.parse(result.content?.[0]?.text ?? '{}') as Record<string, unknown>;
+}
+
+describe('app_state_snapshot contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listBootedMock.mockResolvedValue([{ udid: 'D1', name: 'iPhone 15' }]);
+    listRunningAppsMock.mockResolvedValue([{ label: 'com.example.app', pid: 123 }]);
+    dumpTreeMock.mockResolvedValue(axTree());
+    getSoleDeviceIdMock.mockReturnValue('D1');
+  });
+
+  it('returns compact non-mutating state with confidence and recovery hints', async () => {
+    const { collectAppSessionState } = await import('../../src/tools/app-state-snapshot');
+    const state = await collectAppSessionState({ expectedBundleId: 'com.example.app', includeFlutter: true, includeWebView: true });
+    expect(state.schemaVersion).toBe('1');
+    expect(state.device.id).toBe('D1');
+    expect(state.ui.visibleSummary[0]).toMatchObject({ role: 'AXApplication' });
+    expect(state.flutter).toMatchObject({ vmConnected: false });
+    expect(state.confidence).toMatch(/verified|heuristic|unknown/);
+    expect(state.recoveryHints.some((h) => h.action === 'debug_bundle_collect' && h.destructive === false)).toBe(true);
+  });
+
+  it('reports DEVICE_NOT_BOOTED only when no device can be resolved', async () => {
+    listBootedMock.mockResolvedValueOnce([]);
+    getSoleDeviceIdMock.mockReturnValueOnce(null);
+    const { registerAppStateSnapshotTool } = await import('../../src/tools/app-state-snapshot');
+    const server = new MCPServer();
+    registerAppStateSnapshotTool(server);
+
+    const result = await server.getToolHandler('app_state_snapshot')!('s', {});
+    const payload = parseToolError(result);
+    expect(payload.error).toBe(ErrorCode.DEVICE_NOT_BOOTED);
+  });
+
+  it('reports APP_STATE_UNKNOWN for snapshot collection failures after device resolution', async () => {
+    dumpTreeMock.mockRejectedValueOnce(new Error('AX dump failed'));
+    const { registerAppStateSnapshotTool } = await import('../../src/tools/app-state-snapshot');
+    const server = new MCPServer();
+    registerAppStateSnapshotTool(server);
+
+    const result = await server.getToolHandler('app_state_snapshot')!('s', {});
+    const payload = parseToolError(result);
+    expect(payload.error).toBe(ErrorCode.APP_STATE_UNKNOWN);
+    expect(payload.message).toContain('AX dump failed');
+  });
+});

--- a/tests/unit/flutter-connect-diagnostics.test.ts
+++ b/tests/unit/flutter-connect-diagnostics.test.ts
@@ -1,0 +1,8 @@
+import { redactVmServiceUrl } from '../../src/tools/flutter-connect';
+
+describe('flutter_connect diagnostics', () => {
+  it('redacts VM service auth tokens from HTTP and WS URLs', () => {
+    expect(redactVmServiceUrl('http://127.0.0.1:12345/abc=/')).toBe('http://127.0.0.1:12345/<redacted>/');
+    expect(redactVmServiceUrl('ws://127.0.0.1:12345/abc=/ws')).toBe('ws://127.0.0.1:12345/<redacted>/ws');
+  });
+});

--- a/tests/unit/flutter-selector-quality.test.ts
+++ b/tests/unit/flutter-selector-quality.test.ts
@@ -1,0 +1,36 @@
+import { analyzeSelectorQuality } from '../../src/tools/qa-flutter-semantics';
+import type { AXNode } from '../../src/native';
+
+function node(partial: Partial<AXNode>): AXNode {
+  return {
+    role: 'AXGroup',
+    label: undefined,
+    identifier: undefined,
+    value: undefined,
+    frame: { x: 0, y: 0, width: 100, height: 50 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    traits: [],
+    path: '/0',
+    children: [],
+    ...partial,
+  };
+}
+
+describe('Flutter selector quality audit', () => {
+  it('flags label-only and duplicate selectors', () => {
+    const tree = node({ children: [
+      node({ role: 'AXButton', label: 'Save', path: '/0/0' }),
+      node({ role: 'AXButton', label: 'Save', identifier: 'save', path: '/0/1' }),
+      node({ role: 'AXButton', label: 'Other Save', identifier: 'save', path: '/0/2' }),
+    ] });
+
+    const report = analyzeSelectorQuality(tree);
+    expect(report.summary.interactiveNodes).toBe(3);
+    expect(report.summary.nodesWithIdentifier).toBe(2);
+    expect(report.summary.duplicateIdentifiers).toBe(1);
+    expect(report.summary.duplicateLabels).toBe(1);
+    expect(report.findings.map((f) => f.category)).toEqual(expect.arrayContaining(['label_only_selector', 'duplicate_identifier', 'duplicate_label']));
+  });
+});

--- a/tests/unit/scenario-runner-v2.test.ts
+++ b/tests/unit/scenario-runner-v2.test.ts
@@ -1,6 +1,11 @@
 import { ScenarioRunner } from '../../src/orchestration/scenario-runner';
 import { waitForSettle } from '../../src/tools/settle-policy';
 
+const queryMock = jest.fn();
+const pressMock = jest.fn();
+const tapMock = jest.fn();
+const typeTextMock = jest.fn();
+
 jest.mock('../../src/tools/app-state-snapshot', () => ({
   collectAppSessionState: jest.fn(async ({ deviceId }) => ({ schemaVersion: '1', device: { id: deviceId }, app: { classification: 'TARGET_BUNDLE_CONFIRMED' } })),
 }));
@@ -9,6 +14,19 @@ jest.mock('../../src/tools/settle-policy', () => ({
 }));
 jest.mock('../../src/tools/debug-bundle-collect', () => ({
   collectDebugBundle: jest.fn(async ({ deviceId }) => ({ schemaVersion: '1', device: { udid: deviceId }, collectedAt: 'now' })),
+}));
+jest.mock('../../src/native', () => ({
+  getAccessibilityBridge: () => ({
+    query: queryMock,
+    press: pressMock,
+  }),
+}));
+jest.mock('../../src/tools/native-input-utils', () => ({
+  getInputBackend: jest.fn(async () => ({
+    kind: 'simhid',
+    tap: tapMock,
+    typeText: typeTextMock,
+  })),
 }));
 
 const sim = {
@@ -21,6 +39,12 @@ const sim = {
 const pool = { getAll: jest.fn(() => [sim]) };
 
 describe('ScenarioRunner v2', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryMock.mockResolvedValue({ matches: [{ path: '/0/1', frame: { x: 10, y: 20, width: 30, height: 40 } }] });
+    pressMock.mockResolvedValue({ ok: true });
+    (waitForSettle as jest.Mock).mockResolvedValue({ met: true, polls: 1, elapsedMs: 1, stableForMs: 0, matchingCount: 1, lastObserved: [], errors: [] });
+  });
   it('records state with per-device result metadata', async () => {
     const runner = new ScenarioRunner(pool as any);
     const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'recordState', expectedBundleId: 'com.example' }] });
@@ -50,6 +74,53 @@ describe('ScenarioRunner v2', () => {
     const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'gotoScreen', value: 'myapp://settings' }] });
     expect(result.passed).toBe(false);
     expect(result.steps[0].devices[0].error).toContain('gotoScreen requires a postcondition query');
+  });
+
+
+  it('fails tapElement before mutation when settle postcondition is omitted', async () => {
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'tapElement', query: { identifier: 'menu' } }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].error).toContain('tapElement requires a settle.query postcondition');
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(tapMock).not.toHaveBeenCalled();
+  });
+
+  it('passes tapElement fallback only after settle verification succeeds and preserves AX evidence', async () => {
+    pressMock.mockResolvedValueOnce({ ok: false, error: 'not pressable' });
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({
+      name: 'mobile',
+      version: 2,
+      steps: [{ action: 'tapElement', query: { identifier: 'menu' }, settle: { query: { identifier: 'drawer' } } }],
+    });
+    expect(result.passed).toBe(true);
+    expect(tapMock).toHaveBeenCalledWith('D1', 25, 40);
+    expect(result.steps[0].devices[0].result).toMatchObject({ backend: 'simhid', axPress: { ok: false, error: 'not pressable' } });
+    expect(result.steps[0].devices[0].verification).toMatchObject({ met: true });
+  });
+
+  it('fails typeElement before mutation when settle postcondition is omitted', async () => {
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'typeElement', query: { identifier: 'email' }, value: 'agent@example.com' }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].error).toContain('typeElement requires a settle.query postcondition');
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(typeTextMock).not.toHaveBeenCalled();
+  });
+
+  it('records focus failure for typeElement but only passes when settle verification succeeds', async () => {
+    pressMock.mockRejectedValueOnce(new Error('focus failed'));
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({
+      name: 'mobile',
+      version: 2,
+      steps: [{ action: 'typeElement', query: { identifier: 'email' }, value: 'agent@example.com', settle: { query: { text: 'agent@example.com' } } }],
+    });
+    expect(result.passed).toBe(true);
+    expect(typeTextMock).toHaveBeenCalledWith('D1', 'agent@example.com');
+    expect(result.steps[0].devices[0].result).toMatchObject({ backend: 'simhid', focus: { ok: false, error: 'focus failed' } });
+    expect(result.steps[0].devices[0].verification).toMatchObject({ met: true });
   });
 
   it('allows state-only gotoScreen when a postcondition is supplied', async () => {

--- a/tests/unit/scenario-runner-v2.test.ts
+++ b/tests/unit/scenario-runner-v2.test.ts
@@ -1,0 +1,61 @@
+import { ScenarioRunner } from '../../src/orchestration/scenario-runner';
+import { waitForSettle } from '../../src/tools/settle-policy';
+
+jest.mock('../../src/tools/app-state-snapshot', () => ({
+  collectAppSessionState: jest.fn(async ({ deviceId }) => ({ schemaVersion: '1', device: { id: deviceId }, app: { classification: 'TARGET_BUNDLE_CONFIRMED' } })),
+}));
+jest.mock('../../src/tools/settle-policy', () => ({
+  waitForSettle: jest.fn(async () => ({ met: true, polls: 1, elapsedMs: 1, stableForMs: 0, matchingCount: 1, lastObserved: [], errors: [] })),
+}));
+jest.mock('../../src/tools/debug-bundle-collect', () => ({
+  collectDebugBundle: jest.fn(async ({ deviceId }) => ({ schemaVersion: '1', device: { udid: deviceId }, collectedAt: 'now' })),
+}));
+
+const sim = {
+  device: { udid: 'D1', name: 'iPhone' },
+  preset: 'iphone',
+  client: { screenshot: jest.fn(async () => Buffer.from('png')) },
+  bootedAt: Date.now(),
+  lastActivity: Date.now(),
+};
+const pool = { getAll: jest.fn(() => [sim]) };
+
+describe('ScenarioRunner v2', () => {
+  it('records state with per-device result metadata', async () => {
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'recordState', expectedBundleId: 'com.example' }] });
+    expect(result.passed).toBe(true);
+    expect(result.steps[0].devices[0].beforeState).toBeDefined();
+    expect(result.steps[0].devices[0].selectedBackend).toBe('ax');
+  });
+
+  it('fails waitFor when the settle postcondition is unmet', async () => {
+    (waitForSettle as jest.Mock).mockResolvedValueOnce({ met: false, polls: 2, elapsedMs: 50, stableForMs: 0, matchingCount: 0, lastObserved: [], errors: [] });
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'waitFor', query: { identifier: 'missing' } }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].passed).toBe(false);
+    expect(result.steps[0].devices[0].verification).toMatchObject({ met: false });
+  });
+
+  it('requires version 2 for mobile semantic actions', async () => {
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', steps: [{ action: 'recordState' }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].error).toContain('requires scenario.version === 2');
+  });
+
+  it('fails gotoScreen when no postcondition is supplied, even with a deeplink', async () => {
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'gotoScreen', value: 'myapp://settings' }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].error).toContain('gotoScreen requires a postcondition query');
+  });
+
+  it('allows state-only gotoScreen when a postcondition is supplied', async () => {
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'gotoScreen', query: { identifier: 'settings' } }] });
+    expect(result.passed).toBe(true);
+    expect(waitForSettle).toHaveBeenCalledWith('D1', expect.objectContaining({ query: { identifier: 'settings' } }));
+  });
+});

--- a/tests/unit/scenario-tools-schema.test.ts
+++ b/tests/unit/scenario-tools-schema.test.ts
@@ -1,0 +1,44 @@
+import Ajv, { type AnySchema } from 'ajv';
+import { MCPServer } from '../../src/mcp-server';
+import { registerScenarioTools } from '../../src/tools/scenario-tools';
+
+function schemaValidator() {
+  const server = new MCPServer();
+  registerScenarioTools(server);
+  const tools = (server as unknown as { tools: Map<string, { definition: { inputSchema: unknown } }> }).tools;
+  const schema = tools.get('run_scenario')!.definition.inputSchema;
+  return new Ajv({ strict: false }).compile(schema as AnySchema);
+}
+
+describe('run_scenario v2 schema SSOT', () => {
+  const invalidCases = [
+    ['launchApp requires bundleId', { action: 'launchApp' }],
+    ['tapElement requires query', { action: 'tapElement' }],
+    ['typeElement requires query', { action: 'typeElement', value: 'hello' }],
+    ['typeElement requires value', { action: 'typeElement', query: { identifier: 'email' } }],
+    ['waitFor requires query or settle.query', { action: 'waitFor' }],
+    ['assertElement requires query or settle.query', { action: 'assertElement' }],
+    ['gotoScreen requires postcondition query', { action: 'gotoScreen', value: 'myapp://settings' }],
+  ] as const;
+
+  it.each(invalidCases)('rejects %s', (_name, step) => {
+    const validate = schemaValidator();
+    expect(validate({ name: 'mobile', version: 2, steps: [step] })).toBe(false);
+  });
+
+  it('accepts runtime-valid mobile semantic v2 actions', () => {
+    const validate = schemaValidator();
+    expect(validate({
+      name: 'mobile',
+      version: 2,
+      steps: [
+        { action: 'launchApp', bundleId: 'com.example.app' },
+        { action: 'tapElement', query: { identifier: 'settings' } },
+        { action: 'typeElement', query: { identifier: 'email' }, value: 'agent@example.com' },
+        { action: 'waitFor', settle: { query: { label: 'Home' } } },
+        { action: 'assertElement', query: { text: 'Done' } },
+        { action: 'gotoScreen', value: 'myapp://settings', query: { identifier: 'settings' } },
+      ],
+    })).toBe(true);
+  });
+});

--- a/tests/unit/scenario-tools-schema.test.ts
+++ b/tests/unit/scenario-tools-schema.test.ts
@@ -13,9 +13,11 @@ function schemaValidator() {
 describe('run_scenario v2 schema SSOT', () => {
   const invalidCases = [
     ['launchApp requires bundleId', { action: 'launchApp' }],
-    ['tapElement requires query', { action: 'tapElement' }],
-    ['typeElement requires query', { action: 'typeElement', value: 'hello' }],
-    ['typeElement requires value', { action: 'typeElement', query: { identifier: 'email' } }],
+    ['tapElement requires query', { action: 'tapElement', settle: { query: { identifier: 'done' } } }],
+    ['tapElement requires settle.query postcondition', { action: 'tapElement', query: { identifier: 'button' } }],
+    ['typeElement requires query', { action: 'typeElement', value: 'hello', settle: { query: { identifier: 'done' } } }],
+    ['typeElement requires value', { action: 'typeElement', query: { identifier: 'email' }, settle: { query: { identifier: 'done' } } }],
+    ['typeElement requires settle.query postcondition', { action: 'typeElement', query: { identifier: 'email' }, value: 'hello' }],
     ['waitFor requires query or settle.query', { action: 'waitFor' }],
     ['assertElement requires query or settle.query', { action: 'assertElement' }],
     ['gotoScreen requires postcondition query', { action: 'gotoScreen', value: 'myapp://settings' }],
@@ -33,8 +35,8 @@ describe('run_scenario v2 schema SSOT', () => {
       version: 2,
       steps: [
         { action: 'launchApp', bundleId: 'com.example.app' },
-        { action: 'tapElement', query: { identifier: 'settings' } },
-        { action: 'typeElement', query: { identifier: 'email' }, value: 'agent@example.com' },
+        { action: 'tapElement', query: { identifier: 'settings' }, settle: { query: { identifier: 'settings_open' } } },
+        { action: 'typeElement', query: { identifier: 'email' }, value: 'agent@example.com', settle: { query: { text: 'agent@example.com' } } },
         { action: 'waitFor', settle: { query: { label: 'Home' } } },
         { action: 'assertElement', query: { text: 'Done' } },
         { action: 'gotoScreen', value: 'myapp://settings', query: { identifier: 'settings' } },

--- a/tests/unit/settle-policy.test.ts
+++ b/tests/unit/settle-policy.test.ts
@@ -1,0 +1,37 @@
+import { evaluateSettleCondition, sampleSettleMatches, updateStableWindow } from '../../src/tools/settle-policy';
+import type { AXNode } from '../../src/native';
+
+const node: AXNode = {
+  role: 'AXButton',
+  label: 'Continue',
+  identifier: 'continue',
+  value: undefined,
+  frame: { x: 0, y: 0, width: 44, height: 44 },
+  visible: true,
+  enabled: true,
+  focused: false,
+  traits: [],
+  path: '/0/1',
+  children: [],
+};
+
+describe('settle-policy helpers', () => {
+  it('evaluates exists/not_exists/visible/enabled', () => {
+    expect(evaluateSettleCondition([node], 'exists')).toBe(true);
+    expect(evaluateSettleCondition([], 'not_exists')).toBe(true);
+    expect(evaluateSettleCondition([{ ...node, visible: false }], 'visible')).toBe(false);
+    expect(evaluateSettleCondition([{ ...node, enabled: false }], 'enabled')).toBe(false);
+  });
+
+  it('tracks stable windows and resets on broken condition', () => {
+    const first = updateStableWindow(true, null, 100, 250);
+    expect(first.stable).toBe(false);
+    const stable = updateStableWindow(true, first.firstMetAtMs, 350, 250);
+    expect(stable.stable).toBe(true);
+    expect(updateStableWindow(false, stable.firstMetAtMs, 400, 250)).toEqual({ stable: false, firstMetAtMs: null, stableForMs: 0 });
+  });
+
+  it('samples bounded AX metadata', () => {
+    expect(sampleSettleMatches([node], 1)).toEqual([{ role: 'AXButton', label: 'Continue', identifier: 'continue', visible: true, enabled: true, frame: node.frame, path: '/0/1' }]);
+  });
+});

--- a/tests/unit/tier0-error-envelope.test.ts
+++ b/tests/unit/tier0-error-envelope.test.ts
@@ -202,13 +202,21 @@ describe('tier-0 error envelope shape (#797 PR2)', () => {
     assertStructuredError(result, ErrorCode.INVALID_URL);
   });
 
-  // 1b. app-goto-screen — DEVICE_NOT_BOOTED (no url scheme ok, no device)
+  test('app_goto_screen: INVALID_INPUT when waitFor postcondition is omitted', async () => {
+    const { registerAppGotoScreenTool } = await import('../../src/tools/app-goto-screen');
+    registerAppGotoScreenTool(server);
+    const handler = server.getToolHandler('app_goto_screen')!;
+    const result = await handler('s', { url: 'myapp://home' });
+    assertStructuredError(result, ErrorCode.INVALID_INPUT);
+  });
+
+  // 1b. app-goto-screen — DEVICE_NOT_BOOTED (valid url/postcondition, no device)
   test('app_goto_screen: DEVICE_NOT_BOOTED when no simulator', async () => {
     const { registerAppGotoScreenTool } = await import('../../src/tools/app-goto-screen');
     registerAppGotoScreenTool(server);
     const handler = server.getToolHandler('app_goto_screen')!;
-    // url is valid but resolveDeviceId will return null (session mock returns null)
-    const result = await handler('s', { url: 'myapp://home' });
+    // url and waitFor are valid but resolveDeviceId will return null (session mock returns null)
+    const result = await handler('s', { url: 'myapp://home', waitFor: { identifier: 'home' } });
     assertStructuredError(result, ErrorCode.DEVICE_NOT_BOOTED);
   });
 


### PR DESCRIPTION
## Summary

Implements the first SSOT #795-aligned mobile semantic QA runtime slice and makes issues #822-#827 actionable through concrete code/docs/tests:

- adds read-only `app_state_snapshot` for AppSessionState/ScreenStateSnapshot evidence (#822)
- adds shared settle/postcondition helpers and tests (#824)
- upgrades `app_goto_screen` with before/after state, already-on-target detection, attempts, and postcondition evidence (#823)
- extends `qa_flutter_semantics` with selector-quality findings for Flutter automation readiness (#825)
- adds deterministic Flutter VM attach diagnostics and fixed-port inputs to `flutter_connect` (#826)
- versions `run_scenario` for mobile semantic v2 steps with state/verification/backend metadata (#827)
- documents the semantic mobile QA runtime in `docs/mobile-semantic-qa.md`

## SSOT / drift guard

This keeps OpenSafari on the #795 direction: portable MCP-native contracts, semantic actions over raw operations, structured failures, debugging evidence, and no Appium/Maestro runtime dependency. Relaunch/reset is not introduced as a default recovery path.

## Issues / PR shape

- Starts #822 PR 1/2/3: state contract, MCP tool, docs
- Starts #823 PR 1/2/4: controller evidence via `app_goto_screen`; native fallback can continue in a follow-up PR
- Starts #824 PR 1 and partial PR 2/3: shared settle helper and integration in `app_goto_screen`
- Starts #825 PR 1/3: AX selector-quality audit and docs
- Starts #826 PR 1/2/3: attach diagnostics, fixed-port inputs, user-facing payload
- Starts #827 PR 1/2/3: versioned mobile scenario v2 schema and initial semantic steps

## Testing

- `npm test -- --runInBand`
- `npm run build:src`
- `npm run lint -- --quiet`

## Not tested

- Live simulator Flutter/native app flows
