### PR TITLE
feat(native): surface semantics-activation failure as a warning across tools (#833 PR 3.1)

### DIFF
--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -22,4 +22,4 @@ export type {
 export { AccessibilityBridge, AccessibilityBridgeError, getAccessibilityBridge } from './accessibility-bridge';
 export type { AXPressResponse } from './accessibility-bridge';
 export type { AXNode, AXFrame, AXQuery, AXQueryResult, AXDumpOptions, AXQueryOptions } from './ax-types';
-export { ensureSemanticsActive, countNodes, isLikelyChromeOnlyTree } from './semantics-activator';
+export { ensureSemanticsActive, activateSemanticsOrWarn, SEMANTICS_INACTIVE_WARNING, countNodes, isLikelyChromeOnlyTree } from './semantics-activator';

--- a/src/native/semantics-activator.ts
+++ b/src/native/semantics-activator.ts
@@ -134,6 +134,39 @@ export function isLikelyChromeOnlyTree(node: AXNode): boolean {
  * This is a no-op for native (non-Flutter) apps that already expose a full
  * accessibility tree.
  */
+/**
+ * Canonical warning surfaced when accessibility semantics fail to populate.
+ * Single source of truth so every tool emits identical, non-absolute wording
+ * (a slow device can still recover on a later call). Issue #833.
+ */
+export const SEMANTICS_INACTIVE_WARNING =
+  'Accessibility semantics may not have populated (the tree was empty after activation). ' +
+  'A missing element may be a symptom of this. If this is a Flutter app, rebuild with ' +
+  '`flutter run --debug`, restart the app, or wrap the target widget in Semantics(); ' +
+  'on a slow device, retrying the call may also succeed.';
+
+export interface SemanticsActivationResult {
+  active: boolean;
+  warning?: string;
+}
+
+/**
+ * Activate semantics and, when activation does not populate the tree, return a
+ * structured warning instead of silently proceeding (issue #833).
+ *
+ * Thin wrapper over {@link ensureSemanticsActive}; the boolean contract is
+ * unchanged. Tools merge `warning` (when present) into their response so an
+ * empty-tree degradation is never silent. `app_tap` and `app_tree` already
+ * surface this themselves and intentionally do not use this helper.
+ */
+export async function activateSemanticsOrWarn(
+  deviceId: string,
+  options?: EnsureSemanticsOptions,
+): Promise<SemanticsActivationResult> {
+  const active = await ensureSemanticsActive(deviceId, options);
+  return active ? { active: true } : { active: false, warning: SEMANTICS_INACTIVE_WARNING };
+}
+
 export async function ensureSemanticsActive(
   deviceId: string,
   options?: EnsureSemanticsOptions,

--- a/src/tools/app-assert-element.ts
+++ b/src/tools/app-assert-element.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import { getAccessibilityBridge, ensureSemanticsActive, activateSemanticsOrWarn } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
 import {
@@ -108,6 +108,7 @@ export function registerAppAssertElementTool(server: MCPServer): void {
           activationAttempted: false,
           activationRetries: 0,
         };
+        let semanticsWarning: string | undefined;
         if (bundleId) {
           const context = await activateAndClassify({
             bridge,
@@ -120,7 +121,7 @@ export function registerAppAssertElementTool(server: MCPServer): void {
             throw createContextMismatchError(meta);
           }
         } else {
-          await ensureSemanticsActive(deviceId, { bundleId });
+          semanticsWarning = (await activateSemanticsOrWarn(deviceId, { bundleId })).warning;
         }
         const result = await bridge.query(query, { deviceId });
         const matches = result.matches;
@@ -171,6 +172,9 @@ export function registerAppAssertElementTool(server: MCPServer): void {
           debug: !passed && match === null
             ? await collectNoMatchDebug(bridge, deviceId, query)
             : undefined,
+          // Surface the empty-tree cause only when the assertion failed
+          // because nothing was found (not for a passing not_exists check).
+          semanticsWarning: !passed && match === null ? semanticsWarning : undefined,
           _meta: { context: meta },
           element: match ? {
             role: match.role,

--- a/src/tools/app-query.ts
+++ b/src/tools/app-query.ts
@@ -1,5 +1,5 @@
 import { MCPServer } from '../mcp-server';
-import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import { getAccessibilityBridge, ensureSemanticsActive, activateSemanticsOrWarn } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
 import {
@@ -78,6 +78,7 @@ export function registerAppQueryTool(server: MCPServer): void {
           activationAttempted: false,
           activationRetries: 0,
         };
+        let semanticsWarning: string | undefined;
         if (bundleId) {
           const context = await activateAndClassify({
             bridge,
@@ -90,7 +91,7 @@ export function registerAppQueryTool(server: MCPServer): void {
             throw createContextMismatchError(meta);
           }
         } else {
-          await ensureSemanticsActive(deviceId, { bundleId });
+          semanticsWarning = (await activateSemanticsOrWarn(deviceId, { bundleId })).warning;
         }
 
         let result = await bridge.query(
@@ -189,6 +190,9 @@ export function registerAppQueryTool(server: MCPServer): void {
             type: 'text' as const,
             text: JSON.stringify({
               ...result,
+              // Surface the empty-tree cause only when the query ultimately
+              // found nothing — a recovered match means semantics did populate.
+              ...(semanticsWarning && result.total === 0 ? { semanticsWarning } : {}),
               _meta: {
                 context: meta,
                 queryRecovery,

--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -10,6 +10,7 @@ import { MCPServer, getWebKitClient } from '../mcp-server';
 import {
   getAccessibilityBridge,
   ensureSemanticsActive,
+  activateSemanticsOrWarn,
   countNodes,
   isLikelyChromeOnlyTree,
 } from '../native';
@@ -166,6 +167,7 @@ export function registerAppTapElementTool(server: MCPServer): void {
           activationAttempted: false,
           activationRetries: 0,
         };
+        let semanticsWarning: string | undefined;
         if (bundleId) {
           const context = await activateAndClassify({
             bridge,
@@ -178,7 +180,7 @@ export function registerAppTapElementTool(server: MCPServer): void {
             throw createContextMismatchError(contextMeta);
           }
         } else {
-          await ensureSemanticsActive(deviceId, { bundleId });
+          semanticsWarning = (await activateSemanticsOrWarn(deviceId, { bundleId })).warning;
         }
         const query = { identifier, label, text, role };
 
@@ -261,6 +263,7 @@ export function registerAppTapElementTool(server: MCPServer): void {
               labelAliases: labelAliases.length > 0 ? labelAliases : undefined,
               index,
               timeout,
+              semanticsWarning,
               _meta: { context: contextMeta },
             },
           );

--- a/src/tools/app-type-element.ts
+++ b/src/tools/app-type-element.ts
@@ -43,7 +43,7 @@ import {
   wrapHandlerForBundle,
   COLLECT_DEBUG_BUNDLE_ON_FAILURE_SCHEMA,
 } from './debug-bundle-attach';
-import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import { getAccessibilityBridge, activateSemanticsOrWarn } from '../native';
 import type { AXNode, AXQuery } from '../native';
 import { resolveDeviceId, getInputBackend, runInputOp } from './native-input-utils';
 import { tryPress } from './app-tap-element';
@@ -220,7 +220,7 @@ export function registerAppTypeElementTool(server: MCPServer): void {
             ? perKeyDelayMsRaw
             : 0;
 
-        await ensureSemanticsActive(deviceId);
+        const { warning: semanticsWarning } = await activateSemanticsOrWarn(deviceId);
 
         const bridge = getAccessibilityBridge();
         // Note: the bridge supports a `text` query param (searches label/value),
@@ -246,7 +246,7 @@ export function registerAppTypeElementTool(server: MCPServer): void {
           }
         }
         if (!match) {
-          return respondWithStructuredError(ErrorCode.APP_STATE_UNKNOWN, 'Element not found', { query, index, timeout });
+          return respondWithStructuredError(ErrorCode.APP_STATE_UNKNOWN, 'Element not found', { query, index, timeout, semanticsWarning });
         }
 
         if (!match.visible || match.frame.width <= 0 || match.frame.height <= 0) {

--- a/src/tools/app-wait-for.ts
+++ b/src/tools/app-wait-for.ts
@@ -7,7 +7,7 @@
  */
 
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
+import { getAccessibilityBridge, ensureSemanticsActive, activateSemanticsOrWarn } from '../native';
 import type { AXNode } from '../native';
 import { getSessionManager } from '../session-manager';
 import { getInputBackend } from './native-input-utils';
@@ -174,6 +174,7 @@ export function registerAppWaitForNativeTool(server: MCPServer): void {
           activationAttempted: false,
           activationRetries: 0,
         };
+        let semanticsWarning: string | undefined;
         if (bundleId) {
           const context = await activateAndClassify({
             bridge,
@@ -186,7 +187,7 @@ export function registerAppWaitForNativeTool(server: MCPServer): void {
             throw createContextMismatchError(meta);
           }
         } else {
-          await ensureSemanticsActive(deviceId, { bundleId });
+          semanticsWarning = (await activateSemanticsOrWarn(deviceId, { bundleId })).warning;
         }
         const startTime = Date.now();
         const deadline = startTime + timeout;
@@ -267,7 +268,7 @@ export function registerAppWaitForNativeTool(server: MCPServer): void {
         return respondWithStructuredError(
           ErrorCode.APP_STATE_UNKNOWN,
           'Timeout waiting for element',
-          { condition, query, timeout, elapsed, polls: pollCount },
+          { condition, query, timeout, elapsed, polls: pollCount, semanticsWarning },
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/tests/unit/app-interaction-tools.test.ts
+++ b/tests/unit/app-interaction-tools.test.ts
@@ -107,6 +107,7 @@ jest.mock('../../src/native/accessibility-bridge', () => ({
 
 jest.mock('../../src/native/semantics-activator', () => ({
   ensureSemanticsActive: jest.fn().mockResolvedValue(true),
+  activateSemanticsOrWarn: jest.fn().mockResolvedValue({ active: true }),
   countNodes: jest.fn().mockReturnValue(10),
 }));
 

--- a/tests/unit/app-query-tool.test.ts
+++ b/tests/unit/app-query-tool.test.ts
@@ -3,8 +3,10 @@ import { registerAppQueryTool } from '../../src/tools/app-query';
 import {
   AccessibilityBridge,
   ensureSemanticsActive,
+  activateSemanticsOrWarn,
   getAccessibilityBridge,
 } from '../../src/native';
+import { SEMANTICS_INACTIVE_WARNING } from '../../src/native/semantics-activator';
 
 jest.mock('../../src/native');
 jest.mock('../../src/session-manager', () => ({
@@ -16,6 +18,7 @@ jest.mock('../../src/session-manager', () => ({
 const MockBridge = AccessibilityBridge as jest.MockedClass<typeof AccessibilityBridge>;
 const mockGetBridge = getAccessibilityBridge as jest.MockedFunction<typeof getAccessibilityBridge>;
 const mockEnsureSemanticsActive = ensureSemanticsActive as jest.MockedFunction<typeof ensureSemanticsActive>;
+const mockActivate = activateSemanticsOrWarn as jest.MockedFunction<typeof activateSemanticsOrWarn>;
 
 describe('app_query tool', () => {
   let server: MCPServer;
@@ -24,6 +27,7 @@ describe('app_query tool', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockEnsureSemanticsActive.mockResolvedValue(true);
+    mockActivate.mockResolvedValue({ active: true });
     server = {
       registerTool: jest.fn((_def, h) => { handler = h; }),
     } as unknown as MCPServer;
@@ -59,6 +63,39 @@ describe('app_query tool', () => {
     const parsed = JSON.parse(result.content[0].text!);
     expect(parsed.total).toBe(1);
     expect(parsed.matches[0].identifier).toBe('submit-btn');
+  });
+
+  it('surfaces semanticsWarning when activation fails and the query finds nothing (#833)', async () => {
+    mockActivate.mockResolvedValue({ active: false, warning: SEMANTICS_INACTIVE_WARNING });
+    MockBridge.prototype.query = jest.fn().mockResolvedValue({
+      matches: [], total: 0, query: { label: 'Login' }, ambiguous: false,
+    });
+    MockBridge.prototype.dumpTree = jest.fn().mockResolvedValue({
+      role: 'AXWindow', traits: [], frame: { x: 0, y: 0, width: 1, height: 1 },
+      visible: true, enabled: true, focused: false, path: '0', children: [],
+    });
+    mockGetBridge.mockReturnValue(new MockBridge());
+
+    const result = await handler('session-1', { label: 'Login' });
+
+    const parsed = JSON.parse(result.content[0].text!);
+    expect(parsed.total).toBe(0);
+    expect(parsed.semanticsWarning).toBe(SEMANTICS_INACTIVE_WARNING);
+  });
+
+  it('omits semanticsWarning when the query recovers a match (no false alarm) (#833)', async () => {
+    mockActivate.mockResolvedValue({ active: false, warning: SEMANTICS_INACTIVE_WARNING });
+    MockBridge.prototype.query = jest.fn().mockResolvedValue({
+      matches: [{ role: 'AXButton', identifier: 'login_btn', path: '0/1' }],
+      total: 1, query: { label: 'Login' }, ambiguous: false,
+    });
+    mockGetBridge.mockReturnValue(new MockBridge());
+
+    const result = await handler('session-1', { label: 'Login' });
+
+    const parsed = JSON.parse(result.content[0].text!);
+    expect(parsed.total).toBe(1);
+    expect(parsed.semanticsWarning).toBeUndefined();
   });
 
   it('queries by label and text combined', async () => {
@@ -117,10 +154,12 @@ describe('app_query tool', () => {
     const result = await handler('session-1', { label: 'Email address field' });
 
     expect(queryMock).toHaveBeenCalledTimes(2);
-    expect(mockEnsureSemanticsActive).toHaveBeenNthCalledWith(1, 'mock-device-id', {
+    // The initial activation goes through activateSemanticsOrWarn (#833);
+    // the zero-match recovery still force-refreshes via ensureSemanticsActive.
+    expect(mockActivate).toHaveBeenCalledWith('mock-device-id', {
       bundleId: undefined,
     });
-    expect(mockEnsureSemanticsActive).toHaveBeenNthCalledWith(2, 'mock-device-id', {
+    expect(mockEnsureSemanticsActive).toHaveBeenCalledWith('mock-device-id', {
       bundleId: undefined,
       forceRefresh: true,
     });

--- a/tests/unit/app-tap-element.test.ts
+++ b/tests/unit/app-tap-element.test.ts
@@ -18,6 +18,9 @@ import {
 } from '../../src/tools/app-tap-element';
 import type { AXNode, AXQueryResult } from '../../src/native/ax-types';
 import { DEVICE_PRESETS } from '../../src/simulator/presets';
+import { activateSemanticsOrWarn } from '../../src/native/semantics-activator';
+
+const mockActivate = activateSemanticsOrWarn as unknown as jest.Mock;
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -50,6 +53,7 @@ jest.mock('../../src/native/accessibility-bridge', () => ({
 
 jest.mock('../../src/native/semantics-activator', () => ({
   ensureSemanticsActive: jest.fn().mockResolvedValue(true),
+  activateSemanticsOrWarn: jest.fn().mockResolvedValue({ active: true }),
   countNodes: jest.fn().mockReturnValue(10),
   isLikelyChromeOnlyTree: jest.fn().mockReturnValue(false),
 }));
@@ -234,6 +238,20 @@ describe('app_tap_element', () => {
     const body = JSON.parse(result.content[0].text);
     expect(body.error).toBe('APP_STATE_UNKNOWN');
     expect(body.message).toBe('Element not found');
+  });
+
+  it('propagates semanticsWarning into the not-found error when activation fails (#833)', async () => {
+    mockActivate.mockResolvedValueOnce({
+      active: false,
+      warning: 'semantics may not have populated',
+    });
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+
+    const result = await handler('session', { label: 'NonExistent', timeout: 0 });
+
+    const body = JSON.parse(result.content[0].text);
+    expect(body.message).toBe('Element not found');
+    expect(body.semanticsWarning).toBe('semantics may not have populated');
   });
 
   it('returns error when element is not visible', async () => {

--- a/tests/unit/app-type-element.test.ts
+++ b/tests/unit/app-type-element.test.ts
@@ -53,6 +53,7 @@ jest.mock('../../src/native/accessibility-bridge', () => ({
 
 jest.mock('../../src/native/semantics-activator', () => ({
   ensureSemanticsActive: jest.fn().mockResolvedValue(true),
+  activateSemanticsOrWarn: jest.fn().mockResolvedValue({ active: true }),
   countNodes: jest.fn().mockReturnValue(10),
 }));
 

--- a/tests/unit/app-wait-for.test.ts
+++ b/tests/unit/app-wait-for.test.ts
@@ -26,6 +26,7 @@ jest.mock('../../src/native/accessibility-bridge', () => ({
 
 jest.mock('../../src/native/semantics-activator', () => ({
   ensureSemanticsActive: jest.fn().mockResolvedValue(true),
+  activateSemanticsOrWarn: jest.fn().mockResolvedValue({ active: true }),
   countNodes: jest.fn().mockReturnValue(10),
 }));
 

--- a/tests/unit/semantics-activator.test.ts
+++ b/tests/unit/semantics-activator.test.ts
@@ -44,7 +44,11 @@ jest.mock('../../src/flutter/vm-service-client', () => ({
 }));
 
 // Import after mocks
-import { ensureSemanticsActive } from '../../src/native/semantics-activator';
+import {
+  ensureSemanticsActive,
+  activateSemanticsOrWarn,
+  SEMANTICS_INACTIVE_WARNING,
+} from '../../src/native/semantics-activator';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -417,5 +421,39 @@ describe('ensureSemanticsActive', () => {
     expect(result).toBe(false);
     // disconnect() should still be attempted in the finally block
     expect(mockVMDisconnect).toHaveBeenCalled();
+  });
+});
+
+describe('activateSemanticsOrWarn (issue #833)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockDiscoverVMServiceUrl.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns active:true with no warning when semantics populate', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(10));
+
+    const result = await activateSemanticsOrWarn('test-device-id');
+
+    expect(result.active).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('returns active:false with the canonical warning when the tree never populates', async () => {
+    mockDumpTree.mockResolvedValue(makeTree(2));
+    mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
+    mockDiscoverVMServiceUrl.mockResolvedValue(null);
+
+    const promise = activateSemanticsOrWarn('test-device-id', { timeout: 600 });
+    await jest.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result.active).toBe(false);
+    expect(result.warning).toBe(SEMANTICS_INACTIVE_WARNING);
   });
 });


### PR DESCRIPTION
## Summary

Implements **PR 3.1 of #833**. Five tools called `ensureSemanticsActive()` and **ignored its boolean result**, then queried an empty accessibility tree and returned a bare "not found" with no explanation. This makes that silent degradation visible across the whole family from one source.

## Change

- New `activateSemanticsOrWarn(deviceId, opts) → { active, warning? }` plus the canonical `SEMANTICS_INACTIVE_WARNING` constant in `semantics-activator.ts` — a single source of wording (non-absolute: a slow device may recover on retry).
- Wired into the five verified silent call sites: `app_tap_element`, `app_query`, `app_assert_element`, `app_wait_for`, `app_type_element`.
- Each surfaces the warning **only on its failure/empty path** (not-found / total 0 / timeout / failed assertion), so a recovered match never raises a false alarm.
- `app_tap` (already warns) and `app_tree` (already raises `DEVICE_CONTENT_ROOT_EMPTY`) are intentionally **untouched**.

Uses a dedicated additive `semanticsWarning` field rather than mutating each tool's existing `warning` string (no clobbering, no concatenation).

## Verification

```
npx jest semantics-activator app-tap-element app-query-tool app-assert \
  app-wait-for app-type-element app-interaction-tools app-tap-safety app-tap   # 213 passed
npx tsc --noEmit   # exit 0
npx eslint <changed files>   # exit 0
```

Tests: exhaustive helper unit tests (active→no warning; inactive→canonical warning); two representative integrations (`app_tap_element` not-found and `app_query` empty-result propagate the warning; `app_query` recovered-match omits it — the no-false-alarm guard).

## Scope guardrails

- Warning-only — no dispatch/query/coordinate changes, no new params.
- One shared helper = one message source.
- `app_tap` / `app_tree` behavior unchanged.

Part of #833. Coordinate-fallback warning follows in PR 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)