### PR TITLE
feat(app-tap-element): warn on raw-coordinate fallback for unknown device presets (#833 PR 3.2)

### DIFF
--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -490,9 +490,10 @@ export function registerAppTapElementTool(server: MCPServer): void {
         // — same behavior as before. The lookup is deferred to here (rather
         // than running before AXPress) so successful AXPress taps avoid the
         // `simctl list` round-trip entirely.
+        let coordinateWarning: string | undefined;
         const macOSPtSize = queryResult?.deviceContentMacOSPt;
         if (macOSPtSize) {
-          const iosPtSize = await getIosPtSizeForDevice(deviceId);
+          const { size: iosPtSize, reason } = await getIosPtSizeForDevice(deviceId);
           if (iosPtSize) {
             const before = { x: centerX, y: centerY };
             const converted = convertMacOSPtToIOSPt(before, macOSPtSize, iosPtSize);
@@ -505,6 +506,14 @@ export function registerAppTapElementTool(server: MCPServer): void {
                 `scale=(${(iosPtSize.width / macOSPtSize.width).toFixed(4)}, ` +
                 `${(iosPtSize.height / macOSPtSize.height).toFixed(4)})`,
             );
+          } else if (reason === 'preset_miss') {
+            // simctl resolved the device but its name is not in the preset
+            // table, so no scale factor is known. Warn rather than silently
+            // tap with raw AX coordinates (which are off on a scaled Simulator
+            // window). Transient simctl failures are intentionally silent.
+            coordinateWarning =
+              'device is not in the known preset table; tap used raw AX-frame ' +
+              'coordinates and may be inaccurate on a scaled Simulator window';
           }
         }
 
@@ -576,6 +585,9 @@ export function registerAppTapElementTool(server: MCPServer): void {
             `ambiguous: ${totalMatches} elements matched; tapped index ${index}`,
           );
         }
+        if (coordinateWarning) {
+          warnings.push(coordinateWarning);
+        }
         if (warnings.length > 0) {
           response.warning = warnings.join('; ');
         }
@@ -628,15 +640,28 @@ function sleep(ms: number): Promise<void> {
  * Resolves: device UDID → device name (from simctl list) → preset entry
  * (matched by name) → `{ width: w, height: h }`.
  *
- * Returns `null` when the device cannot be found, no name matches a preset,
- * or the simctl call fails — callers treat `null` as "no conversion available"
- * and fall back to using raw AX-frame coordinates.
+ * Returns a discriminated result so the caller can tell apart the two ways a
+ * size can be absent (issue #833):
+ *   - `preset_miss` — simctl resolved the device, but its name is not in the
+ *     preset table. Permanent for this process; the caller should warn that
+ *     raw coordinates may be inaccurate.
+ *   - `transient` — simctl could not see the device on this call. May recover
+ *     on a later dispatch, so it is NOT cached and must NOT raise a warning
+ *     (avoids alarm fatigue).
+ *   - `ok` — a usable iOS-point size was resolved.
  */
-const iosPtSizeCache = new Map<string, Size2D | null>();
+type IosPtSizeReason = 'ok' | 'preset_miss' | 'transient';
+interface IosPtSizeResult {
+  size: Size2D | null;
+  reason: IosPtSizeReason;
+}
 
-async function getIosPtSizeForDevice(deviceId: string): Promise<Size2D | null> {
-  if (iosPtSizeCache.has(deviceId)) {
-    return iosPtSizeCache.get(deviceId) ?? null;
+const iosPtSizeCache = new Map<string, IosPtSizeResult>();
+
+async function getIosPtSizeForDevice(deviceId: string): Promise<IosPtSizeResult> {
+  const cached = iosPtSizeCache.get(deviceId);
+  if (cached) {
+    return cached;
   }
   try {
     const manager = new SimulatorManager();
@@ -646,15 +671,15 @@ async function getIosPtSizeForDevice(deviceId: string): Promise<Size2D | null> {
       // dispatch after simctl recovers should retry, so do NOT memoize
       // this failure (otherwise one transient error permanently disables
       // coordinate conversion for the UDID until process restart).
-      return null;
+      return { size: null, reason: 'transient' };
     }
     const deviceNameLower = device.name.toLowerCase();
     const preset = Object.values(DEVICE_PRESETS).find(
       (p) => p.name.toLowerCase() === deviceNameLower,
     );
-    const result: Size2D | null = preset
-      ? { width: preset.w, height: preset.h }
-      : null;
+    const result: IosPtSizeResult = preset
+      ? { size: { width: preset.w, height: preset.h }, reason: 'ok' }
+      : { size: null, reason: 'preset_miss' };
     // simctl returned a stable device descriptor — caching the preset
     // hit-or-miss is safe (the device's name and the preset table are
     // both static for this process). Transient simctl failures handled
@@ -663,7 +688,7 @@ async function getIosPtSizeForDevice(deviceId: string): Promise<Size2D | null> {
     return result;
   } catch {
     // Same rationale as the !device branch — never cache a thrown error.
-    return null;
+    return { size: null, reason: 'transient' };
   }
 }
 

--- a/tests/unit/app-tap-element.test.ts
+++ b/tests/unit/app-tap-element.test.ts
@@ -1025,6 +1025,9 @@ describe('app_tap_element — macOS-pt → iOS-pt coordinate conversion (#693 WU
     expect(body.status).toBe('tapped');
     // Raw center unchanged: 200, 222
     expect(body.coordinates).toEqual({ x: 200, y: 222 });
+    // #833 PR 3.2: a known-device preset miss warns that raw coordinates may
+    // be inaccurate rather than degrading silently.
+    expect(body.warning).toContain('not in the known preset table');
   });
 
   it('falls back to raw AX coordinates when getDevice returns null (simctl failure)', async () => {
@@ -1043,6 +1046,9 @@ describe('app_tap_element — macOS-pt → iOS-pt coordinate conversion (#693 WU
     expect(body.status).toBe('tapped');
     // Raw center unchanged.
     expect(body.coordinates).toEqual({ x: 200, y: 222 });
+    // #833 PR 3.2: a transient simctl failure must NOT emit the preset-miss
+    // warning (avoids alarm fatigue), since it may recover on a later call.
+    expect(body.warning ?? '').not.toContain('preset table');
   });
 });
 


### PR DESCRIPTION
## Summary

Implements **PR 3.2 of #833**. When `app_tap_element` resolves a device whose name is not in `DEVICE_PRESETS`, no macOS-pt→iOS-pt scale factor is known, so it taps with **raw AX-frame coordinates** — which are off (≈1.7×) on a scaled Simulator window. This was silent; it now warns.

## Change

`getIosPtSizeForDevice` now returns a discriminated `{ size, reason }`:
- `preset_miss` — device resolved but not in the preset table → emit a coordinate-accuracy `warning`;
- `transient` — simctl could not see the device → **stay silent** (may recover on a later call; avoids alarm fatigue) and remains **un-cached**;
- `ok` — usable size → convert as before.

Warning-only: coordinate math and dispatch are unchanged; raw coordinates are forwarded exactly as before.

## Verification

```
npx jest app-tap-element   # 52 passed
npx tsc --noEmit           # exit 0
npx eslint <changed files> # exit 0
```

Tests assert: preset-miss device → `warning` contains "not in the known preset table"; transient (`getDevice` returns null) → **no** preset-miss warning (the alarm-fatigue guard); `ok` preset → conversion still applied (existing tests unchanged).

## Scope guardrails

- Warning-only — no scale-factor guessing for unknown presets, no dispatch change.
- Preserves `getIosPtSizeForDevice` caching (transient stays un-cached).

Part of #833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)