### PR TITLE
feat(flutter): disclose build mode & probe-backed evaluate capability on connect

### DIFF
--- a/docs/flutter-inspector.md
+++ b/docs/flutter-inspector.md
@@ -41,7 +41,7 @@ Legend:
 
 ### Detecting release-mode fall-through
 
-When Tier 0 probes a release build it rejects with `FlutterVMInputBackendError { code: 'VM_NO_EVALUATE' }` whose `.message` surfaces the canonical recipe link. Tool consumers can key on the structured code to prompt users to rebuild with `--profile`, or parse `flutter_connect`'s response metadata (Dart VM flags expose the build mode).
+When Tier 0 probes a release build it rejects with `FlutterVMInputBackendError { code: 'VM_NO_EVALUATE' }` whose `.message` surfaces the canonical recipe link. Tool consumers can key on the structured code to prompt users to rebuild with `--profile`, or read `flutter_connect`'s `buildMode` / `capabilities.evaluate` response fields up front (see [Deterministic Flutter VM attach](./flutter-vm-attach.md#success-response-fields)) instead of waiting for the first `evaluate` to fail.
 
 ## Flutter Compatibility Matrix
 

--- a/docs/flutter-vm-attach.md
+++ b/docs/flutter-vm-attach.md
@@ -24,3 +24,24 @@ shape, auth-code mismatch, and release-build limitations.
 
 Release builds disable VM Service. Treat VM unavailable as data and fall back to
 AX/native semantic tools unless the scenario explicitly requires Flutter VM.
+
+## Success response fields
+
+A successful `flutter_connect` returns, in addition to `status`, `vmServiceUrl`,
+`wsUrl`, `deviceId`, `attachDiagnostics`, `vm`, `mainIsolateId`, `dartVersion`,
+and `flutterMajor`:
+
+| Field | Meaning |
+|-------|---------|
+| `buildMode` | Detected build mode: `debug`, `profile`, or `unknown`. (A successful connect is never `release` — release disables the VM Service.) |
+| `vmServiceAvailable` | Always `true` on a successful connect; present so the contract is uniform with the failure path. |
+| `capabilities` | Per-capability booleans (`hot_reload`, `logs`, `widget_tree`, `evaluate`, `breakpoints`, `cpu_profile`, `heap_snapshot`, `network_proxy`, `ui_automation`, `screenshot`). |
+| `evaluateProbed` | Whether `capabilities.evaluate` was confirmed by a live probe (`true`) or inferred (`false`, for `debug` where JIT always evaluates). |
+
+`capabilities.evaluate` is the load-bearing signal for Tier-0 tooling. It is
+**probe-backed**, not inferred from `buildMode`: a no-compiler AOT attach (e.g.
+`simctl launch` without `flutter run`) is classified `profile` yet rejects
+`evaluate` with code 113, so the connect issues one `evaluate('1')` probe and
+reports the empirical result. An MCP client should branch on
+`capabilities.evaluate` rather than `buildMode` when deciding whether to call
+`flutter_evaluate`, widget hit-testing, or synthetic pointer input.

--- a/src/tools/flutter-build-mode.ts
+++ b/src/tools/flutter-build-mode.ts
@@ -30,7 +30,7 @@ export interface FlutterCapabilities {
 }
 
 /** Tools that remain usable in release mode (no VM Service required). */
-const RELEASE_FALLBACK_TOOLS = [
+export const RELEASE_FALLBACK_TOOLS = [
   'app_tap_element',
   'app_assert_element',
   'app_wait_for',
@@ -41,7 +41,7 @@ const RELEASE_FALLBACK_TOOLS = [
   'flutter_network', // HTTP proxy works regardless of build mode
 ];
 
-function capabilitiesFor(mode: FlutterBuildMode): FlutterCapabilities {
+export function capabilitiesFor(mode: FlutterBuildMode): FlutterCapabilities {
   const vmAvailable = mode === 'debug' || mode === 'profile';
   return {
     hot_reload: mode === 'debug',

--- a/src/tools/flutter-connect.ts
+++ b/src/tools/flutter-connect.ts
@@ -15,6 +15,12 @@ import {
   probeVMServiceUrl,
   wsToHttpUrl,
 } from '../flutter/vm-service-discovery';
+import {
+  detectBuildMode,
+  capabilitiesFor,
+  type FlutterBuildMode,
+  type FlutterCapabilities,
+} from './flutter-build-mode';
 
 export function registerFlutterConnectTool(server: MCPServer): void {
   server.registerTool(
@@ -89,6 +95,12 @@ export function registerFlutterConnectTool(server: MCPServer): void {
           timeout: params.timeout as number | undefined,
         });
 
+        // Build-mode + capability disclosure (issue #831): tell the caller
+        // up front whether Tier-0 `evaluate` actually works, instead of
+        // surfacing a code-113 failure on the first downstream tool.
+        const { buildMode, capabilities, evaluateProbed } =
+          await computeBuildModeDisclosure(deviceId, client);
+
         return {
           content: [{
             type: 'text' as const,
@@ -97,6 +109,10 @@ export function registerFlutterConnectTool(server: MCPServer): void {
               vmServiceUrl: redactVmServiceUrl(state.httpUrl),
               wsUrl: redactVmServiceUrl(state.wsUrl),
               deviceId: state.deviceId,
+              buildMode,
+              vmServiceAvailable: true,
+              capabilities,
+              evaluateProbed,
               attachDiagnostics: {
                 attempts: attachDiagnostics.attempts,
               },
@@ -123,6 +139,51 @@ export function registerFlutterConnectTool(server: MCPServer): void {
       }
     },
   );
+}
+
+/**
+ * Compute the build-mode + capability disclosure for a freshly connected
+ * Flutter VM (issue #831).
+ *
+ * The load-bearing `evaluate` capability is **probe-backed**, not inferred
+ * from the mode label: a no-compiler AOT attach (e.g. `simctl launch` without
+ * `flutter run`) has no `ext.flutter.reassemble` and is therefore classified
+ * `profile`, yet it rejects `evaluate` with code 113. Trusting the label would
+ * report `evaluate: true` falsely. Debug builds skip the probe entirely (JIT
+ * always evaluates). Detection/probe failure degrades to `unknown` + no
+ * evaluate, and never throws — the connect itself already succeeded.
+ */
+export async function computeBuildModeDisclosure(
+  deviceId: string,
+  client: { probeEvaluateCompile(): Promise<{ available: boolean }> },
+): Promise<{
+  buildMode: FlutterBuildMode;
+  capabilities: FlutterCapabilities;
+  evaluateProbed: boolean;
+}> {
+  let buildMode: FlutterBuildMode = 'unknown';
+  let capabilities: FlutterCapabilities = capabilitiesFor('unknown');
+  let evaluateProbed = false;
+  try {
+    const probe = await detectBuildMode(deviceId);
+    buildMode = probe.mode;
+    if (buildMode === 'debug') {
+      // JIT always evaluates — no probe needed.
+      capabilities = capabilitiesFor('debug');
+    } else {
+      const evalProbe = await client.probeEvaluateCompile();
+      evaluateProbed = true;
+      capabilities = { ...capabilitiesFor(buildMode), evaluate: evalProbe.available };
+    }
+  } catch (err) {
+    console.error(
+      `[flutter_connect] build-mode disclosure skipped: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    buildMode = 'unknown';
+    capabilities = { ...capabilitiesFor('unknown'), evaluate: false };
+    evaluateProbed = false;
+  }
+  return { buildMode, capabilities, evaluateProbed };
 }
 
 export interface AttachAttempt {

--- a/tests/unit/flutter-connect-buildmode.test.ts
+++ b/tests/unit/flutter-connect-buildmode.test.ts
@@ -52,6 +52,18 @@ describe('computeBuildModeDisclosure (issue #831)', () => {
     expect(r.evaluateProbed).toBe(true);
   });
 
+  it('unknown mode (VM discovered but not yet distinguished) still probes evaluate', async () => {
+    // detectBuildMode's happy path can return 'unknown' (VM URL seen in logs
+    // but debug-vs-profile not yet confirmed). This must still probe, not skip.
+    detectBuildMode.mockResolvedValue({ mode: 'unknown', vmServiceAvailable: true, details: '' });
+    const client = fakeClient(true);
+    const r = await computeBuildModeDisclosure('udid', client);
+    expect(r.buildMode).toBe('unknown');
+    expect(r.capabilities.evaluate).toBe(true);
+    expect(r.evaluateProbed).toBe(true);
+    expect(client.probeEvaluateCompile).toHaveBeenCalledTimes(1);
+  });
+
   it('detection failure degrades to unknown + no evaluate, never throws', async () => {
     detectBuildMode.mockRejectedValue(new Error('vm gone'));
     const client = fakeClient(true);

--- a/tests/unit/flutter-connect-buildmode.test.ts
+++ b/tests/unit/flutter-connect-buildmode.test.ts
@@ -1,0 +1,64 @@
+import { computeBuildModeDisclosure } from '../../src/tools/flutter-connect';
+import * as buildModeModule from '../../src/tools/flutter-build-mode';
+
+// Mock only `detectBuildMode`; keep the real `capabilitiesFor` so the
+// capability table stays the single source of truth under test.
+jest.mock('../../src/tools/flutter-build-mode', () => {
+  const actual = jest.requireActual('../../src/tools/flutter-build-mode');
+  return { ...actual, detectBuildMode: jest.fn() };
+});
+
+const detectBuildMode = buildModeModule.detectBuildMode as jest.MockedFunction<
+  typeof buildModeModule.detectBuildMode
+>;
+
+function fakeClient(available: boolean) {
+  return { probeEvaluateCompile: jest.fn(async () => ({ available })) };
+}
+
+describe('computeBuildModeDisclosure (issue #831)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('debug build reports evaluate:true without issuing a probe', async () => {
+    detectBuildMode.mockResolvedValue({ mode: 'debug', vmServiceAvailable: true, details: '' });
+    const client = fakeClient(true);
+    const r = await computeBuildModeDisclosure('udid', client);
+    expect(r.buildMode).toBe('debug');
+    expect(r.capabilities.evaluate).toBe(true);
+    expect(r.evaluateProbed).toBe(false);
+    expect(client.probeEvaluateCompile).not.toHaveBeenCalled();
+  });
+
+  it('no-compiler AOT (probe code-113) reports evaluate:false despite mode profile', async () => {
+    // The false-positive guard: inference would say evaluate:true for profile.
+    detectBuildMode.mockResolvedValue({ mode: 'profile', vmServiceAvailable: true, details: '' });
+    const client = fakeClient(false);
+    const r = await computeBuildModeDisclosure('udid', client);
+    expect(r.buildMode).toBe('profile');
+    expect(r.capabilities.evaluate).toBe(false);
+    expect(r.evaluateProbed).toBe(true);
+    expect(client.probeEvaluateCompile).toHaveBeenCalledTimes(1);
+  });
+
+  it('genuine profile with a live compiler reports evaluate:true', async () => {
+    detectBuildMode.mockResolvedValue({ mode: 'profile', vmServiceAvailable: true, details: '' });
+    const client = fakeClient(true);
+    const r = await computeBuildModeDisclosure('udid', client);
+    expect(r.capabilities.evaluate).toBe(true);
+    expect(r.evaluateProbed).toBe(true);
+  });
+
+  it('detection failure degrades to unknown + no evaluate, never throws', async () => {
+    detectBuildMode.mockRejectedValue(new Error('vm gone'));
+    const client = fakeClient(true);
+    const r = await computeBuildModeDisclosure('udid', client);
+    expect(r.buildMode).toBe('unknown');
+    expect(r.capabilities.evaluate).toBe(false);
+    expect(r.evaluateProbed).toBe(false);
+    expect(client.probeEvaluateCompile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements #831. A successful `flutter_connect` now discloses, in its response:

- `buildMode` (`debug` / `profile` / `unknown`),
- `vmServiceAvailable: true`,
- `capabilities` (the existing `FlutterCapabilities` shape),
- `evaluateProbed` (whether the evaluate capability was confirmed by a probe).

This closes the most common silent failure: a developer connecting to a build where Tier-0 `evaluate` does not work, then hitting a confusing **code-113** error on the first `flutter_evaluate` / widget-hit-test / synthetic-input call.

## Why probe-backed, not inferred

`capabilitiesFor()` infers `evaluate` from the mode label (`debug || profile`). But a **no-compiler AOT attach** (e.g. `simctl launch` without `flutter run`) has no `ext.flutter.reassemble`, is classified `profile`, yet rejects `evaluate` with code 113. Trusting the label would falsely report `evaluate: true`.

So the load-bearing `evaluate` field is set by:
- `debug` → `true` **without probing** (JIT always evaluates);
- otherwise → one `client.probeEvaluateCompile()` call (the existing SSOT probe).

Detection/probe failure degrades to `buildMode: "unknown"`, `evaluate: false`, `evaluateProbed: false` and **never fails the connect**.

## Reuse / drift control

- Exports and reuses `detectBuildMode`, `capabilitiesFor`, `RELEASE_FALLBACK_TOOLS` from `flutter-build-mode.ts` — one capability table.
- Reuses `client.probeEvaluateCompile()` — one probe shape (same one `flutter-resolver` uses).
- Disclosure logic extracted into the exported, unit-tested `computeBuildModeDisclosure`.

## Verification

```
npx jest flutter-connect-buildmode flutter-connect-diagnostics flutter-build-mode  # 14 passed
npx tsc --noEmit   # exit 0
npx eslint <changed files>   # exit 0
```

New tests assert:
- debug → `evaluate:true`, `evaluateProbed:false`, **probe not called**;
- probe code-113 → `evaluate:false` despite mode `profile` (the false-positive guard);
- genuine profile → `evaluate:true`, `evaluateProbed:true`;
- detection failure → degrades to `unknown` without throwing.

## Scope guardrails

- Success path only; no connection/retry/heartbeat/discovery/failure-path behavior change.
- No release detection (unreliable at connect; owned by `flutter_build_mode`).
- No new params, no new MCP tool, no removed/renamed fields.

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)