### PR TITLE
feat(native): attach searched-tree diagnostics to not-found errors (#834 PR 4.1)

### DIFF
--- a/src/native/not-found-diagnostics.ts
+++ b/src/native/not-found-diagnostics.ts
@@ -1,0 +1,122 @@
+/**
+ * not-found-diagnostics — attach a bounded snapshot of the searched
+ * accessibility tree to "element not found" errors (issue #834).
+ *
+ * The most frequent inner-loop bottleneck is a query that fails to match,
+ * after which the developer manually re-runs `app_tree` to see what was
+ * actually on screen. This helper automates exactly that one step: on a
+ * terminal miss it performs a single bounded `dumpTree`, returns a capped
+ * digest plus the nearest label/identifier candidates, and degrades to
+ * `undefined` if the dump fails — so it never makes the failure worse.
+ *
+ * Deliberately minimal: substring matching only (no fuzzy/ranking), a hard
+ * node cap, and exactly one dump. See the issue's over-engineering checklist.
+ */
+
+import type { AXNode, AXQuery } from './ax-types';
+
+/** Default ceiling on how many nodes the digest carries. */
+export const DEFAULT_MAX_NODES = 40;
+
+/** Compact node shape — just enough to recognise an element, no geometry. */
+export interface CompactAXNode {
+  role: string;
+  label?: string;
+  identifier?: string;
+  value?: string;
+  path: string;
+}
+
+export interface NotFoundDiagnostics {
+  /** Total nodes in the dumped tree (may exceed `nodes.length`). */
+  searchedNodeCount: number;
+  /** Whether `nodes` was truncated at the cap. */
+  truncated: boolean;
+  /** Up to `maxNodes` compacted nodes from the searched tree. */
+  nodes: CompactAXNode[];
+  /** Up to 5 nodes whose label/identifier/value contains the query term. */
+  candidates: CompactAXNode[];
+}
+
+/** Minimal surface this helper needs from the accessibility bridge. */
+export interface TreeDumper {
+  dumpTree(options?: { deviceId?: string; maxDepth?: number }): Promise<AXNode>;
+}
+
+const MAX_CANDIDATES = 5;
+
+function compact(node: AXNode): CompactAXNode {
+  return {
+    role: node.role,
+    label: node.label,
+    identifier: node.identifier,
+    value: node.value,
+    path: node.path,
+  };
+}
+
+/** The term the query searched for, used for substring candidate matching. */
+function queryTerm(query: AXQuery): string {
+  return (query.identifier ?? query.label ?? query.text ?? query.role ?? '')
+    .trim()
+    .toLowerCase();
+}
+
+function matchesTerm(node: AXNode, term: string): boolean {
+  if (!term) return false;
+  const hay = [node.label, node.identifier, node.value]
+    .filter((s): s is string => Boolean(s))
+    .join(' ')
+    .toLowerCase();
+  return hay.includes(term);
+}
+
+/**
+ * Build a bounded not-found diagnostic from a single tree dump.
+ *
+ * Performs exactly one `dumpTree`. Returns `undefined` (no diagnostics) when
+ * the dump throws or times out — callers keep their original error untouched.
+ */
+export async function buildNotFoundDiagnostics(
+  bridge: TreeDumper,
+  deviceId: string | undefined,
+  query: AXQuery,
+  opts?: { maxNodes?: number },
+): Promise<NotFoundDiagnostics | undefined> {
+  const maxNodes = opts?.maxNodes ?? DEFAULT_MAX_NODES;
+  let root: AXNode;
+  try {
+    root = await bridge.dumpTree(deviceId ? { deviceId } : undefined);
+  } catch {
+    // Graceful degradation: a failed/slow dump must not worsen the
+    // already-failing not-found path.
+    return undefined;
+  }
+
+  const term = queryTerm(query);
+  const nodes: CompactAXNode[] = [];
+  const candidates: CompactAXNode[] = [];
+  let searchedNodeCount = 0;
+
+  // Single DFS: count every node, collect the capped digest, and gather
+  // substring candidates across the whole tree.
+  const stack: AXNode[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop() as AXNode;
+    searchedNodeCount += 1;
+    if (nodes.length < maxNodes) nodes.push(compact(node));
+    if (candidates.length < MAX_CANDIDATES && matchesTerm(node, term)) {
+      candidates.push(compact(node));
+    }
+    if (node.children) {
+      for (const child of node.children) stack.push(child);
+    }
+  }
+
+  return {
+    searchedNodeCount,
+    truncated: searchedNodeCount > nodes.length,
+    nodes,
+    candidates,
+  };
+}

--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -33,6 +33,7 @@ import { SimulatorManager } from '../simulator';
 import { DEVICE_PRESETS } from '../simulator/presets';
 import { convertMacOSPtToIOSPt } from '../utils/coordinate-space';
 import type { Size2D } from '../utils/coordinate-space';
+import { buildNotFoundDiagnostics } from '../native/not-found-diagnostics';
 
 type AXPressVerification = {
   verified: boolean;
@@ -253,6 +254,11 @@ export function registerAppTapElementTool(server: MCPServer): void {
         }
 
         if (!match) {
+          // Terminal miss (all relaxed/alias attempts failed): attach a
+          // bounded snapshot of the searched tree so the developer sees the
+          // cause in one call instead of manually re-running app_tree. One
+          // dump, capped; absent if the dump fails. (issue #834)
+          const diagnostics = await buildNotFoundDiagnostics(bridge, deviceId, query);
           return respondWithStructuredError(
             ErrorCode.APP_STATE_UNKNOWN,
             'Element not found',
@@ -261,6 +267,10 @@ export function registerAppTapElementTool(server: MCPServer): void {
               labelAliases: labelAliases.length > 0 ? labelAliases : undefined,
               index,
               timeout,
+              diagnostics,
+              hint: diagnostics
+                ? 'No node matched. See diagnostics.candidates for near matches; narrow the query or enable autoScroll if the element is offscreen.'
+                : undefined,
               _meta: { context: contextMeta },
             },
           );

--- a/tests/unit/app-tap-element.test.ts
+++ b/tests/unit/app-tap-element.test.ts
@@ -236,6 +236,55 @@ describe('app_tap_element', () => {
     expect(body.message).toBe('Element not found');
   });
 
+  it('attaches bounded searched-tree diagnostics on a terminal miss (#834)', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+    mockDumpTree.mockResolvedValue({
+      role: 'AXWindow',
+      traits: [],
+      frame: { x: 0, y: 0, width: 100, height: 100 },
+      visible: true,
+      enabled: true,
+      focused: false,
+      path: '0',
+      children: [
+        {
+          role: 'AXButton',
+          label: 'Submit Order',
+          traits: [],
+          frame: { x: 0, y: 0, width: 10, height: 10 },
+          visible: true,
+          enabled: true,
+          focused: false,
+          path: '0/0',
+        },
+      ],
+    });
+
+    const result = await handler('session', { label: 'submit', timeout: 0 });
+
+    const body = JSON.parse(result.content[0].text);
+    expect(body.message).toBe('Element not found');
+    expect(body.diagnostics).toBeDefined();
+    expect(body.diagnostics.candidates.map((c: { label?: string }) => c.label)).toContain(
+      'Submit Order',
+    );
+    expect(typeof body.hint).toBe('string');
+    // Exactly one diagnostic dump, and only because we missed.
+    expect(mockDumpTree).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits diagnostics gracefully when the diagnostic dump fails (#834)', async () => {
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+    mockDumpTree.mockRejectedValue(new Error('dump timed out'));
+
+    const result = await handler('session', { label: 'submit', timeout: 0 });
+
+    const body = JSON.parse(result.content[0].text);
+    expect(body.message).toBe('Element not found');
+    expect(body.diagnostics).toBeUndefined();
+    expect(body.hint).toBeUndefined();
+  });
+
   it('returns error when element is not visible', async () => {
     const node = makeNode({ visible: false, frame: { x: 0, y: 0, width: 0, height: 0 } });
     mockQuery.mockResolvedValue(makeQueryResult([node]));

--- a/tests/unit/not-found-diagnostics.test.ts
+++ b/tests/unit/not-found-diagnostics.test.ts
@@ -1,0 +1,90 @@
+import {
+  buildNotFoundDiagnostics,
+  DEFAULT_MAX_NODES,
+  type TreeDumper,
+} from '../../src/native/not-found-diagnostics';
+import type { AXNode } from '../../src/native/ax-types';
+
+function node(partial: Partial<AXNode> & { path: string }): AXNode {
+  return {
+    role: 'AXGroup',
+    traits: [],
+    frame: { x: 0, y: 0, width: 10, height: 10 },
+    visible: true,
+    enabled: true,
+    focused: false,
+    ...partial,
+  };
+}
+
+/** Build a root whose subtree has `count` leaf children. */
+function rootWith(count: number, extra: AXNode[] = []): AXNode {
+  const children: AXNode[] = [];
+  for (let i = 0; i < count; i++) {
+    children.push(node({ role: 'AXStaticText', label: `leaf ${i}`, path: `0/${i}` }));
+  }
+  return node({ role: 'AXWindow', path: '0', children: [...children, ...extra] });
+}
+
+function dumperReturning(root: AXNode): TreeDumper & { dumpTree: jest.Mock } {
+  return { dumpTree: jest.fn(async () => root) };
+}
+
+describe('buildNotFoundDiagnostics (issue #834)', () => {
+  it('returns a digest capped at maxNodes and reports truncation', async () => {
+    const root = rootWith(100); // 1 root + 100 leaves = 101 nodes
+    const bridge = dumperReturning(root);
+    const diag = await buildNotFoundDiagnostics(bridge, 'udid', { label: 'nope' });
+    expect(diag).toBeDefined();
+    expect(diag!.searchedNodeCount).toBe(101);
+    expect(diag!.nodes.length).toBe(DEFAULT_MAX_NODES);
+    expect(diag!.truncated).toBe(true);
+    expect(bridge.dumpTree).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces substring near-matches as candidates', async () => {
+    const root = rootWith(3, [
+      node({ role: 'AXButton', label: 'Submit Order', path: '0/x' }),
+    ]);
+    const bridge = dumperReturning(root);
+    const diag = await buildNotFoundDiagnostics(bridge, 'udid', { label: 'submit' });
+    expect(diag!.candidates.map((c) => c.label)).toContain('Submit Order');
+  });
+
+  it('returns empty candidates when nothing matches (never fabricates)', async () => {
+    const bridge = dumperReturning(rootWith(3));
+    const diag = await buildNotFoundDiagnostics(bridge, 'udid', { label: 'Checkout' });
+    expect(diag!.candidates).toEqual([]);
+  });
+
+  it('matches candidates by identifier and value, not only label', async () => {
+    const root = rootWith(1, [
+      node({ role: 'AXButton', identifier: 'checkout_cta', path: '0/a' }),
+      node({ role: 'AXStaticText', value: 'Total: checkout', path: '0/b' }),
+    ]);
+    const bridge = dumperReturning(root);
+    const diag = await buildNotFoundDiagnostics(bridge, 'udid', { identifier: 'checkout' });
+    expect(diag!.candidates.length).toBe(2);
+  });
+
+  it('degrades to undefined when dumpTree fails (never worsens the failure)', async () => {
+    const bridge: TreeDumper & { dumpTree: jest.Mock } = {
+      dumpTree: jest.fn(async () => {
+        throw new Error('dump timed out');
+      }),
+    };
+    const diag = await buildNotFoundDiagnostics(bridge, 'udid', { label: 'x' });
+    expect(diag).toBeUndefined();
+    expect(bridge.dumpTree).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps candidates at 5 even with many matches', async () => {
+    const matches: AXNode[] = [];
+    for (let i = 0; i < 10; i++) {
+      matches.push(node({ role: 'AXButton', label: `save ${i}`, path: `0/m${i}` }));
+    }
+    const bridge = dumperReturning(node({ role: 'AXWindow', path: '0', children: matches }));
+    const diag = await buildNotFoundDiagnostics(bridge, 'udid', { label: 'save' });
+    expect(diag!.candidates.length).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **PR 4.1 of #834**. The most frequent inner-loop bottleneck is a query that fails to match, after which the developer manually re-runs `app_tree` to see what was on screen. This attaches that snapshot automatically.

On a **terminal miss** (after all relaxed/alias attempts), `app_tap_element`'s "Element not found" error now carries:
- `diagnostics`: a bounded digest of the searched tree (`searchedNodeCount`, `truncated`, up to 40 compacted `nodes`, up to 5 substring `candidates`);
- `hint`: a one-line pointer to the candidates / autoScroll.

## Design (bounded & graceful by construction)

New shared helper `src/native/not-found-diagnostics.ts`:
- **exactly one** `dumpTree`, and **only** inside the terminal-miss branch (single call site → never on success or per retry);
- hard node cap (`DEFAULT_MAX_NODES = 40`) — never an unbounded dump;
- **substring** candidate matching only (no fuzzy/Levenshtein/AI ranking);
- returns `undefined` when the dump throws/times out → original error is preserved, failure never worsened.

`AXQueryResult` carries only matches (verified — the bridge filters natively and does not return the tree), so a digest genuinely requires this one explicit `dumpTree`; there is no already-fetched tree to reuse.

## Verification

```
npx jest app-tap-element not-found-diagnostics   # 60 passed
npx tsc --noEmit                                  # exit 0
npx eslint <changed files>                        # exit 0
```

Tests assert: digest capped + truncation flag; substring candidate surfaces; empty candidates when no match (never fabricated); identifier/value matching; **dumpTree called exactly once**; **graceful `undefined` on dump failure**; and tool-level integration that diagnostics attach on a miss and are omitted when the dump fails.

## Scope guardrails

- Diagnostic enrichment only — no change to query matching, retry, or success payloads.
- No fuzzy ranking, no screenshots, no `app_tree` changes, no new required params.

Part of #834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)