### PR TITLE
Complete mobile semantic QA follow-up runtime

### DIFF
--- a/docs/flutter-vm-attach.md
+++ b/docs/flutter-vm-attach.md
@@ -1,0 +1,26 @@
+# Deterministic Flutter VM attach for mobile QA
+
+OpenSafari does not own `flutter run`. Launch the Flutter app externally, then use
+`flutter_connect` to attach to the VM Service for debug/profile inspection.
+
+Recommended debug/profile launch patterns:
+
+```sh
+flutter run --debug --host-vmservice-port=50642
+flutter run --profile --host-vmservice-port=50642
+```
+
+Then attach with one of:
+
+```json
+{ "vm_service_url": "http://127.0.0.1:50642/<auth-code>/" }
+{ "vm_service_port": 50642, "vm_service_auth_code": "<auth-code>" }
+```
+
+Attach priority is explicit URL, environment URL, environment WS URL, cached URL,
+fixed-port input, then simulator log scan. Failure payloads include typed attempts
+and troubleshooting suggestions for stale cache, closed fixed ports, invalid URL
+shape, auth-code mismatch, and release-build limitations.
+
+Release builds disable VM Service. Treat VM unavailable as data and fall back to
+AX/native semantic tools unless the scenario explicitly requires Flutter VM.

--- a/docs/mobile-semantic-qa.md
+++ b/docs/mobile-semantic-qa.md
@@ -46,3 +46,26 @@ Release builds generally do not expose VM Service and should use native AX seman
 ## Scenario runner v2
 
 `run_scenario` accepts `version: 2` for currently implemented mobile semantic steps: `recordState`, `launchApp`, `gotoScreen`, `tapElement`, `typeElement`, `waitFor`, `assertElement`, and `collectDebugBundle`. V2 results include per-device state, backend hint, verification, timing, and partial-failure data. Existing v1 browser scenarios remain compatible. V2 starts from the current simulator state by design; use an explicit `launchApp` step only when a scenario needs to foreground an app.
+
+## Follow-up runtime contracts after PR #828
+
+Semantic navigation is now controller-shaped: every strategy records an attempt,
+skipped reason, selected strategy, verification evidence, and recovery hint. A
+transport dispatch (`simctl openurl`, native tap, text injection, route mutation)
+is never success without a route or AX postcondition.
+
+Shared settle policies are available to high-level interaction and scenario
+steps. `app_tap_element` and `app_type_element` preserve their historical behavior
+when no `settle` object is supplied; when `settle.query` is supplied, the response
+includes settle evidence and failed postconditions become tool errors.
+
+Scenario v2 is stateful-by-default. Use explicit `launchApp` only when a scenario
+requires a fresh foreground app. Otherwise, start from current state with
+`recordState`, `gotoScreen`, `waitFor`, `tapElement`, `typeElement`, `popUntil`,
+`dismissOverlay`, and `collectDebugBundle` steps. `gotoScreen` requires `query`,
+`settle.query`, or a Flutter route target and cannot pass from deeplink dispatch
+alone.
+
+Flutter selector quality remains AX-first and release-compatible. When Flutter VM
+is attached, findings may include best-effort route/widget/source hints; VM
+absence is reported as data, not failure.

--- a/src/orchestration/scenario-runner.ts
+++ b/src/orchestration/scenario-runner.ts
@@ -2,6 +2,7 @@ import { SimulatorPool, PooledSimulator } from '../simulator/pool';
 import { ActionTraceRecorder } from '../observability/action-trace';
 import { collectAppSessionState } from '../tools/app-state-snapshot';
 import { waitForSettle, type SettlePolicy } from '../tools/settle-policy';
+import { navigateSemantically, type NativeFallbackQuery } from '../tools/semantic-navigation';
 import { SimulatorManager } from '../simulator';
 import { getAccessibilityBridge } from '../native';
 import { getInputBackend } from '../tools/native-input-utils';
@@ -19,7 +20,7 @@ export interface TestStep {
   action:
     | 'navigate' | 'click' | 'type' | 'scroll' | 'wait' | 'assert' | 'screenshot'
     | 'recordState' | 'launchApp' | 'gotoScreen' | 'tapElement' | 'typeElement'
-    | 'waitFor' | 'assertElement' | 'collectDebugBundle';
+    | 'waitFor' | 'assertElement' | 'popUntil' | 'dismissOverlay' | 'collectDebugBundle';
   target?: string;     // CSS selector
   value?: string;      // input value, URL, or scroll direction
   assertion?: string;  // JS expression for assert steps
@@ -31,6 +32,10 @@ export interface TestStep {
   settle?: SettlePolicy;
   condition?: SettlePolicy['condition'];
   context?: 'native' | 'webview' | 'safari' | 'flutter';
+  allowNativeFallback?: boolean;
+  nativeFallbackQueries?: NativeFallbackQuery[];
+  maxNativeAttempts?: number;
+  mode?: 'auto' | 'drawer' | 'bottom_sheet' | 'dialog';
 }
 
 export interface StepResult {
@@ -196,24 +201,30 @@ export class ScenarioRunner {
         }
         case 'gotoScreen': {
           const postconditionQuery = step.settle?.query ?? step.query;
-          if (!postconditionQuery) {
-            throw new Error('gotoScreen requires a postcondition query');
+          const route = step.context === 'flutter' && step.target ? step.target : undefined;
+          if (!postconditionQuery && !route) {
+            throw new Error('gotoScreen requires a postcondition query or Flutter route target');
           }
-          if (step.value) {
-            await new SimulatorManager().openUrl(sim.device.udid, step.value);
-          }
-          {
-            verification = await waitForSettle(sim.device.udid, {
-              ...(step.settle ?? {}),
-              query: postconditionQuery,
-              condition: step.condition ?? step.settle?.condition ?? 'exists',
+          const nav = await navigateSemantically({
+            deviceId: sim.device.udid,
+            url: step.value,
+            bundleId: step.expectedBundleId ?? step.bundleId,
+            postcondition: {
+              ...(postconditionQuery ?? {}),
+              route,
               timeoutMs: step.timeout ?? step.settle?.timeoutMs,
-            });
-            if (!(verification as { met?: boolean }).met) {
-              throw new Error('gotoScreen postcondition was not met');
-            }
+              stableMs: step.settle?.stableMs,
+            },
+            allowNativeFallback: step.allowNativeFallback,
+            nativeFallbackQueries: step.nativeFallbackQueries,
+            maxNativeAttempts: step.maxNativeAttempts,
+            collectState: false,
+          });
+          verification = nav.verification;
+          if (nav.strategy === 'failed') {
+            throw new Error('gotoScreen postcondition was not met');
           }
-          result = { strategy: step.value ? 'deeplink_postcondition' : 'state_only', value: step.value };
+          result = nav;
           break;
         }
         case 'waitFor':
@@ -291,6 +302,50 @@ export class ScenarioRunner {
           result = { typed: true, path: match.path, length: step.value.length, backend: backend.kind, focus };
           break;
         }
+        case 'popUntil': {
+          const backend = await getInputBackend(sim.device.udid, sim.client);
+          const attempts: Array<{ action: string; ok: boolean; elapsedMs: number; error?: string }> = [];
+          const max = Math.max(1, Math.min(step.maxNativeAttempts ?? 3, 10));
+          const dispatches: Array<{ action: string; run: () => Promise<void> }> = [
+            { action: 'escape', run: () => backend.sendKey(sim.device.udid, 'Escape') },
+            { action: 'edge_swipe', run: () => backend.swipe(sim.device.udid, 2, 420, 220, 420, 0.18) },
+          ];
+          for (let i = 0; i < max; i++) {
+            for (const dispatch of dispatches) {
+              const started = Date.now();
+              try {
+                await dispatch.run();
+                attempts.push({ action: dispatch.action, ok: true, elapsedMs: Date.now() - started });
+              } catch (err) {
+                attempts.push({ action: dispatch.action, ok: false, elapsedMs: Date.now() - started, error: err instanceof Error ? err.message : String(err) });
+                continue;
+              }
+              if (step.settle?.query || step.query) {
+                verification = await waitForSettle(sim.device.udid, { ...(step.settle ?? {}), query: step.settle?.query ?? step.query, condition: step.condition ?? step.settle?.condition ?? 'exists', timeoutMs: step.timeout ?? step.settle?.timeoutMs });
+                if ((verification as { met?: boolean }).met) break;
+              }
+            }
+            if (!step.settle?.query && !step.query) break;
+            if ((verification as { met?: boolean } | undefined)?.met) break;
+          }
+          if ((step.settle?.query || step.query) && !(verification as { met?: boolean } | undefined)?.met) throw new Error('popUntil postcondition was not met');
+          result = { popped: attempts.filter((a) => a.ok).length, attempts };
+          break;
+        }
+        case 'dismissOverlay': {
+          const backend = await getInputBackend(sim.device.udid, sim.client);
+          const mode = step.mode ?? 'auto';
+          const attempts: string[] = [];
+          if (mode === 'dialog' || mode === 'auto') { await backend.sendKey(sim.device.udid, 'Escape').catch(() => undefined); attempts.push('escape'); }
+          if (mode === 'drawer' || mode === 'auto') { await backend.swipe(sim.device.udid, 360, 400, 80, 400, 0.25).catch(() => undefined); attempts.push('swipe_from_right'); }
+          if (mode === 'bottom_sheet' || mode === 'auto') { await backend.swipe(sim.device.udid, 200, 240, 200, 720, 0.25).catch(() => undefined); attempts.push('swipe_down'); }
+          if (step.settle?.query || step.query) {
+            verification = await waitForSettle(sim.device.udid, { ...(step.settle ?? {}), query: step.settle?.query ?? step.query, condition: step.condition ?? step.settle?.condition ?? 'not_exists', timeoutMs: step.timeout ?? step.settle?.timeoutMs });
+            if (!(verification as { met?: boolean }).met) throw new Error('dismissOverlay postcondition was not met');
+          }
+          result = { dismissed: true, mode, attempts };
+          break;
+        }
         case 'collectDebugBundle': {
           result = await collectDebugBundle({
             deviceId: sim.device.udid,
@@ -348,6 +403,8 @@ function isMobileV2Step(step: TestStep): boolean {
     'typeElement',
     'waitFor',
     'assertElement',
+    'popUntil',
+    'dismissOverlay',
     'collectDebugBundle',
   ].includes(step.action);
 }

--- a/src/orchestration/scenario-runner.ts
+++ b/src/orchestration/scenario-runner.ts
@@ -303,6 +303,8 @@ export class ScenarioRunner {
           break;
         }
         case 'popUntil': {
+          const postconditionQuery = step.settle?.query ?? step.query;
+          if (!postconditionQuery) throw new Error('popUntil requires query or settle.query postcondition');
           const backend = await getInputBackend(sim.device.udid, sim.client);
           const attempts: Array<{ action: string; ok: boolean; elapsedMs: number; error?: string }> = [];
           const max = Math.max(1, Math.min(step.maxNativeAttempts ?? 3, 10));
@@ -320,28 +322,66 @@ export class ScenarioRunner {
                 attempts.push({ action: dispatch.action, ok: false, elapsedMs: Date.now() - started, error: err instanceof Error ? err.message : String(err) });
                 continue;
               }
-              if (step.settle?.query || step.query) {
-                verification = await waitForSettle(sim.device.udid, { ...(step.settle ?? {}), query: step.settle?.query ?? step.query, condition: step.condition ?? step.settle?.condition ?? 'exists', timeoutMs: step.timeout ?? step.settle?.timeoutMs });
-                if ((verification as { met?: boolean }).met) break;
-              }
+              verification = await waitForSettle(sim.device.udid, { ...(step.settle ?? {}), query: postconditionQuery, condition: step.condition ?? step.settle?.condition ?? 'exists', timeoutMs: step.timeout ?? step.settle?.timeoutMs });
+              if ((verification as { met?: boolean }).met) break;
             }
-            if (!step.settle?.query && !step.query) break;
             if ((verification as { met?: boolean } | undefined)?.met) break;
           }
-          if ((step.settle?.query || step.query) && !(verification as { met?: boolean } | undefined)?.met) throw new Error('popUntil postcondition was not met');
+          if (!(verification as { met?: boolean } | undefined)?.met) {
+            return {
+              device: sim.preset,
+              deviceId: sim.device.udid,
+              passed: false,
+              beforeState,
+              afterState: await safeState(sim.device.udid, step.expectedBundleId ?? step.bundleId),
+              selectedBackend: inferStepBackend(step),
+              headless: true,
+              result: { popped: attempts.filter((a) => a.ok).length, attempts },
+              verification,
+              error: 'popUntil postcondition was not met',
+              timing: Date.now() - start,
+            };
+          }
           result = { popped: attempts.filter((a) => a.ok).length, attempts };
           break;
         }
         case 'dismissOverlay': {
+          const postconditionQuery = step.settle?.query ?? step.query;
+          if (!postconditionQuery) throw new Error('dismissOverlay requires query or settle.query postcondition');
           const backend = await getInputBackend(sim.device.udid, sim.client);
           const mode = step.mode ?? 'auto';
-          const attempts: string[] = [];
-          if (mode === 'dialog' || mode === 'auto') { await backend.sendKey(sim.device.udid, 'Escape').catch(() => undefined); attempts.push('escape'); }
-          if (mode === 'drawer' || mode === 'auto') { await backend.swipe(sim.device.udid, 360, 400, 80, 400, 0.25).catch(() => undefined); attempts.push('swipe_from_right'); }
-          if (mode === 'bottom_sheet' || mode === 'auto') { await backend.swipe(sim.device.udid, 200, 240, 200, 720, 0.25).catch(() => undefined); attempts.push('swipe_down'); }
-          if (step.settle?.query || step.query) {
-            verification = await waitForSettle(sim.device.udid, { ...(step.settle ?? {}), query: step.settle?.query ?? step.query, condition: step.condition ?? step.settle?.condition ?? 'not_exists', timeoutMs: step.timeout ?? step.settle?.timeoutMs });
-            if (!(verification as { met?: boolean }).met) throw new Error('dismissOverlay postcondition was not met');
+          const attempts: Array<{ action: string; ok: boolean; elapsedMs: number; error?: string }> = [];
+          const dispatches: Array<{ action: string; enabled: boolean; run: () => Promise<void> }> = [
+            { action: 'escape', enabled: mode === 'dialog' || mode === 'auto', run: () => backend.sendKey(sim.device.udid, 'Escape') },
+            { action: 'swipe_from_right', enabled: mode === 'drawer' || mode === 'auto', run: () => backend.swipe(sim.device.udid, 360, 400, 80, 400, 0.25) },
+            { action: 'swipe_down', enabled: mode === 'bottom_sheet' || mode === 'auto', run: () => backend.swipe(sim.device.udid, 200, 240, 200, 720, 0.25) },
+          ];
+          for (const dispatch of dispatches.filter((d) => d.enabled)) {
+            const started = Date.now();
+            try {
+              await dispatch.run();
+              attempts.push({ action: dispatch.action, ok: true, elapsedMs: Date.now() - started });
+            } catch (err) {
+              attempts.push({ action: dispatch.action, ok: false, elapsedMs: Date.now() - started, error: err instanceof Error ? err.message : String(err) });
+              continue;
+            }
+            verification = await waitForSettle(sim.device.udid, { ...(step.settle ?? {}), query: postconditionQuery, condition: step.condition ?? step.settle?.condition ?? 'not_exists', timeoutMs: step.timeout ?? step.settle?.timeoutMs });
+            if ((verification as { met?: boolean }).met) break;
+          }
+          if (!(verification as { met?: boolean } | undefined)?.met) {
+            return {
+              device: sim.preset,
+              deviceId: sim.device.udid,
+              passed: false,
+              beforeState,
+              afterState: await safeState(sim.device.udid, step.expectedBundleId ?? step.bundleId),
+              selectedBackend: inferStepBackend(step),
+              headless: true,
+              result: { dismissed: false, mode, attempts },
+              verification,
+              error: 'dismissOverlay postcondition was not met',
+              timing: Date.now() - start,
+            };
           }
           result = { dismissed: true, mode, attempts };
           break;

--- a/src/tools/app-dismiss-overlay.ts
+++ b/src/tools/app-dismiss-overlay.ts
@@ -17,9 +17,9 @@
 
 import { MCPServer, getWebKitClient } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
-import { getAccessibilityBridge } from '../native';
 import { getInputBackend } from './native-input-utils';
 import { ErrorCode, respondWithStructuredError } from '../errors';
+import { waitForSettle } from './settle-policy';
 import {
   wrapHandlerForBundle,
   COLLECT_DEBUG_BUNDLE_ON_FAILURE_SCHEMA,
@@ -84,49 +84,30 @@ async function verifyPostcondition(
   kind: VerificationKind,
   spec: OverlayVerificationSpec,
 ): Promise<OverlayVerificationResult> {
-  const bridge = getAccessibilityBridge();
   const query = {
     identifier: spec.identifier,
     label: spec.label,
     text: spec.text,
     role: spec.role,
   };
-  const timeoutMs = Math.max(0, Math.floor(spec.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS));
-  const intervalMs = Math.max(50, Math.floor(spec.intervalMs ?? DEFAULT_VERIFY_INTERVAL_MS));
-  const start = Date.now();
-  const deadline = start + timeoutMs;
-  let polls = 0;
-  let finalMatchCount = 0;
-
-  while (Date.now() <= deadline) {
-    polls++;
-    const result = await bridge.query(query, { deviceId });
-    finalMatchCount = result.matches.length;
-    const verified = kind === 'gone' ? finalMatchCount === 0 : finalMatchCount > 0;
-    if (verified) {
-      return {
-        requested: true,
-        kind,
-        verified: true,
-        query,
-        elapsedMs: Date.now() - start,
-        polls,
-        finalMatchCount,
-      };
-    }
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) break;
-    await new Promise((resolve) => setTimeout(resolve, Math.min(intervalMs, remaining)));
-  }
-
+  const settle = await waitForSettle(deviceId, {
+    query,
+    condition: kind === 'gone' ? 'not_exists' : 'exists',
+    timeoutMs: spec.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS,
+    intervalMs: spec.intervalMs ?? DEFAULT_VERIFY_INTERVAL_MS,
+    stableMs: 0,
+    allowTransientErrors: true,
+    maxRecoverableRetries: 2,
+  });
   return {
     requested: true,
     kind,
-    verified: false,
+    verified: settle.met,
     query,
-    elapsedMs: Date.now() - start,
-    polls,
-    finalMatchCount,
+    elapsedMs: settle.elapsedMs,
+    polls: settle.polls,
+    finalMatchCount: settle.matchingCount,
+    error: settle.errors.at(-1),
   };
 }
 

--- a/src/tools/app-goto-screen.ts
+++ b/src/tools/app-goto-screen.ts
@@ -1,27 +1,11 @@
 /**
- * `app_goto_screen` — high-level "take me to this screen" macro.
+ * `app_goto_screen` — high-level verified semantic screen navigation.
  *
- * Composes a deeplink open with a post-condition wait, so cross-screen
- * navigation that previously took the LLM 3-4 separate calls
- * (`app_deeplink` → `app_wait_for` → maybe `app_tap_element` to land
- * on the exact tab) collapses into a single semantic action.
- *
- * Input
- *   url           — required. The deeplink to dispatch via `simctl
- *                   openurl`. Callers can mint this from
- *                   `app_list_routes` (#779) if they need to discover
- *                   what's supported.
- *   waitFor       — required postcondition. After the openurl succeeds,
- *                   poll the AX tree until an element matching this label /
- *                   identifier appears. Default timeout 5000 ms.
- *
- * On failure the response uses StructuredErrorException's MCP shape so
- * the caller's auto-retry layer can introspect `recoverable` /
- * `suggestion`.
+ * Dispatching a deeplink/tap/route mutation is not success. The tool first
+ * checks whether the requested postcondition is already true, then tries the
+ * requested transport, and only reports success when the postcondition is met.
  */
 
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { MCPServer } from '../mcp-server';
 import { getSessionManager } from '../session-manager';
 import { SimulatorManager } from '../simulator';
@@ -31,10 +15,12 @@ import {
   wrapHandlerForBundle,
   COLLECT_DEBUG_BUNDLE_ON_FAILURE_SCHEMA,
 } from './debug-bundle-attach';
-import { collectAppSessionState } from './app-state-snapshot';
-import { waitForSettle } from './settle-policy';
-
-const execFileAsync = promisify(execFile);
+import {
+  hasScreenPostconditionSignal,
+  navigateSemantically,
+  type NativeFallbackQuery,
+  type ScreenTargetPostcondition,
+} from './semantic-navigation';
 
 async function resolveDeviceId(explicit?: string): Promise<string | null> {
   if (explicit) return explicit;
@@ -49,21 +35,14 @@ async function resolveDeviceId(explicit?: string): Promise<string | null> {
   return null;
 }
 
-interface WaitForSpec {
-  label?: string;
-  identifier?: string;
-  role?: string;
-  text?: string;
-  timeoutMs?: number;
-  stableMs?: number;
-}
+type WaitForSpec = ScreenTargetPostcondition;
 
 export function registerAppGotoScreenTool(server: MCPServer): void {
   server.registerTool(
     {
       name: 'app_goto_screen',
       description:
-        'High-level "take me to this screen" macro. Dispatches a deeplink via simctl openurl, then requires a waitFor postcondition to verify the target screen before reporting success. Collapses the common app_deeplink → app_wait_for sequence into a single call.',
+        'High-level verified semantic navigation. Dispatches a deeplink only after an already-on-target check, optionally tries bounded native fallback queries, and reports success only when waitFor postcondition is met.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -71,18 +50,34 @@ export function registerAppGotoScreenTool(server: MCPServer): void {
           waitFor: {
             type: 'object',
             description:
-              'Required postcondition. The tool polls the AX tree until at least one node matches the supplied label / identifier / text / role, or the timeout fires. Dispatch-only deeplink calls are rejected as unverified.',
+              'Required postcondition. Provide identifier, label, text, role, and/or Flutter route. Transport-only navigation is rejected as unverified.',
             properties: {
               label: { type: 'string' },
               identifier: { type: 'string' },
               text: { type: 'string' },
               role: { type: 'string' },
+              route: { type: 'string', description: 'Optional Flutter route name to verify when VM Service is connected.' },
               timeoutMs: { type: 'number', description: 'Poll timeout (default 5000)' },
               stableMs: { type: 'number', description: 'Require the postcondition to hold continuously for this many ms before success.' },
             },
           },
           bundleId: { type: 'string', description: 'Target app bundle ID (forces ensureSemanticsActive scope)' },
           deviceId: { type: 'string' },
+          allowNativeFallback: { type: 'boolean', description: 'When true, try bounded native fallback queries after already-on-target/deeplink strategies fail. Default false.' },
+          nativeFallbackQueries: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                identifier: { type: 'string' },
+                label: { type: 'string' },
+                text: { type: 'string' },
+                role: { type: 'string' },
+              },
+            },
+            description: 'Bounded native fallback elements to press/tap in order. Requires allowNativeFallback=true and every attempt is postcondition-verified.',
+          },
+          maxNativeAttempts: { type: 'number', description: 'Maximum native fallback attempts (default 3).' },
           collectDebugBundleOnFailure: COLLECT_DEBUG_BUNDLE_ON_FAILURE_SCHEMA,
         },
         required: ['url', 'waitFor'],
@@ -102,10 +97,10 @@ export function registerAppGotoScreenTool(server: MCPServer): void {
           { url },
         );
       }
-      if (!hasWaitForSignal(waitForSpec)) {
+      if (!hasScreenPostconditionSignal(waitForSpec)) {
         return respondWithStructuredError(
           ErrorCode.INVALID_INPUT,
-          'waitFor requires at least one of identifier, label, text, or role',
+          'waitFor requires at least one of identifier, label, text, role, or route',
           { waitFor: waitForSpec },
         );
       }
@@ -115,174 +110,44 @@ export function registerAppGotoScreenTool(server: MCPServer): void {
         return respondWithStructuredError(ErrorCode.DEVICE_NOT_BOOTED, 'No booted simulator found');
       }
 
-      // Make sure semantics are active before we start polling.
       const bundleId = params.bundleId as string | undefined;
       try {
         await ensureSemanticsActive(deviceId, { bundleId });
       } catch {
-        // Continue — the poll loop tolerates AX errors as transient.
+        // Continue — the settle loop tolerates AX errors as transient.
       }
 
-      const attempts: Array<{
-        strategy: string;
-        elapsedMs: number;
-        ok: boolean;
-        skipped?: boolean;
-        skipReason?: string;
-        verification?: unknown;
-        error?: string;
-      }> = [];
-
-      let beforeState: unknown;
       try {
-        beforeState = await collectAppSessionState({
+        const result = await navigateSemantically({
           deviceId,
-          expectedBundleId: bundleId,
-          includeFlutter: true,
-          maxVisibleNodes: 12,
+          url,
+          bundleId,
+          postcondition: waitForSpec,
+          allowNativeFallback: params.allowNativeFallback === true,
+          nativeFallbackQueries: Array.isArray(params.nativeFallbackQueries)
+            ? (params.nativeFallbackQueries as NativeFallbackQuery[])
+            : undefined,
+          maxNativeAttempts: params.maxNativeAttempts as number | undefined,
         });
-      } catch (err) {
-        attempts.push({
-          strategy: 'state_snapshot',
-          elapsedMs: 0,
-          ok: false,
-          skipped: true,
-          skipReason: err instanceof Error ? err.message : String(err),
-        });
-      }
 
-      if (waitForSpec) {
-        const alreadyStart = Date.now();
-        try {
-          const pre = await waitForSettle(deviceId, {
-            query: {
-              identifier: waitForSpec.identifier,
-              label: waitForSpec.label,
-              text: waitForSpec.text,
-              role: waitForSpec.role,
-            },
-            condition: 'exists',
-            timeoutMs: 250,
-            intervalMs: 100,
-            stableMs: 0,
-            allowTransientErrors: true,
-            maxRecoverableRetries: 1,
-          });
-          attempts.push({
-            strategy: 'already_on_target',
-            elapsedMs: Date.now() - alreadyStart,
-            ok: pre.met,
-            verification: pre,
-          });
-          if (pre.met) {
-            return {
-              content: [{
-                type: 'text' as const,
-                text: JSON.stringify({
-                  navigated: false,
-                  strategy: 'already_on_target',
-                  url,
-                  deviceId,
-                  beforeState,
-                  afterState: beforeState,
-                  attempts,
-                  waitFor: { ...waitForSpec, matched: true, elapsedMs: pre.elapsedMs, matchCount: pre.matchingCount },
-                  verification: pre,
-                }, null, 2),
-              }],
-            };
-          }
-        } catch (err) {
-          attempts.push({
-            strategy: 'already_on_target',
-            elapsedMs: Date.now() - alreadyStart,
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+        if (!result.navigated && result.strategy === 'failed') {
+          return respondWithStructuredError(
+            ErrorCode.FLUTTER_EVAL_FAILED,
+            'app_goto_screen postcondition was not met',
+            { ...result },
+          );
         }
-      }
 
-      // Dispatch the deeplink only after the non-mutating already-on-target
-      // check has failed. This preserves the semantic navigation contract:
-      // when the requested postcondition is already true, the tool returns
-      // without perturbing the app state.
-      const openedAt = Date.now();
-      try {
-        await execFileAsync('xcrun', ['simctl', 'openurl', deviceId, url]);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+        };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        attempts.push({
-          strategy: 'deeplink',
-          elapsedMs: Date.now() - openedAt,
-          ok: false,
-          error: message,
-        });
         return respondWithStructuredError(ErrorCode.FLUTTER_EVAL_FAILED, message, {
           url,
           deviceId,
-          beforeState,
-          attempts,
         });
       }
-
-      const verifyStart = Date.now();
-      let verification: unknown;
-      let verdict: { matched: boolean; elapsedMs: number; matchCount: number };
-      const settle = await waitForSettle(deviceId, {
-        query: {
-          identifier: waitForSpec.identifier,
-          label: waitForSpec.label,
-          text: waitForSpec.text,
-          role: waitForSpec.role,
-        },
-        condition: 'exists',
-        timeoutMs: waitForSpec.timeoutMs ?? 5000,
-        intervalMs: 250,
-        stableMs: waitForSpec.stableMs ?? 0,
-        allowTransientErrors: true,
-        maxRecoverableRetries: 3,
-      });
-      verification = settle;
-      verdict = { matched: settle.met, elapsedMs: settle.elapsedMs, matchCount: settle.matchingCount };
-      attempts.push({
-        strategy: 'deeplink_postcondition',
-        elapsedMs: Date.now() - verifyStart,
-        ok: settle.met,
-        verification: settle,
-      });
-      let afterState: unknown;
-      try {
-        afterState = await collectAppSessionState({
-          deviceId,
-          expectedBundleId: bundleId,
-          includeFlutter: true,
-          maxVisibleNodes: 12,
-        });
-      } catch {
-        afterState = undefined;
-      }
-      return {
-        content: [{
-          type: 'text' as const,
-          text: JSON.stringify({
-            navigated: true,
-            strategy: 'deeplink',
-            url,
-            deviceId,
-            openedAt: new Date(openedAt).toISOString(),
-            beforeState,
-            afterState,
-            attempts,
-            waitFor: { ...waitForSpec, ...verdict },
-            verification,
-          }, null, 2),
-        }],
-        isError: !verdict.matched,
-      };
     }),
   );
-}
-
-function hasWaitForSignal(spec: WaitForSpec): boolean {
-  return Boolean(spec.identifier || spec.label || spec.text || spec.role);
 }

--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -23,6 +23,7 @@ import type { AccessibilityBridge } from '../native/accessibility-bridge';
 import { walkTree, fingerprintTree } from '../native/ax-verification';
 import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 import { probeMobileContext } from './app-context';
+import { waitForSettle, type SettlePolicy } from './settle-policy';
 import {
   activateAndClassify,
   createContextMismatchError,
@@ -116,6 +117,19 @@ export function registerAppTapElementTool(server: MCPServer): void {
             type: 'boolean',
             description:
               'When the primary identifier/label/text/role query misses, retry with a relaxed `text` substring built from all provided query fields. Catches the common case where the desired string lives in `value` rather than `label`. Default false.',
+          },
+          settle: {
+            type: 'object',
+            description: 'Optional semantic postcondition. When supplied, the tap is only reported successful if the shared settle policy is met after dispatch.',
+            properties: {
+              query: { type: 'object', properties: { identifier: { type: 'string' }, label: { type: 'string' }, text: { type: 'string' }, role: { type: 'string' } } },
+              condition: { type: 'string', enum: ['exists', 'not_exists', 'visible', 'enabled'] },
+              timeoutMs: { type: 'number' },
+              intervalMs: { type: 'number' },
+              stableMs: { type: 'number' },
+              allowTransientErrors: { type: 'boolean' },
+              maxRecoverableRetries: { type: 'number' },
+            },
           },
           collectDebugBundleOnFailure: COLLECT_DEBUG_BUNDLE_ON_FAILURE_SCHEMA,
         },
@@ -421,6 +435,8 @@ export function registerAppTapElementTool(server: MCPServer): void {
                 ...(response._meta as Record<string, unknown>),
                 context: contextMeta,
               };
+              const settle = await runOptionalPostActionSettle(deviceId, params, response);
+              if (settle) return settle;
               return {
                 content: [{ type: 'text' as const, text: JSON.stringify(response) }],
               };
@@ -573,6 +589,8 @@ export function registerAppTapElementTool(server: MCPServer): void {
           response.warning = response.warning
             ? `${response.warning}; The tap was dispatched but post-action AX verification was unavailable.`
             : 'The tap was dispatched but post-action AX verification was unavailable.';
+          const settle = await runOptionalPostActionSettle(deviceId, params, response);
+          if (settle) return settle;
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(response) }],
           };
@@ -586,6 +604,8 @@ export function registerAppTapElementTool(server: MCPServer): void {
           );
         }
 
+        const settle = await runOptionalPostActionSettle(deviceId, params, response);
+        if (settle) return settle;
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(response) }],
         };
@@ -939,4 +959,21 @@ export function buildAXPressResponse(args: {
     response.warning = warnings.join('; ');
   }
   return response;
+}
+
+
+async function runOptionalPostActionSettle(
+  deviceId: string,
+  params: Record<string, unknown>,
+  response: Record<string, unknown>,
+): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean } | null> {
+  const settle = params.settle as SettlePolicy | undefined;
+  if (!settle?.query) return null;
+  const verification = await waitForSettle(deviceId, settle);
+  response.settle = verification;
+  response.verifiedPostcondition = verification.met;
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(response) }],
+    ...(verification.met ? {} : { isError: true as const }),
+  };
 }

--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -53,6 +53,7 @@ import {
   type PasteNotAppliedError,
 } from './pasteboard-input';
 import { mismatchHint } from './keyboard-layout';
+import { waitForSettle, type SettlePolicy } from './settle-policy';
 
 const execFileAsync = promisify(execFile);
 
@@ -162,6 +163,19 @@ export function registerAppTypeElementTool(server: MCPServer): void {
             type: 'number',
             description:
               'When backend resolves to simhid (HID keyboard): inserts an inter-character pause between consecutive key sends. Default 0 (no pause). Required for segmented OTP-style fields (e.g. 6-cell verify-code inputs in Flutter) that drop characters when keys arrive faster than the field can advance focus. Recommended: 80–150 ms for 6-digit OTP inputs.',
+          },
+          settle: {
+            type: 'object',
+            description: 'Optional semantic postcondition. When supplied, typing is only reported successful if the shared settle policy is met after dispatch.',
+            properties: {
+              query: { type: 'object', properties: { identifier: { type: 'string' }, label: { type: 'string' }, text: { type: 'string' }, role: { type: 'string' } } },
+              condition: { type: 'string', enum: ['exists', 'not_exists', 'visible', 'enabled'] },
+              timeoutMs: { type: 'number' },
+              intervalMs: { type: 'number' },
+              stableMs: { type: 'number' },
+              allowTransientErrors: { type: 'boolean' },
+              maxRecoverableRetries: { type: 'number' },
+            },
           },
           collectDebugBundleOnFailure: COLLECT_DEBUG_BUNDLE_ON_FAILURE_SCHEMA,
         },
@@ -334,32 +348,24 @@ export function registerAppTypeElementTool(server: MCPServer): void {
             throw err;
           }
 
+          const pasteResponse: Record<string, unknown> = {
+            status: 'typed',
+            element: elementDescriptor,
+            coordinates: { x: centerX, y: centerY },
+            length: textToType.length,
+            backend: 'pasteboard',
+            focusBackend: focusedViaAXPress ? 'ax-press' : backend.kind,
+            pasteboardRestored: pasteResult.pasteboardRestored,
+            permissionDialog: pasteResult.permissionDialog,
+            permissionDialogMatchedLabel: pasteResult.permissionDialogMatchedLabel,
+            elapsedMs: pasteResult.elapsedMs,
+            deviceId,
+            ...(pasteResult.secureField ? { secureField: true } : {}),
+          };
+          const settle = await runOptionalPostTypeSettle(deviceId, params, pasteResponse);
           return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify({
-                  status: 'typed',
-                  element: elementDescriptor,
-                  coordinates: { x: centerX, y: centerY },
-                  length: textToType.length,
-                  backend: 'pasteboard',
-                  focusBackend: focusedViaAXPress ? 'ax-press' : backend.kind,
-                  pasteboardRestored: pasteResult.pasteboardRestored,
-                  permissionDialog: pasteResult.permissionDialog,
-                  permissionDialogMatchedLabel:
-                    pasteResult.permissionDialogMatchedLabel,
-                  elapsedMs: pasteResult.elapsedMs,
-                  deviceId,
-                  // Echoed when readback was skipped because the focused
-                  // element is an `AXSecureTextField` (password) whose AX
-                  // value is OS-masked. Lets callers distinguish "no
-                  // readback because secure field" from "no readback because
-                  // verify opted out" (issue #760).
-                  ...(pasteResult.secureField ? { secureField: true } : {}),
-                }),
-              },
-            ],
+            content: [{ type: 'text' as const, text: JSON.stringify(pasteResponse) }],
+            ...(settle?.met === false ? { isError: true as const } : {}),
           };
         }
 
@@ -464,12 +470,14 @@ export function registerAppTypeElementTool(server: MCPServer): void {
                 };
           }
         }
+        const settle = await runOptionalPostTypeSettle(deviceId, params, responseBody);
         const result: {
           content: Array<{ type: 'text'; text: string }>;
           isError?: boolean;
         } = {
           content: [{ type: 'text' as const, text: JSON.stringify(responseBody) }],
         };
+        if (settle?.met === false) result.isError = true;
         if (mismatched) {
           result.isError = true;
         }
@@ -645,4 +653,18 @@ function computeDroppedIndices(expected: string, actual: string): number[] {
   }
 
   return dropped;
+}
+
+
+async function runOptionalPostTypeSettle(
+  deviceId: string,
+  params: Record<string, unknown>,
+  response: Record<string, unknown>,
+): Promise<{ met: boolean } | null> {
+  const settle = params.settle as SettlePolicy | undefined;
+  if (!settle?.query) return null;
+  const verification = await waitForSettle(deviceId, settle);
+  response.settle = verification;
+  response.verifiedPostcondition = verification.met;
+  return { met: verification.met };
 }

--- a/src/tools/flutter-connect.ts
+++ b/src/tools/flutter-connect.ts
@@ -115,15 +115,17 @@ export function registerFlutterConnectTool(server: MCPServer): void {
       } catch (err) {
         const message = redactVmServiceUrl(err instanceof Error ? err.message : String(err)) ?? '';
         console.error(`[flutter_connect] ${message}`);
+        const attachDiagnostics = buildStaticAttachDiagnostics(params);
         return respondWithStructuredError(ErrorCode.FLUTTER_VM_NOT_CONNECTED, message, {
-          attachDiagnostics: buildStaticAttachDiagnostics(params),
+          attachDiagnostics,
+          suggestions: buildAttachTroubleshooting(message, attachDiagnostics.attempts),
         });
       }
     },
   );
 }
 
-interface AttachAttempt {
+export interface AttachAttempt {
   source: 'explicit_url' | 'env_http_url' | 'env_ws_url' | 'cache' | 'fixed_port' | 'log_scan';
   url?: string;
   valid?: boolean;
@@ -132,7 +134,7 @@ interface AttachAttempt {
   reason?: string;
 }
 
-async function buildAttachDiagnostics(args: {
+export async function buildAttachDiagnostics(args: {
   explicitUrl?: string;
   port?: number;
   authCode?: string;
@@ -206,7 +208,7 @@ async function buildAttachDiagnostics(args: {
   return { attempts, fixedPortUrl, cachedUrl: cached };
 }
 
-function buildStaticAttachDiagnostics(params: Record<string, unknown>): { attempts: AttachAttempt[] } {
+export function buildStaticAttachDiagnostics(params: Record<string, unknown>): { attempts: AttachAttempt[] } {
   const explicit = params.vm_service_url as string | undefined;
   const port = params.vm_service_port as number | undefined;
   const attempts: AttachAttempt[] = [];
@@ -239,4 +241,26 @@ export function redactVmServiceUrl(url: string | undefined): string | undefined 
       return `${prefix}<redacted>${suffix ?? '/'}`;
     },
   );
+}
+
+
+export function buildAttachTroubleshooting(message: string, attempts: AttachAttempt[]): string[] {
+  const suggestions: string[] = [];
+  if (/invalid/i.test(message) || attempts.some((a) => a.valid === false)) {
+    suggestions.push('Check the VM Service URL shape: use http://127.0.0.1:<port>/<auth-code>/ or ws://127.0.0.1:<port>/<auth-code>/ws.');
+  }
+  if (attempts.some((a) => a.source === 'cache' && a.reachable === false)) {
+    suggestions.push('Cached VM Service URL is stale; reconnect with vm_service_url or restart the debug/profile Flutter app.');
+  }
+  if (attempts.some((a) => a.source === 'fixed_port' && a.reachable === false)) {
+    suggestions.push('Fixed VM Service port is not reachable; verify the external flutter run/profile command uses the same host port and auth-code settings.');
+  }
+  if (!attempts.some((a) => a.source === 'explicit_url' || a.source === 'fixed_port' || a.source.startsWith('env_'))) {
+    suggestions.push('For deterministic QA, launch Flutter externally with a fixed VM Service port and pass vm_service_port plus vm_service_auth_code, or pass vm_service_url directly.');
+  }
+  if (/release/i.test(message)) {
+    suggestions.push('Flutter release builds disable VM Service; use debug or profile builds for flutter_* inspection tools.');
+  }
+  suggestions.push('OpenSafari does not own flutter run; keep app launch external and use flutter_connect only to attach.');
+  return [...new Set(suggestions)];
 }

--- a/src/tools/qa-flutter-semantics.ts
+++ b/src/tools/qa-flutter-semantics.ts
@@ -45,6 +45,7 @@ export interface SelectorQualityFinding {
     frame?: AXNode['frame'];
   };
   recommendation: string;
+  vmContext?: { route?: string; widgetTreeHint?: string; sourceLocationHint?: string };
 }
 
 export interface FlutterSelectorQualityReport {
@@ -63,6 +64,8 @@ export interface FlutterSelectorQualityReport {
   enrichment: {
     flutterVmConnected: boolean;
     widgetTreeUsed: boolean;
+    routeContext?: string | null;
+    widgetSummaryHint?: string;
   };
 }
 
@@ -128,9 +131,13 @@ export function registerQaFlutterSemanticsTool(server: MCPServer): void {
           ? Math.round((withIdentifier / totalInteractive) * 100)
           : 100;
         const passed = coverage >= minCoverage;
+        const flutterClient = getFlutterVMClient(deviceId);
+        const vmContext = flutterClient.isConnected()
+          ? await collectSelectorVmContext(flutterClient)
+          : { flutterVmConnected: false };
         const selectorQuality = params.include_selector_quality === false
           ? undefined
-          : analyzeSelectorQuality(tree, { flutterVmConnected: getFlutterVMClient(deviceId).isConnected() });
+          : analyzeSelectorQuality(tree, vmContext);
 
         return {
           content: [{
@@ -223,7 +230,7 @@ function analyzeSemantics(
 
 export function analyzeSelectorQuality(
   tree: AXNode,
-  enrichment: { flutterVmConnected: boolean; widgetTreeUsed?: boolean } = { flutterVmConnected: false },
+  enrichment: { flutterVmConnected: boolean; widgetTreeUsed?: boolean; routeContext?: string | null; widgetSummaryHint?: string; sourceLocationHint?: string } = { flutterVmConnected: false },
 ): FlutterSelectorQualityReport {
   const allNodes: AXNode[] = [];
   const interactive: AXNode[] = [];
@@ -257,6 +264,7 @@ export function analyzeSelectorQuality(
         recommendation: hasLabel
           ? 'Add Semantics(identifier: "...") so automation does not depend on locale/user-visible text.'
           : 'Add Semantics(identifier: "...", label: "...") or an equivalent accessibility identifier for this interactive widget.',
+        vmContext: shapeVmContext(enrichment),
       });
     }
     if (!node.role?.trim()) {
@@ -265,6 +273,7 @@ export function analyzeSelectorQuality(
         category: 'missing_role',
         node: shapeNode(node),
         recommendation: 'Expose an accessibility role/trait so agents can distinguish buttons, fields, tabs, and custom controls.',
+        vmContext: shapeVmContext(enrichment),
       });
     }
   }
@@ -276,6 +285,7 @@ export function analyzeSelectorQuality(
         category: 'duplicate_identifier',
         node: shapeNode(nodes[0]),
         recommendation: `Identifier "${identifier}" appears ${nodes.length} times. Use unique Semantics(identifier:) values for automation targets.`,
+        vmContext: shapeVmContext(enrichment),
       });
     }
   }
@@ -286,6 +296,7 @@ export function analyzeSelectorQuality(
         category: 'duplicate_label',
         node: shapeNode(nodes[0]),
         recommendation: `Label "${label}" appears ${nodes.length} times. Prefer identifiers for disambiguation or include more specific labels.`,
+        vmContext: shapeVmContext(enrichment),
       });
     }
   }
@@ -315,6 +326,8 @@ export function analyzeSelectorQuality(
     enrichment: {
       flutterVmConnected: enrichment.flutterVmConnected,
       widgetTreeUsed: Boolean(enrichment.widgetTreeUsed),
+      routeContext: enrichment.routeContext,
+      widgetSummaryHint: enrichment.widgetSummaryHint,
     },
   };
 }
@@ -338,5 +351,66 @@ function shapeNode(node: AXNode): SelectorQualityFinding['node'] {
     label: node.label,
     identifier: node.identifier,
     frame: node.frame,
+  };
+}
+
+
+async function collectSelectorVmContext(client: ReturnType<typeof getFlutterVMClient>): Promise<{
+  flutterVmConnected: boolean;
+  widgetTreeUsed?: boolean;
+  routeContext?: string | null;
+  widgetSummaryHint?: string;
+  sourceLocationHint?: string;
+}> {
+  let routeContext: string | null | undefined;
+  let widgetSummaryHint: string | undefined;
+  let sourceLocationHint: string | undefined;
+  try {
+    const routeRaw = await client.evaluate(`(() { try { final binding = WidgetsBinding.instance; final root = binding.rootElement; if (root == null) return 'null'; String? name; void visit(Element el) { if (name != null) return; final s = el.toString(); final m = RegExp(r'name:\s*"([^"]+)"').firstMatch(s) ?? RegExp(r"name:\s*'([^']+)'").firstMatch(s); if (m != null) name = m.group(1); el.visitChildren(visit); } visit(root); return name ?? 'unknown'; } catch (e) { return 'unavailable'; } })()`);
+    routeContext = (routeRaw as { valueAsString?: string }).valueAsString ?? null;
+  } catch {
+    routeContext = null;
+  }
+  try {
+    const tree = await client.getRootWidgetSummaryTree({ objectGroup: 'opensafari-selector-quality' });
+    widgetSummaryHint = summarizeWidgetTree(tree);
+    sourceLocationHint = findSourceLocation(tree);
+    return { flutterVmConnected: true, widgetTreeUsed: true, routeContext, widgetSummaryHint, sourceLocationHint };
+  } catch {
+    return { flutterVmConnected: true, widgetTreeUsed: false, routeContext };
+  }
+}
+
+function summarizeWidgetTree(tree: unknown): string | undefined {
+  if (!tree || typeof tree !== 'object') return undefined;
+  const node = tree as { description?: unknown; widgetRuntimeType?: unknown; children?: unknown };
+  const desc = typeof node.description === 'string' ? node.description : undefined;
+  const runtime = typeof node.widgetRuntimeType === 'string' ? node.widgetRuntimeType : undefined;
+  return runtime ?? desc;
+}
+
+function findSourceLocation(tree: unknown): string | undefined {
+  if (!tree || typeof tree !== 'object') return undefined;
+  const node = tree as { creationLocation?: unknown; children?: unknown };
+  if (typeof node.creationLocation === 'string') return node.creationLocation;
+  if (node.creationLocation && typeof node.creationLocation === 'object') {
+    const loc = node.creationLocation as { file?: unknown; line?: unknown; column?: unknown };
+    if (typeof loc.file === 'string') return `${loc.file}:${String(loc.line ?? '?')}:${String(loc.column ?? '?')}`;
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      const found = findSourceLocation(child);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+function shapeVmContext(enrichment: { routeContext?: string | null; widgetSummaryHint?: string; sourceLocationHint?: string } | undefined): SelectorQualityFinding['vmContext'] | undefined {
+  if (!enrichment || (!enrichment.routeContext && !enrichment.widgetSummaryHint && !enrichment.sourceLocationHint)) return undefined;
+  return {
+    route: enrichment.routeContext ?? undefined,
+    widgetTreeHint: enrichment.widgetSummaryHint,
+    sourceLocationHint: enrichment.sourceLocationHint,
   };
 }

--- a/src/tools/qa-flutter-semantics.ts
+++ b/src/tools/qa-flutter-semantics.ts
@@ -366,7 +366,7 @@ async function collectSelectorVmContext(client: ReturnType<typeof getFlutterVMCl
   let widgetSummaryHint: string | undefined;
   let sourceLocationHint: string | undefined;
   try {
-    const routeRaw = await client.evaluate(`(() { try { final binding = WidgetsBinding.instance; final root = binding.rootElement; if (root == null) return 'null'; String? name; void visit(Element el) { if (name != null) return; final s = el.toString(); final m = RegExp(r'name:\s*"([^"]+)"').firstMatch(s) ?? RegExp(r"name:\s*'([^']+)'").firstMatch(s); if (m != null) name = m.group(1); el.visitChildren(visit); } visit(root); return name ?? 'unknown'; } catch (e) { return 'unavailable'; } })()`);
+    const routeRaw = await client.evaluate(`(() { try { final binding = WidgetsBinding.instance; final root = binding.rootElement; if (root == null) return 'null'; String? name; void visit(Element el) { if (name != null) return; final s = el.toString(); final m = RegExp(r'name:\\s*"([^"]+)"').firstMatch(s) ?? RegExp(r"name:\\s*'([^']+)'").firstMatch(s); if (m != null) name = m.group(1); el.visitChildren(visit); } visit(root); return name ?? 'unknown'; } catch (e) { return 'unavailable'; } })()`);
     routeContext = (routeRaw as { valueAsString?: string }).valueAsString ?? null;
   } catch {
     routeContext = null;
@@ -414,3 +414,5 @@ function shapeVmContext(enrichment: { routeContext?: string | null; widgetSummar
     sourceLocationHint: enrichment.sourceLocationHint,
   };
 }
+
+export const __forTests = { collectSelectorVmContext };

--- a/src/tools/scenario-tools.ts
+++ b/src/tools/scenario-tools.ts
@@ -159,6 +159,31 @@ export function registerScenarioTools(server: MCPServer): void {
                     ],
                   },
                 },
+
+                {
+                  if: { properties: { action: { const: 'popUntil' } }, required: ['action'] },
+                  then: {
+                    anyOf: [
+                      { required: ['query'] },
+                      {
+                        required: ['settle'],
+                        properties: { settle: { required: ['query'] } },
+                      },
+                    ],
+                  },
+                },
+                {
+                  if: { properties: { action: { const: 'dismissOverlay' } }, required: ['action'] },
+                  then: {
+                    anyOf: [
+                      { required: ['query'] },
+                      {
+                        required: ['settle'],
+                        properties: { settle: { required: ['query'] } },
+                      },
+                    ],
+                  },
+                },
               ],
             },
             description: 'Ordered list of test steps',

--- a/src/tools/scenario-tools.ts
+++ b/src/tools/scenario-tools.ts
@@ -20,7 +20,7 @@ export function registerScenarioTools(server: MCPServer): void {
   server.registerTool(
     {
       name: 'run_scenario',
-      description: 'Execute a declarative test scenario across devices with per-step, per-device results. Mobile semantic v2 navigation is postcondition-first: action-specific required fields are enforced in the schema before runtime execution.',
+      description: 'Execute a declarative test scenario across devices with per-step, per-device results. Mobile semantic v2 navigation is postcondition-first: action-specific required fields are enforced in the schema before runtime execution; gotoScreen accepts query, settle.query, or context=flutter plus target route and never succeeds on deeplink dispatch alone.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -36,15 +36,30 @@ export function registerScenarioTools(server: MCPServer): void {
                   enum: [
                     'navigate', 'click', 'type', 'scroll', 'wait', 'assert', 'screenshot',
                     'recordState', 'launchApp', 'gotoScreen', 'tapElement', 'typeElement',
-                    'waitFor', 'assertElement', 'collectDebugBundle',
+                    'waitFor', 'assertElement', 'popUntil', 'dismissOverlay', 'collectDebugBundle',
                   ],
                 },
-                target: { type: 'string', description: 'CSS selector' },
-                value: { type: 'string', description: 'Input value, URL, or scroll direction. Required for typeElement. For v2 gotoScreen this is an optional deeplink transport; query or settle.query is still required as the postcondition.' },
+                target: { type: 'string', description: 'CSS selector for browser v1 steps. For v2 gotoScreen with context=flutter, target may be a Flutter route postcondition.' },
+                value: { type: 'string', description: 'Input value, URL, or scroll direction. Required for typeElement. For v2 gotoScreen this is an optional deeplink transport; query, settle.query, or context=flutter plus target route is still required as the postcondition.' },
                 assertion: { type: 'string', description: 'JS expression evaluated in the page context (same as javascript tool). Returns boolean.' },
                 bundleId: { type: 'string', description: 'Bundle id for mobile v2 launchApp' },
                 expectedBundleId: { type: 'string', description: 'Expected app bundle for state snapshots and post-step verification' },
                 context: { type: 'string', enum: ['native', 'webview', 'safari', 'flutter'] },
+                mode: { type: 'string', enum: ['auto', 'drawer', 'bottom_sheet', 'dialog'], description: 'Overlay mode for dismissOverlay.' },
+                allowNativeFallback: { type: 'boolean', description: 'Allow bounded native fallback for gotoScreen.' },
+                nativeFallbackQueries: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      identifier: { type: 'string' },
+                      label: { type: 'string' },
+                      text: { type: 'string' },
+                      role: { type: 'string' },
+                    },
+                  },
+                },
+                maxNativeAttempts: { type: 'number', description: 'Bounded max attempts for native mobile actions.' },
                 query: {
                   type: 'object',
                   description: 'AX query for mobile v2 tap/type/wait/assert steps. Required for tapElement and typeElement as the target selector; gotoScreen, waitFor, and assertElement require query unless settle.query is supplied. Mutating tap/type steps also require settle.query as the success postcondition.',
@@ -58,7 +73,7 @@ export function registerScenarioTools(server: MCPServer): void {
                 condition: { type: 'string', enum: ['exists', 'not_exists', 'visible', 'enabled'] },
                 settle: {
                   type: 'object',
-                  description: 'Shared settle/postcondition policy for mobile v2 steps. For gotoScreen, provide settle.query here or query at the step root; transport-only gotoScreen is invalid.',
+                  description: 'Shared settle/postcondition policy for mobile v2 steps. For gotoScreen, provide settle.query here, query at the step root, or context=flutter plus target route; transport-only gotoScreen is invalid.',
                   properties: {
                     query: {
                       type: 'object',
@@ -94,6 +109,10 @@ export function registerScenarioTools(server: MCPServer): void {
                       {
                         required: ['settle'],
                         properties: { settle: { required: ['query'] } },
+                      },
+                      {
+                        required: ['context', 'target'],
+                        properties: { context: { const: 'flutter' } },
                       },
                     ],
                   },

--- a/src/tools/semantic-navigation.ts
+++ b/src/tools/semantic-navigation.ts
@@ -202,15 +202,23 @@ export async function navigateSemantically(args: SemanticNavigationTarget): Prom
 
   if (args.url) {
     const openStart = Date.now();
-    await execFileAsync('xcrun', ['simctl', 'openurl', args.deviceId, args.url]);
-    attempts.push({ strategy: 'deeplink', elapsedMs: Date.now() - openStart, ok: true });
-    const verifyStart = Date.now();
-    const verification = await verifyPostcondition(args.deviceId, args.postcondition);
-    const ok = postconditionMet(verification);
-    attempts.push({ strategy: 'deeplink_postcondition', elapsedMs: Date.now() - verifyStart, ok, verification });
-    if (ok) {
-      const afterState = args.collectState === false ? undefined : await collectAppSessionState({ deviceId: args.deviceId, expectedBundleId: args.bundleId, includeFlutter: args.includeFlutter !== false, maxVisibleNodes: 12 }).catch(() => undefined);
-      return { navigated: true, strategy: 'deeplink_postcondition', deviceId: args.deviceId, url: args.url, route: args.postcondition.route, beforeState, afterState, attempts, verification, waitFor: args.postcondition as Record<string, unknown>, recoveryHints: [] };
+    let openOk = false;
+    try {
+      await execFileAsync('xcrun', ['simctl', 'openurl', args.deviceId, args.url]);
+      openOk = true;
+      attempts.push({ strategy: 'deeplink', elapsedMs: Date.now() - openStart, ok: true });
+    } catch (err) {
+      attempts.push({ strategy: 'deeplink', elapsedMs: Date.now() - openStart, ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+    if (openOk) {
+      const verifyStart = Date.now();
+      const verification = await verifyPostcondition(args.deviceId, args.postcondition);
+      const ok = postconditionMet(verification);
+      attempts.push({ strategy: 'deeplink_postcondition', elapsedMs: Date.now() - verifyStart, ok, verification });
+      if (ok) {
+        const afterState = args.collectState === false ? undefined : await collectAppSessionState({ deviceId: args.deviceId, expectedBundleId: args.bundleId, includeFlutter: args.includeFlutter !== false, maxVisibleNodes: 12 }).catch(() => undefined);
+        return { navigated: true, strategy: 'deeplink_postcondition', deviceId: args.deviceId, url: args.url, route: args.postcondition.route, beforeState, afterState, attempts, verification, waitFor: args.postcondition as Record<string, unknown>, recoveryHints: [] };
+      }
     }
   } else {
     attempts.push({ strategy: 'deeplink', elapsedMs: 0, ok: false, skipped: true, skipReason: 'No deeplink URL supplied.' });

--- a/src/tools/semantic-navigation.ts
+++ b/src/tools/semantic-navigation.ts
@@ -118,7 +118,7 @@ async function verifyPostcondition(deviceId: string, spec: ScreenTargetPostcondi
   }
   const settle = await waitForSettle(deviceId, settlePolicyFromPostcondition(spec));
   if (spec.route) {
-    const route = await verifyRoute(deviceId, spec.route, Math.min(spec.timeoutMs ?? 1000, 1000));
+    const route = await verifyRoute(deviceId, spec.route, spec.timeoutMs ?? 1000);
     return { ax: settle, route, met: settle.met && route.met };
   }
   return settle;
@@ -195,7 +195,7 @@ export async function navigateSemantically(args: SemanticNavigationTarget): Prom
   const hasAxPostcondition = Boolean(args.postcondition.identifier || args.postcondition.label || args.postcondition.text || args.postcondition.role);
   if (args.postcondition.route) {
     const routeStart = Date.now();
-    const route = await verifyRoute(args.deviceId, args.postcondition.route, Math.min(args.postcondition.timeoutMs ?? 1000, 1000));
+    const route = await verifyRoute(args.deviceId, args.postcondition.route, args.postcondition.timeoutMs ?? 1000);
     attempts.push({ strategy: 'flutter_route', elapsedMs: Date.now() - routeStart, ok: route.met && !hasAxPostcondition, verification: route, skipped: !getFlutterVMClient(args.deviceId).isConnected() || hasAxPostcondition, skipReason: hasAxPostcondition ? 'Route evidence alone is insufficient because AX postcondition was also requested.' : (getFlutterVMClient(args.deviceId).isConnected() ? undefined : 'Flutter VM is not connected.') });
     if (route.met && !hasAxPostcondition) return { navigated: false, strategy: 'flutter_route', deviceId: args.deviceId, url: args.url, route: args.postcondition.route, beforeState, afterState: beforeState, attempts, verification: route, waitFor: args.postcondition as Record<string, unknown>, recoveryHints: [] };
   }
@@ -241,3 +241,5 @@ export async function navigateSemantically(args: SemanticNavigationTarget): Prom
     ],
   };
 }
+
+export const __forTests = { verifyRoute, verifyPostcondition };

--- a/src/tools/semantic-navigation.ts
+++ b/src/tools/semantic-navigation.ts
@@ -1,0 +1,243 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { getAccessibilityBridge } from '../native';
+import { getFlutterVMClient } from '../flutter';
+import { getInputBackend } from './native-input-utils';
+import { waitForSettle, type SettlePolicy } from './settle-policy';
+import { collectAppSessionState } from './app-state-snapshot';
+import { getWebKitClient } from '../mcp-server';
+
+const execFileAsync = promisify(execFile);
+
+export interface ScreenTargetPostcondition {
+  identifier?: string;
+  label?: string;
+  text?: string;
+  role?: string;
+  route?: string;
+  timeoutMs?: number;
+  stableMs?: number;
+}
+
+export interface NativeFallbackQuery {
+  identifier?: string;
+  label?: string;
+  text?: string;
+  role?: string;
+}
+
+export interface SemanticNavigationTarget {
+  deviceId: string;
+  url?: string;
+  bundleId?: string;
+  postcondition: ScreenTargetPostcondition;
+  allowNativeFallback?: boolean;
+  nativeFallbackQueries?: NativeFallbackQuery[];
+  maxNativeAttempts?: number;
+  includeFlutter?: boolean;
+  collectState?: boolean;
+}
+
+export interface SemanticNavigationAttempt {
+  strategy: 'state_snapshot' | 'already_on_target' | 'flutter_route' | 'deeplink' | 'deeplink_postcondition' | 'native_fallback';
+  elapsedMs: number;
+  ok: boolean;
+  skipped?: boolean;
+  skipReason?: string;
+  verification?: unknown;
+  error?: string;
+  detail?: string;
+}
+
+export interface SemanticNavigationResult {
+  navigated: boolean;
+  strategy: string;
+  deviceId: string;
+  url?: string;
+  route?: string;
+  beforeState?: unknown;
+  afterState?: unknown;
+  attempts: SemanticNavigationAttempt[];
+  verification?: unknown;
+  waitFor: Record<string, unknown>;
+  recoveryHints: Array<{ action: string; reason: string; destructive: boolean }>;
+}
+
+export function hasScreenPostconditionSignal(spec: ScreenTargetPostcondition | undefined): spec is ScreenTargetPostcondition {
+  return Boolean(spec && (spec.identifier || spec.label || spec.text || spec.role || spec.route));
+}
+
+export function settlePolicyFromPostcondition(spec: ScreenTargetPostcondition, overrides: Partial<SettlePolicy> = {}): SettlePolicy {
+  if (!(spec.identifier || spec.label || spec.text || spec.role)) {
+    throw new Error('AX settle policy requires identifier, label, text, or role');
+  }
+  return {
+    query: {
+      identifier: spec.identifier,
+      label: spec.label,
+      text: spec.text,
+      role: spec.role,
+    },
+    condition: 'exists',
+    timeoutMs: spec.timeoutMs ?? 5000,
+    intervalMs: 250,
+    stableMs: spec.stableMs ?? 0,
+    allowTransientErrors: true,
+    maxRecoverableRetries: 3,
+    ...overrides,
+  };
+}
+
+async function verifyRoute(deviceId: string, route: string, timeoutMs = 1000): Promise<{ met: boolean; route: string; elapsedMs: number; raw?: string; error?: string }> {
+  const start = Date.now();
+  const client = getFlutterVMClient(deviceId);
+  if (!client.isConnected()) {
+    return { met: false, route, elapsedMs: Date.now() - start, error: 'Flutter VM is not connected' };
+  }
+  const escaped = route.replace(/'/g, "\\'");
+  const expr = `(() { try { final binding = WidgetsBinding.instance; final root = binding.rootElement; if (root == null) return 'opensafari_route:no_root'; String? name; void visit(Element el) { if (name != null) return; final type = el.widget.runtimeType.toString(); if (type == '_ModalScopeStatus') { final s = el.toString(); final m = RegExp(r'name:\\s*"([^"]+)"').firstMatch(s) ?? RegExp(r"name:\\s*'([^']+)'").firstMatch(s); if (m != null) name = m.group(1); } el.visitChildren(visit); } visit(root); return name == '${escaped}' ? 'opensafari_route:ok' : 'opensafari_route:mismatch:' + (name ?? 'null').toString(); } catch (e) { return 'opensafari_route:error:' + e.toString().replaceAll(':', '_'); } })()`;
+  const deadline = Date.now() + timeoutMs;
+  let raw = '';
+  let error: string | undefined;
+  while (Date.now() <= deadline) {
+    try {
+      const result = await client.evaluate(expr);
+      raw = (result as { valueAsString?: string }).valueAsString ?? '';
+      if (raw.includes('opensafari_route:ok')) return { met: true, route, elapsedMs: Date.now() - start, raw };
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.min(150, Math.max(0, deadline - Date.now()))));
+  }
+  return { met: false, route, elapsedMs: Date.now() - start, raw, error };
+}
+
+async function verifyPostcondition(deviceId: string, spec: ScreenTargetPostcondition): Promise<unknown> {
+  if (spec.route && !(spec.identifier || spec.label || spec.text || spec.role)) {
+    return verifyRoute(deviceId, spec.route, spec.timeoutMs ?? 1000);
+  }
+  const settle = await waitForSettle(deviceId, settlePolicyFromPostcondition(spec));
+  if (spec.route) {
+    const route = await verifyRoute(deviceId, spec.route, Math.min(spec.timeoutMs ?? 1000, 1000));
+    return { ax: settle, route, met: settle.met && route.met };
+  }
+  return settle;
+}
+
+function postconditionMet(result: unknown): boolean {
+  if (!result || typeof result !== 'object') return false;
+  const r = result as { met?: boolean; ax?: { met?: boolean }; route?: { met?: boolean } };
+  if ('ax' in r && 'route' in r) return r.ax?.met === true && r.route?.met === true;
+  return r.met === true || r.ax?.met === true || r.route?.met === true;
+}
+
+async function tryNativeFallback(args: SemanticNavigationTarget, attempts: SemanticNavigationAttempt[]): Promise<{ ok: boolean; verification?: unknown; detail?: string }> {
+  if (!args.allowNativeFallback) {
+    attempts.push({ strategy: 'native_fallback', elapsedMs: 0, ok: false, skipped: true, skipReason: 'Native fallback not allowed by target spec.' });
+    return { ok: false };
+  }
+  const queries = args.nativeFallbackQueries ?? [];
+  if (queries.length === 0) {
+    attempts.push({ strategy: 'native_fallback', elapsedMs: 0, ok: false, skipped: true, skipReason: 'No native fallback queries were supplied.' });
+    return { ok: false };
+  }
+  const bridge = getAccessibilityBridge();
+  const backend = await getInputBackend(args.deviceId, getWebKitClient(args.deviceId));
+  const max = Math.max(1, Math.min(args.maxNativeAttempts ?? 3, queries.length));
+  for (let i = 0; i < max; i++) {
+    const query = queries[i];
+    const start = Date.now();
+    try {
+      const result = await bridge.query(query, { deviceId: args.deviceId, maxResults: 1 });
+      const match = result.matches[0];
+      if (!match) {
+        attempts.push({ strategy: 'native_fallback', elapsedMs: Date.now() - start, ok: false, skipped: true, skipReason: 'query matched no element', detail: JSON.stringify(query) });
+        continue;
+      }
+      const press = await bridge.press(match.path, args.deviceId).catch(() => ({ ok: false }));
+      if (!press.ok) {
+        await backend.tap(args.deviceId, match.frame.x + match.frame.width / 2, match.frame.y + match.frame.height / 2);
+      }
+      const verification = await verifyPostcondition(args.deviceId, args.postcondition);
+      const ok = postconditionMet(verification);
+      attempts.push({ strategy: 'native_fallback', elapsedMs: Date.now() - start, ok, verification, detail: press.ok ? `ax-press:${match.path}` : `tap:${match.path}` });
+      if (ok) return { ok: true, verification, detail: press.ok ? 'ax-press' : 'coordinate-tap' };
+    } catch (err) {
+      attempts.push({ strategy: 'native_fallback', elapsedMs: Date.now() - start, ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return { ok: false };
+}
+
+export async function navigateSemantically(args: SemanticNavigationTarget): Promise<SemanticNavigationResult> {
+  if (!hasScreenPostconditionSignal(args.postcondition)) {
+    throw new Error('semantic navigation requires route or AX postcondition');
+  }
+  const attempts: SemanticNavigationAttempt[] = [];
+  let beforeState: unknown;
+  if (args.collectState !== false) {
+    const start = Date.now();
+    try {
+      beforeState = await collectAppSessionState({ deviceId: args.deviceId, expectedBundleId: args.bundleId, includeFlutter: args.includeFlutter !== false, maxVisibleNodes: 12 });
+      attempts.push({ strategy: 'state_snapshot', elapsedMs: Date.now() - start, ok: true, verification: beforeState });
+    } catch (err) {
+      attempts.push({ strategy: 'state_snapshot', elapsedMs: Date.now() - start, ok: false, skipped: true, skipReason: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  const alreadyStart = Date.now();
+  const pre = await verifyPostcondition(args.deviceId, args.postcondition).catch((err) => ({ met: false, error: err instanceof Error ? err.message : String(err) }));
+  attempts.push({ strategy: 'already_on_target', elapsedMs: Date.now() - alreadyStart, ok: postconditionMet(pre), verification: pre });
+  if (postconditionMet(pre)) {
+    return { navigated: false, strategy: 'already_on_target', deviceId: args.deviceId, url: args.url, route: args.postcondition.route, beforeState, afterState: beforeState, attempts, verification: pre, waitFor: args.postcondition as Record<string, unknown>, recoveryHints: [] };
+  }
+
+  const hasAxPostcondition = Boolean(args.postcondition.identifier || args.postcondition.label || args.postcondition.text || args.postcondition.role);
+  if (args.postcondition.route) {
+    const routeStart = Date.now();
+    const route = await verifyRoute(args.deviceId, args.postcondition.route, Math.min(args.postcondition.timeoutMs ?? 1000, 1000));
+    attempts.push({ strategy: 'flutter_route', elapsedMs: Date.now() - routeStart, ok: route.met && !hasAxPostcondition, verification: route, skipped: !getFlutterVMClient(args.deviceId).isConnected() || hasAxPostcondition, skipReason: hasAxPostcondition ? 'Route evidence alone is insufficient because AX postcondition was also requested.' : (getFlutterVMClient(args.deviceId).isConnected() ? undefined : 'Flutter VM is not connected.') });
+    if (route.met && !hasAxPostcondition) return { navigated: false, strategy: 'flutter_route', deviceId: args.deviceId, url: args.url, route: args.postcondition.route, beforeState, afterState: beforeState, attempts, verification: route, waitFor: args.postcondition as Record<string, unknown>, recoveryHints: [] };
+  }
+
+  if (args.url) {
+    const openStart = Date.now();
+    await execFileAsync('xcrun', ['simctl', 'openurl', args.deviceId, args.url]);
+    attempts.push({ strategy: 'deeplink', elapsedMs: Date.now() - openStart, ok: true });
+    const verifyStart = Date.now();
+    const verification = await verifyPostcondition(args.deviceId, args.postcondition);
+    const ok = postconditionMet(verification);
+    attempts.push({ strategy: 'deeplink_postcondition', elapsedMs: Date.now() - verifyStart, ok, verification });
+    if (ok) {
+      const afterState = args.collectState === false ? undefined : await collectAppSessionState({ deviceId: args.deviceId, expectedBundleId: args.bundleId, includeFlutter: args.includeFlutter !== false, maxVisibleNodes: 12 }).catch(() => undefined);
+      return { navigated: true, strategy: 'deeplink_postcondition', deviceId: args.deviceId, url: args.url, route: args.postcondition.route, beforeState, afterState, attempts, verification, waitFor: args.postcondition as Record<string, unknown>, recoveryHints: [] };
+    }
+  } else {
+    attempts.push({ strategy: 'deeplink', elapsedMs: 0, ok: false, skipped: true, skipReason: 'No deeplink URL supplied.' });
+  }
+
+  const fallback = await tryNativeFallback(args, attempts);
+  if (fallback.ok) {
+    const afterState = args.collectState === false ? undefined : await collectAppSessionState({ deviceId: args.deviceId, expectedBundleId: args.bundleId, includeFlutter: args.includeFlutter !== false, maxVisibleNodes: 12 }).catch(() => undefined);
+    return { navigated: true, strategy: 'native_fallback', deviceId: args.deviceId, url: args.url, route: args.postcondition.route, beforeState, afterState, attempts, verification: fallback.verification, waitFor: args.postcondition as Record<string, unknown>, recoveryHints: [] };
+  }
+
+  const afterState = args.collectState === false ? undefined : await collectAppSessionState({ deviceId: args.deviceId, expectedBundleId: args.bundleId, includeFlutter: args.includeFlutter !== false, maxVisibleNodes: 12 }).catch(() => undefined);
+  const lastVerification = [...attempts].reverse().find((a) => a.verification)?.verification;
+  return {
+    navigated: false,
+    strategy: 'failed',
+    deviceId: args.deviceId,
+    url: args.url,
+    route: args.postcondition.route,
+    beforeState,
+    afterState,
+    attempts,
+    verification: lastVerification,
+    waitFor: args.postcondition as Record<string, unknown>,
+    recoveryHints: [
+      { action: 'debug_bundle_collect', reason: 'Collect evidence before destructive recovery.', destructive: false },
+      { action: 'app_state_snapshot', reason: 'Refresh current state and choose a narrower target or fallback query.', destructive: false },
+    ],
+  };
+}

--- a/tests/unit/flutter-connect-diagnostics.test.ts
+++ b/tests/unit/flutter-connect-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { redactVmServiceUrl } from '../../src/tools/flutter-connect';
+import { buildAttachTroubleshooting, redactVmServiceUrl } from '../../src/tools/flutter-connect';
 
 describe('flutter_connect diagnostics', () => {
   it('redacts VM service auth tokens from HTTP and WS URLs', () => {
@@ -6,3 +6,15 @@ describe('flutter_connect diagnostics', () => {
     expect(redactVmServiceUrl('ws://127.0.0.1:12345/abc=/ws')).toBe('ws://127.0.0.1:12345/<redacted>/ws');
   });
 });
+
+
+  it('returns actionable troubleshooting for stale cache and fixed-port failures', () => {
+    const suggestions = buildAttachTroubleshooting('Could not discover Dart VM Service URL', [
+      { source: 'cache', reachable: false, valid: true },
+      { source: 'fixed_port', reachable: false, valid: true },
+      { source: 'log_scan' },
+    ]);
+    expect(suggestions.join(' ')).toContain('Cached VM Service URL is stale');
+    expect(suggestions.join(' ')).toContain('Fixed VM Service port is not reachable');
+    expect(suggestions.join(' ')).toContain('does not own flutter run');
+  });

--- a/tests/unit/flutter-selector-quality.test.ts
+++ b/tests/unit/flutter-selector-quality.test.ts
@@ -1,4 +1,4 @@
-import { analyzeSelectorQuality } from '../../src/tools/qa-flutter-semantics';
+import { analyzeSelectorQuality, __forTests } from '../../src/tools/qa-flutter-semantics';
 import type { AXNode } from '../../src/native';
 
 function node(partial: Partial<AXNode>): AXNode {
@@ -54,4 +54,16 @@ it('keeps selector quality AX-first when Flutter VM is unavailable', () => {
   const report = analyzeSelectorQuality(node({ children: [node({ role: 'AXButton', label: 'Only Label' })] }), { flutterVmConnected: false });
   expect(report.enrichment).toMatchObject({ flutterVmConnected: false, widgetTreeUsed: false });
   expect(report.findings.map((f) => f.category)).toContain('label_only_selector');
+});
+
+
+it('preserves Dart regex escaping when extracting Flutter route hints', async () => {
+  const evaluate = jest.fn(async (_expression: string) => ({ valueAsString: '/checkout' }));
+  const getRootWidgetSummaryTree = jest.fn(async () => { throw new Error('tree unavailable'); });
+  const context = await __forTests.collectSelectorVmContext({ evaluate, getRootWidgetSummaryTree } as any);
+  const expression = evaluate.mock.calls[0][0];
+  expect(expression).toContain('name:\\s*"');
+  expect(expression).toContain("name:\\s*'");
+  expect(expression).not.toContain('name:s*');
+  expect(context).toMatchObject({ flutterVmConnected: true, widgetTreeUsed: false, routeContext: '/checkout' });
 });

--- a/tests/unit/flutter-selector-quality.test.ts
+++ b/tests/unit/flutter-selector-quality.test.ts
@@ -34,3 +34,24 @@ describe('Flutter selector quality audit', () => {
     expect(report.findings.map((f) => f.category)).toEqual(expect.arrayContaining(['label_only_selector', 'duplicate_identifier', 'duplicate_label']));
   });
 });
+
+it('enriches findings with optional Flutter VM route/widget/source context', () => {
+  const tree = node({ children: [
+    node({ role: 'AXButton', label: 'Continue', path: '/0/0' }),
+  ] });
+  const report = analyzeSelectorQuality(tree, {
+    flutterVmConnected: true,
+    widgetTreeUsed: true,
+    routeContext: '/checkout',
+    widgetSummaryHint: 'CheckoutButton',
+    sourceLocationHint: 'lib/checkout.dart:42:7',
+  });
+  expect(report.enrichment).toMatchObject({ flutterVmConnected: true, widgetTreeUsed: true, routeContext: '/checkout' });
+  expect(report.findings[0].vmContext).toMatchObject({ route: '/checkout', widgetTreeHint: 'CheckoutButton' });
+});
+
+it('keeps selector quality AX-first when Flutter VM is unavailable', () => {
+  const report = analyzeSelectorQuality(node({ children: [node({ role: 'AXButton', label: 'Only Label' })] }), { flutterVmConnected: false });
+  expect(report.enrichment).toMatchObject({ flutterVmConnected: false, widgetTreeUsed: false });
+  expect(report.findings.map((f) => f.category)).toContain('label_only_selector');
+});

--- a/tests/unit/scenario-runner-v2.test.ts
+++ b/tests/unit/scenario-runner-v2.test.ts
@@ -5,6 +5,8 @@ const queryMock = jest.fn();
 const pressMock = jest.fn();
 const tapMock = jest.fn();
 const typeTextMock = jest.fn();
+const sendKeyMock = jest.fn();
+const swipeMock = jest.fn();
 
 jest.mock('../../src/tools/app-state-snapshot', () => ({
   collectAppSessionState: jest.fn(async ({ deviceId }) => ({ schemaVersion: '1', device: { id: deviceId }, app: { classification: 'TARGET_BUNDLE_CONFIRMED' } })),
@@ -26,8 +28,8 @@ jest.mock('../../src/tools/native-input-utils', () => ({
     kind: 'simhid',
     tap: tapMock,
     typeText: typeTextMock,
-    sendKey: jest.fn(async () => undefined),
-    swipe: jest.fn(async () => undefined),
+    sendKey: sendKeyMock,
+    swipe: swipeMock,
   })),
 }));
 
@@ -45,6 +47,8 @@ describe('ScenarioRunner v2', () => {
     jest.clearAllMocks();
     queryMock.mockResolvedValue({ matches: [{ path: '/0/1', frame: { x: 10, y: 20, width: 30, height: 40 } }] });
     pressMock.mockResolvedValue({ ok: true });
+    sendKeyMock.mockResolvedValue(undefined);
+    swipeMock.mockResolvedValue(undefined);
     (waitForSettle as jest.Mock).mockResolvedValue({ met: true, polls: 1, elapsedMs: 1, stableForMs: 0, matchingCount: 1, lastObserved: [], errors: [] });
   });
   it('records state with per-device result metadata', async () => {
@@ -132,6 +136,52 @@ describe('ScenarioRunner v2', () => {
     expect(waitForSettle).toHaveBeenCalledWith('D1', expect.objectContaining({ query: { identifier: 'settings' } }));
   });
 });
+
+
+  it('fails popUntil before dispatch when postcondition is omitted', async () => {
+    sendKeyMock.mockClear();
+    swipeMock.mockClear();
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'popUntil', maxNativeAttempts: 1 }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].error).toContain('popUntil requires query or settle.query postcondition');
+    expect(sendKeyMock).not.toHaveBeenCalled();
+    expect(swipeMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves failed popUntil dispatch evidence when postcondition is not met', async () => {
+    sendKeyMock.mockRejectedValueOnce(new Error('escape failed'));
+    swipeMock.mockRejectedValueOnce(new Error('swipe failed'));
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'popUntil', query: { identifier: 'home' }, maxNativeAttempts: 1 }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].result).toMatchObject({
+      attempts: [
+        { action: 'escape', ok: false, error: 'escape failed' },
+        { action: 'edge_swipe', ok: false, error: 'swipe failed' },
+      ],
+    });
+    expect(result.steps[0].devices[0].error).toContain('popUntil postcondition was not met');
+  });
+
+  it('fails dismissOverlay before dispatch when postcondition is omitted', async () => {
+    sendKeyMock.mockClear();
+    swipeMock.mockClear();
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'dismissOverlay', mode: 'dialog' }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].error).toContain('dismissOverlay requires query or settle.query postcondition');
+    expect(sendKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves failed dismissOverlay dispatch evidence when postcondition is not met', async () => {
+    sendKeyMock.mockRejectedValueOnce(new Error('escape failed'));
+    const runner = new ScenarioRunner(pool as any);
+    const result = await runner.run({ name: 'mobile', version: 2, steps: [{ action: 'dismissOverlay', mode: 'dialog', query: { identifier: 'overlay' } }] });
+    expect(result.passed).toBe(false);
+    expect(result.steps[0].devices[0].result).toMatchObject({ attempts: [{ action: 'escape', ok: false, error: 'escape failed' }] });
+    expect(result.steps[0].devices[0].error).toContain('dismissOverlay postcondition was not met');
+  });
 
 it('supports popUntil and dismissOverlay with shared settle verification', async () => {
   const runner = new ScenarioRunner(pool as any);

--- a/tests/unit/scenario-runner-v2.test.ts
+++ b/tests/unit/scenario-runner-v2.test.ts
@@ -26,20 +26,6 @@ jest.mock('../../src/tools/native-input-utils', () => ({
     kind: 'simhid',
     tap: tapMock,
     typeText: typeTextMock,
-  })),
-}));
-
-jest.mock('../../src/native', () => ({
-  getAccessibilityBridge: jest.fn(() => ({
-    query: jest.fn(async () => ({ matches: [{ path: '/0/1', frame: { x: 0, y: 0, width: 44, height: 44 } }] })),
-    press: jest.fn(async () => ({ ok: true })),
-  })),
-}));
-jest.mock('../../src/tools/native-input-utils', () => ({
-  getInputBackend: jest.fn(async () => ({
-    kind: 'simhid',
-    tap: jest.fn(async () => undefined),
-    typeText: jest.fn(async () => undefined),
     sendKey: jest.fn(async () => undefined),
     swipe: jest.fn(async () => undefined),
   })),

--- a/tests/unit/scenario-runner-v2.test.ts
+++ b/tests/unit/scenario-runner-v2.test.ts
@@ -29,6 +29,22 @@ jest.mock('../../src/tools/native-input-utils', () => ({
   })),
 }));
 
+jest.mock('../../src/native', () => ({
+  getAccessibilityBridge: jest.fn(() => ({
+    query: jest.fn(async () => ({ matches: [{ path: '/0/1', frame: { x: 0, y: 0, width: 44, height: 44 } }] })),
+    press: jest.fn(async () => ({ ok: true })),
+  })),
+}));
+jest.mock('../../src/tools/native-input-utils', () => ({
+  getInputBackend: jest.fn(async () => ({
+    kind: 'simhid',
+    tap: jest.fn(async () => undefined),
+    typeText: jest.fn(async () => undefined),
+    sendKey: jest.fn(async () => undefined),
+    swipe: jest.fn(async () => undefined),
+  })),
+}));
+
 const sim = {
   device: { udid: 'D1', name: 'iPhone' },
   preset: 'iphone',
@@ -129,4 +145,19 @@ describe('ScenarioRunner v2', () => {
     expect(result.passed).toBe(true);
     expect(waitForSettle).toHaveBeenCalledWith('D1', expect.objectContaining({ query: { identifier: 'settings' } }));
   });
+});
+
+it('supports popUntil and dismissOverlay with shared settle verification', async () => {
+  const runner = new ScenarioRunner(pool as any);
+  const result = await runner.run({
+    name: 'mobile-actions',
+    version: 2,
+    steps: [
+      { action: 'popUntil', query: { identifier: 'home' }, maxNativeAttempts: 1 },
+      { action: 'dismissOverlay', query: { identifier: 'overlay' }, condition: 'not_exists', mode: 'dialog' },
+    ],
+  });
+  expect(result.passed).toBe(true);
+  expect(result.steps[0].devices[0].result).toMatchObject({ popped: 1 });
+  expect(result.steps[1].devices[0].result).toMatchObject({ dismissed: true, mode: 'dialog' });
 });

--- a/tests/unit/scenario-tools-schema.test.ts
+++ b/tests/unit/scenario-tools-schema.test.ts
@@ -21,6 +21,8 @@ describe('run_scenario v2 schema SSOT', () => {
     ['waitFor requires query or settle.query', { action: 'waitFor' }],
     ['assertElement requires query or settle.query', { action: 'assertElement' }],
     ['gotoScreen requires postcondition query', { action: 'gotoScreen', value: 'myapp://settings' }],
+    ['popUntil requires query or settle.query postcondition', { action: 'popUntil' }],
+    ['dismissOverlay requires query or settle.query postcondition', { action: 'dismissOverlay', mode: 'dialog' }],
   ] as const;
 
   it.each(invalidCases)('rejects %s', (_name, step) => {
@@ -40,6 +42,8 @@ describe('run_scenario v2 schema SSOT', () => {
         { action: 'waitFor', settle: { query: { label: 'Home' } } },
         { action: 'assertElement', query: { text: 'Done' } },
         { action: 'gotoScreen', value: 'myapp://settings', query: { identifier: 'settings' } },
+        { action: 'popUntil', query: { identifier: 'home' } },
+        { action: 'dismissOverlay', mode: 'dialog', settle: { query: { identifier: 'dialog' }, condition: 'not_exists' } },
       ],
     })).toBe(true);
   });

--- a/tests/unit/semantic-navigation.test.ts
+++ b/tests/unit/semantic-navigation.test.ts
@@ -1,8 +1,10 @@
 import { navigateSemantically } from '../../src/tools/semantic-navigation';
 import { waitForSettle } from '../../src/tools/settle-policy';
 
+var mockExecFile = jest.fn((_cmd: string, _args: string[], cb: (err: Error | null, stdout?: string, stderr?: string) => void) => cb(null, '', ''));
+
 jest.mock('child_process', () => ({
-  execFile: jest.fn((_cmd, _args, cb) => cb(null, '', '')),
+  execFile: (...args: unknown[]) => (mockExecFile as (...inner: unknown[]) => unknown)(...args),
 }));
 jest.mock('../../src/tools/app-state-snapshot', () => ({
   collectAppSessionState: jest.fn(async () => ({ schemaVersion: '1' })),
@@ -27,6 +29,7 @@ describe('semantic navigation combined route+AX postconditions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     evaluate.mockResolvedValue({ valueAsString: 'opensafari_route:ok' });
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: Error | null, stdout?: string, stderr?: string) => void) => cb(null, '', ''));
     (waitForSettle as jest.Mock).mockResolvedValue({ met: false, polls: 1, elapsedMs: 1, stableForMs: 0, matchingCount: 0, lastObserved: [], errors: [] });
   });
 
@@ -42,6 +45,24 @@ describe('semantic navigation combined route+AX postconditions', () => {
     });
     expect(result.strategy).toBe('already_on_target');
     expect(calls).toBeGreaterThanOrEqual(10);
+  });
+
+
+
+  it('records failed deeplink attempts and returns structured failure evidence when openurl throws', async () => {
+    mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], cb: (err: Error | null, stdout?: string, stderr?: string) => void) => cb(new Error('openurl failed')));
+    evaluate.mockResolvedValue({ valueAsString: 'opensafari_route:mismatch:/home' });
+    const result = await navigateSemantically({
+      deviceId: 'D1',
+      url: 'myapp://settings',
+      postcondition: { route: '/settings', timeoutMs: 1 },
+      collectState: false,
+    });
+    expect(result.strategy).toBe('failed');
+    expect(result.attempts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ strategy: 'deeplink', ok: false, error: 'openurl failed' }),
+    ]));
+    expect(result.recoveryHints.map((h) => h.action)).toContain('debug_bundle_collect');
   });
 
   it('does not pass from route-only evidence when AX postcondition is also requested', async () => {

--- a/tests/unit/semantic-navigation.test.ts
+++ b/tests/unit/semantic-navigation.test.ts
@@ -1,0 +1,42 @@
+import { navigateSemantically } from '../../src/tools/semantic-navigation';
+import { waitForSettle } from '../../src/tools/settle-policy';
+
+jest.mock('child_process', () => ({
+  execFile: jest.fn((_cmd, _args, cb) => cb(null, '', '')),
+}));
+jest.mock('../../src/tools/app-state-snapshot', () => ({
+  collectAppSessionState: jest.fn(async () => ({ schemaVersion: '1' })),
+}));
+jest.mock('../../src/tools/settle-policy', () => ({
+  waitForSettle: jest.fn(async () => ({ met: false, polls: 1, elapsedMs: 1, stableForMs: 0, matchingCount: 0, lastObserved: [], errors: [] })),
+}));
+jest.mock('../../src/mcp-server', () => ({ getWebKitClient: jest.fn(() => null) }));
+jest.mock('../../src/native', () => ({
+  getAccessibilityBridge: jest.fn(() => ({ query: jest.fn(), press: jest.fn() })),
+}));
+jest.mock('../../src/tools/native-input-utils', () => ({
+  getInputBackend: jest.fn(async () => ({ kind: 'simhid', tap: jest.fn() })),
+}));
+const evaluate = jest.fn(async () => ({ valueAsString: 'opensafari_route:ok' }));
+jest.mock('../../src/flutter', () => ({
+  getFlutterVMClient: () => ({ isConnected: () => true, evaluate }),
+}));
+
+describe('semantic navigation combined route+AX postconditions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    evaluate.mockResolvedValue({ valueAsString: 'opensafari_route:ok' });
+    (waitForSettle as jest.Mock).mockResolvedValue({ met: false, polls: 1, elapsedMs: 1, stableForMs: 0, matchingCount: 0, lastObserved: [], errors: [] });
+  });
+
+  it('does not pass from route-only evidence when AX postcondition is also requested', async () => {
+    const result = await navigateSemantically({
+      deviceId: 'D1',
+      url: 'myapp://settings',
+      postcondition: { route: '/settings', identifier: 'settings-title', timeoutMs: 1 },
+      collectState: false,
+    });
+    expect(result.strategy).toBe('failed');
+    expect(result.attempts.some((a) => a.strategy === 'flutter_route' && a.ok)).toBe(false);
+  });
+});

--- a/tests/unit/semantic-navigation.test.ts
+++ b/tests/unit/semantic-navigation.test.ts
@@ -23,10 +23,25 @@ jest.mock('../../src/flutter', () => ({
 }));
 
 describe('semantic navigation combined route+AX postconditions', () => {
+  jest.setTimeout(10000);
   beforeEach(() => {
     jest.clearAllMocks();
     evaluate.mockResolvedValue({ valueAsString: 'opensafari_route:ok' });
     (waitForSettle as jest.Mock).mockResolvedValue({ met: false, polls: 1, elapsedMs: 1, stableForMs: 0, matchingCount: 0, lastObserved: [], errors: [] });
+  });
+
+  it('honors caller timeout for slower route-only verification', async () => {
+    let calls = 0;
+    evaluate.mockImplementation(async () => ({
+      valueAsString: ++calls >= 10 ? 'opensafari_route:ok' : 'opensafari_route:mismatch:/loading',
+    }));
+    const result = await navigateSemantically({
+      deviceId: 'D1',
+      postcondition: { route: '/settings', timeoutMs: 1800 },
+      collectState: false,
+    });
+    expect(result.strategy).toBe('already_on_target');
+    expect(calls).toBeGreaterThanOrEqual(10);
   });
 
   it('does not pass from route-only evidence when AX postcondition is also requested', async () => {


### PR DESCRIPTION
## Summary

Completes the remaining #829 mobile semantic QA follow-up implementation as a stacked PR on top of foundation PR #828:

- extracts reusable semantic navigation controller logic from `app_goto_screen`
- adds postcondition-first route/deeplink/native fallback evidence for semantic navigation (#823)
- extends shared settle/postcondition evidence to high-level tap/type/overlay/scenario actions (#824)
- expands scenario runner v2 with `popUntil` and `dismissOverlay` mobile actions plus schema fields (#827)
- hardens AppSessionState snapshot tests and consumer docs (#822)
- enriches Flutter selector-quality findings with optional route/widget/source context while preserving AX-first behavior (#825)
- exports typed Flutter attach diagnostics and adds troubleshooting suggestions/docs (#826)

## SSOT / drift guard

This continues the #795/#829 direction: MCP-native contracts, semantic postconditions over raw transport success, no implicit relaunch/reset, bounded native fallback, optional Flutter VM, and machine-readable evidence.

## Testing

- `npm test -- --runInBand`
- `npm run build:src`
- `npm run lint -- --quiet`
- Targeted suites:
  - `scenario-runner-v2`
  - `app-state-snapshot`
  - `flutter-selector-quality`
  - `flutter-connect-diagnostics`
  - `app-tap-element`
  - `app-type-element`
  - `app-dismiss-overlay`
  - `tier0-error-envelope`

## Not tested

- Live simulator Flutter/native app flows.

## Tracking

Implements the remaining follow-up checklist tracked by #829 after foundation PR #828. Stacked on `ultragoal/mobile-semantic-qa-runtime` until #828 lands.
