### PR TITLE
fix(not-found-diagnostics): redact emitted strings (follow-up to #837)

### DIFF
--- a/src/native/not-found-diagnostics.ts
+++ b/src/native/not-found-diagnostics.ts
@@ -10,20 +10,35 @@
  * `undefined` if the dump fails — so it never makes the failure worse.
  *
  * Deliberately minimal: substring matching only (no fuzzy/ranking), a hard
- * node cap, and exactly one dump. See the issue's over-engineering checklist.
+ * node cap, and exactly one bounded dump. See the issue's over-engineering
+ * checklist.
+ *
+ * Privacy (#795 pillar 6 / checklist #12): the digest is part of the MCP
+ * response body, so it must not leak on-screen secrets. The node `value`
+ * field — which holds user-entered text (passwords, emails, tokens, OTPs) —
+ * is therefore NEVER emitted. Only developer-authored metadata (`role`,
+ * `label`, `identifier`, `path`) is surfaced, and `label`/`identifier` are run
+ * through the shared credential redactor before emission. `value` is still
+ * used internally for candidate matching (it is never returned).
  */
 
 import type { AXNode, AXQuery } from './ax-types';
+import { redactText, REDACTION_POLICY_VERSION } from '../observability/redaction';
 
 /** Default ceiling on how many nodes the digest carries. */
 export const DEFAULT_MAX_NODES = 40;
 
-/** Compact node shape — just enough to recognise an element, no geometry. */
+/** Bound the dump so a huge tree cannot stall the already-failed path. */
+const DUMP_MAX_DEPTH = 8;
+
+/**
+ * Compact node shape — just enough to recognise an element, no geometry and
+ * deliberately no `value` (see the privacy note above).
+ */
 export interface CompactAXNode {
   role: string;
   label?: string;
   identifier?: string;
-  value?: string;
   path: string;
 }
 
@@ -36,6 +51,8 @@ export interface NotFoundDiagnostics {
   nodes: CompactAXNode[];
   /** Up to 5 nodes whose label/identifier/value contains the query term. */
   candidates: CompactAXNode[];
+  /** Redaction policy applied to emitted strings, so clients know the posture. */
+  redactionPolicy: string;
 }
 
 /** Minimal surface this helper needs from the accessibility bridge. */
@@ -45,12 +62,15 @@ export interface TreeDumper {
 
 const MAX_CANDIDATES = 5;
 
+function redact(s: string | undefined): string | undefined {
+  return s === undefined ? undefined : redactText(s, 'ax').text;
+}
+
 function compact(node: AXNode): CompactAXNode {
   return {
     role: node.role,
-    label: node.label,
-    identifier: node.identifier,
-    value: node.value,
+    label: redact(node.label),
+    identifier: redact(node.identifier),
     path: node.path,
   };
 }
@@ -86,7 +106,7 @@ export async function buildNotFoundDiagnostics(
   const maxNodes = opts?.maxNodes ?? DEFAULT_MAX_NODES;
   let root: AXNode;
   try {
-    root = await bridge.dumpTree(deviceId ? { deviceId } : undefined);
+    root = await bridge.dumpTree({ deviceId, maxDepth: DUMP_MAX_DEPTH });
   } catch {
     // Graceful degradation: a failed/slow dump must not worsen the
     // already-failing not-found path.
@@ -108,8 +128,12 @@ export async function buildNotFoundDiagnostics(
     if (candidates.length < MAX_CANDIDATES && matchesTerm(node, term)) {
       candidates.push(compact(node));
     }
+    // Push in reverse so pop() yields natural reading order (pre-order):
+    // the capped digest then keeps the first/top-of-screen elements.
     if (node.children) {
-      for (const child of node.children) stack.push(child);
+      for (let i = node.children.length - 1; i >= 0; i--) {
+        stack.push(node.children[i]);
+      }
     }
   }
 
@@ -118,5 +142,6 @@ export async function buildNotFoundDiagnostics(
     truncated: searchedNodeCount > nodes.length,
     nodes,
     candidates,
+    redactionPolicy: REDACTION_POLICY_VERSION,
   };
 }

--- a/src/tools/app-tap-element.ts
+++ b/src/tools/app-tap-element.ts
@@ -258,6 +258,12 @@ export function registerAppTapElementTool(server: MCPServer): void {
           // bounded snapshot of the searched tree so the developer sees the
           // cause in one call instead of manually re-running app_tree. One
           // dump, capped; absent if the dump fails. (issue #834)
+          //
+          // This `diagnostics` digest is a lightweight, always-on, redacted
+          // inline complement to the heavy opt-in `debugBundle`
+          // (collectDebugBundleOnFailure): same redaction posture, but no
+          // screenshots/logs/file I/O, so it is safe to emit unconditionally.
+          // See #795 for the evidence-layering rationale.
           const diagnostics = await buildNotFoundDiagnostics(bridge, deviceId, query);
           return respondWithStructuredError(
             ErrorCode.APP_STATE_UNKNOWN,

--- a/tests/unit/not-found-diagnostics.test.ts
+++ b/tests/unit/not-found-diagnostics.test.ts
@@ -87,4 +87,37 @@ describe('buildNotFoundDiagnostics (issue #834)', () => {
     const diag = await buildNotFoundDiagnostics(bridge, 'udid', { label: 'save' });
     expect(diag!.candidates.length).toBe(5);
   });
+
+  it('never emits node value and redacts credential patterns in label (#795 #12)', async () => {
+    const token = 'ghp_abcdef0123456789abcdef0123456789abcd'; // 36 chars after ghp_
+    const root = node({ role: 'AXWindow', path: '0', children: [
+      // value holds user-entered secret — must never be emitted.
+      node({ role: 'AXTextField', label: 'API token', value: token, path: '0/0' }),
+      // a credential that leaks into a label must be redacted on emit.
+      node({ role: 'AXButton', label: `token ${token}`, identifier: 'submit', path: '0/1' }),
+    ] });
+    const bridge = dumperReturning(root);
+    const diag = await buildNotFoundDiagnostics(bridge, 'udid', { label: 'nope' });
+
+    const serialized = JSON.stringify(diag);
+    expect(serialized).not.toContain(token); // no raw secret anywhere
+    expect(diag!.nodes.every((n) => !('value' in n))).toBe(true); // no value field at all
+    const submit = diag!.nodes.find((n) => n.identifier === 'submit');
+    expect(submit?.label).toContain('[REDACTED_GH_TOKEN]');
+    expect(diag!.redactionPolicy).toBeTruthy();
+  });
+
+  it('counts and finds candidates across a deeply nested tree', async () => {
+    const deep = node({ role: 'AXWindow', path: '0', children: [
+      node({ role: 'AXGroup', path: '0/0', children: [
+        node({ role: 'AXScrollArea', path: '0/0/0', children: [
+          node({ role: 'AXButton', label: 'Deep Checkout', path: '0/0/0/0' }),
+        ] }),
+      ] }),
+    ] });
+    const bridge = dumperReturning(deep);
+    const diag = await buildNotFoundDiagnostics(bridge, 'udid', { label: 'checkout' });
+    expect(diag!.searchedNodeCount).toBe(4); // all 4 levels counted
+    expect(diag!.candidates.map((c) => c.label)).toContain('Deep Checkout');
+  });
 });


### PR DESCRIPTION
## Why

#837 was merged before a code-review redaction fix could land on its branch, so `develop` currently ships the not-found `diagnostics` digest **without redaction**. This follow-up lands that fix.

## The gap (P0, #795 #12 / pillar 6)

`buildNotFoundDiagnostics` emitted each node's `value` — the `AXValue`, which holds **user-entered text** (passwords, emails, tokens, OTPs) — directly into the MCP error response body. That violates #795 checklist #12 ("secrets redacted") and the redaction posture the existing `debug_bundle_collect` was built to enforce.

## Fix

- **Never emit `value`**: removed from `CompactAXNode` and from `compact()`. It is still used internally for candidate *matching* but never returned.
- **Redact `label`/`identifier`** through `redactText()` (shared credential redactor: Bearer/JWT/AWS/GitHub PAT).
- **`redactionPolicy`** field added to the result so MCP clients know the posture (mirrors the debug bundle).
- **Bound the dump** with `maxDepth: 8` (matches the convention in `app_tap_element`) so a huge tree can't stall the already-failed path.
- **Pre-order DFS** so the capped 40-node digest keeps top-of-screen elements.
- Comment clarifying `diagnostics` is a lightweight always-on redacted complement to the opt-in `debugBundle`.

## Verification

```
npx tsc --noEmit                                    # exit 0 (on current develop)
npx jest not-found-diagnostics app-tap-element      # 62 passed
npx eslint <changed files>                          # exit 0
```

New tests: no `value` ever emitted + credential pattern in a label is redacted (`[REDACTED_GH_TOKEN]`, raw token absent from `JSON.stringify`); deep nested-tree counting and candidate discovery.

Follow-up to #837. Restores merge-ready state for the not-found diagnostics feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)