### PR TITLE
feat(app-wait-for): attach searched-tree diagnostics on timeout (#834 PR 4.2)

### DIFF
--- a/src/tools/app-wait-for.ts
+++ b/src/tools/app-wait-for.ts
@@ -9,6 +9,7 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
 import { getAccessibilityBridge, ensureSemanticsActive } from '../native';
 import type { AXNode } from '../native';
+import { buildNotFoundDiagnostics } from '../native/not-found-diagnostics';
 import { getSessionManager } from '../session-manager';
 import { getInputBackend } from './native-input-utils';
 import { ErrorCode, respondWithStructuredError, StructuredErrorException } from '../errors';
@@ -264,10 +265,18 @@ export function registerAppWaitForNativeTool(server: MCPServer): void {
 
         // Timeout
         const elapsed = Date.now() - startTime;
+        // For "wait until it appears" conditions, attach a bounded snapshot of
+        // what IS on screen so the timeout is diagnosable in one call instead
+        // of a manual app_tree round-trip (#834). Skipped for not_exists, where
+        // a timeout means the element is still present (nothing to surface).
+        const diagnostics =
+          condition === 'not_exists'
+            ? undefined
+            : await buildNotFoundDiagnostics(bridge, deviceId, query);
         return respondWithStructuredError(
           ErrorCode.APP_STATE_UNKNOWN,
           'Timeout waiting for element',
-          { condition, query, timeout, elapsed, polls: pollCount },
+          { condition, query, timeout, elapsed, polls: pollCount, diagnostics },
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/tests/unit/app-wait-for.test.ts
+++ b/tests/unit/app-wait-for.test.ts
@@ -206,6 +206,47 @@ describe('app_wait_for', () => {
     const result = await waitHandler('session', {});
     expect(result.isError).toBe(true);
   });
+
+  it('attaches searched-tree diagnostics on timeout for an appearance condition (#834)', async () => {
+    jest.useFakeTimers();
+    mockQuery.mockResolvedValue(makeQueryResult([]));
+    mockDumpTree.mockResolvedValue({
+      role: 'AXWindow', traits: [], frame: { x: 0, y: 0, width: 1, height: 1 },
+      visible: true, enabled: true, focused: false, path: '0',
+      children: [{
+        role: 'AXButton', label: 'Login', traits: [],
+        frame: { x: 0, y: 0, width: 1, height: 1 },
+        visible: true, enabled: true, focused: false, path: '0/0',
+      }],
+    });
+
+    const promise = waitHandler('session', { label: 'login', timeout: 500, interval: 100 });
+    await jest.advanceTimersByTimeAsync(600);
+    const result = await promise;
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.message).toBe('Timeout waiting for element');
+    expect(body.diagnostics).toBeDefined();
+    expect(body.diagnostics.candidates.map((c: { label?: string }) => c.label)).toContain('Login');
+    jest.useRealTimers();
+  });
+
+  it('omits diagnostics on timeout for a not_exists condition (#834)', async () => {
+    jest.useFakeTimers();
+    // not_exists times out while the element is still present — nothing to surface.
+    mockQuery.mockResolvedValue(makeQueryResult([makeNode()]));
+
+    const promise = waitHandler('session', {
+      label: 'Persist', condition: 'not_exists', timeout: 500, interval: 100,
+    });
+    await jest.advanceTimersByTimeAsync(600);
+    const result = await promise;
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.message).toBe('Timeout waiting for element');
+    expect(body.diagnostics).toBeUndefined();
+    jest.useRealTimers();
+  });
 });
 
 // ── app_assert_element Tests ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements **PR 4.2 of #834** — propagates the not-found diagnostics helper to the query family.

> **Depends on #837** (which adds `buildNotFoundDiagnostics`). This branch is based on #837, so its diff will show only the `app_wait_for` changes once #837 lands on `develop`. **Merge #837 first.**

## Scope refinement (over-engineering avoided)

The issue originally listed `app_query`, `app_assert_element`, and `app_wait_for`. On inspection, **two of the three already return equivalent tree diagnostics on their miss path**:

- `app_query` → `queryDiagnostics` (node count + visible summary, built from its own dump);
- `app_assert_element` → `collectNoMatchDebug` (tree-derived candidate strings).

Wiring the helper into those would add a **redundant second `dumpTree`** for no new information. So this PR instruments **only `app_wait_for`**, whose timeout response previously carried no tree snapshot (it sampled only *matching* nodes — empty when nothing matched).

## Change

On timeout for an appearance condition (`exists` / `visible` / `enabled`), `app_wait_for` attaches a bounded `diagnostics` digest (one dump, capped, graceful on failure). Skipped for `not_exists`, where a timeout means the element is still present.

## Verification

```
npx jest app-wait-for   # 26 passed
npx tsc --noEmit         # exit 0
npx eslint <changed files> # exit 0
```

Tests assert: timeout on an appearance condition → `diagnostics` present with the on-screen candidate; `not_exists` timeout → diagnostics omitted.

## Scope guardrails

- Reuses the reviewed helper (one bounded dump, graceful on failure); no helper behavior change.
- No redundant instrumentation of tools that already diagnose misses.

Part of #834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)