### PR TITLE
feat(ax-bridge): attach --debug walker topology to recoverable AX failures (#842)

### DIFF
--- a/docs/debug-bundle.md
+++ b/docs/debug-bundle.md
@@ -89,6 +89,33 @@ forces auto-attach on for the 5 wired tools regardless of the per-call
 parameter. Useful for CI runs where every recoverable failure should
 carry evidence.
 
+## AX walker topology on failure (#842)
+
+When an AX read fails on a recoverable path (`DEVICE_CONTENT_ROOT_EMPTY`
+or `BRIDGE_EXEC_FAILED`) and `OPENSAFARI_AX_DEBUG_ON_FAILURE=1` is set,
+the accessibility-bridge wrapper re-invokes the failing `dump`/`query`
+**once** with `--debug` and parses the `walker_*` JSON-line stderr
+events the Swift bridge emits (#660 PR C / #691). The parsed summary is
+attached to the thrown `AccessibilityBridgeError` as `topology`:
+
+```jsonc
+{
+  "windowCount": 2,                 // AX children Simulator.app exposed
+  "windows": [ { "role": "AXWindow", "subrole": "AXStandardWindow", … } ],
+  "overlayRolesSeen": 0,            // AXSheet/AXAlert/… encountered during the walk
+  "winner": { "role": "AXGroup", "score": 5, "appSemanticsCount": 0 }
+}
+```
+
+This makes a failed AX read self-diagnosing — e.g. a permission sheet
+sitting in a sibling window (`windowCount > 2`) versus an in-subtree
+sheet the content-root scorer discarded (`overlayRolesSeen > 0`,
+`winner.appSemanticsCount === 0`) — without a manual `--debug` repro.
+
+Opt-in and failure-only by design: the success path never passes
+`--debug`, so a healthy `dump` produces no extra stderr. A failed
+re-capture is best-effort and never masks the original error.
+
 ## Artifacts
 
 By default, `screenshot.png`, `ax-tree.json`, and `logs.txt` are written

--- a/src/native/accessibility-bridge.ts
+++ b/src/native/accessibility-bridge.ts
@@ -47,6 +47,138 @@ function formatStreamTail(label: string, value: string | undefined): string {
   return ` | ${label}: ${truncated}`;
 }
 
+/**
+ * Issue #842: structured AX walker topology, parsed from the `walker_*`
+ * JSON-line stderr events the Swift bridge emits under `--debug`
+ * (#660 PR C / #691). Attached to a thrown {@link AccessibilityBridgeError}
+ * on a recoverable failure so the next real failure is self-diagnosing
+ * without a manual repro.
+ */
+export interface AxTopologyWindow {
+  role: string;
+  subrole: string;
+  title: string;
+  identifier: string;
+}
+
+export interface AxTopologyOverlaySample {
+  depth: number;
+  role: string;
+  label: string | null;
+}
+
+export interface AxTopologyWinner {
+  depth: number;
+  role: string;
+  label: string | null;
+  score: number;
+  appSemanticsCount: number;
+}
+
+export interface AxTopology {
+  /** Number of AX children Simulator.app exposed (device window + menubar, …). */
+  windowCount?: number;
+  windows?: AxTopologyWindow[];
+  /** Count of overlay-suspect roles (AXSheet/AXAlert/…) the walk encountered. */
+  overlayRolesSeen?: number;
+  overlaySamples?: AxTopologyOverlaySample[];
+  /** Winning content-root candidate, or null when the walk found none. */
+  winner?: AxTopologyWinner | null;
+}
+
+/**
+ * Time budget for the best-effort `--debug` re-capture on the failure
+ * path. Kept short: this runs only after an AX read already failed, so a
+ * second hang must not compound the original latency.
+ */
+const AX_DEBUG_RECAPTURE_TIMEOUT_MS = 8_000;
+
+/**
+ * Parse the Swift bridge's `--debug` stderr (one JSON object per line)
+ * into a compact {@link AxTopology}. Non-JSON lines and unrelated debug
+ * events are ignored. Returns `undefined` when no `walker_*` event is
+ * present, so a quiet/empty stream never produces a noisy empty object.
+ */
+export function parseWalkerTopology(stderr: string | undefined): AxTopology | undefined {
+  if (!stderr) return undefined;
+  let found = false;
+  const topology: AxTopology = {};
+
+  for (const rawLine of stderr.split('\n')) {
+    const line = rawLine.trim();
+    if (!line.startsWith('{')) continue;
+
+    let evt: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(line);
+      if (!parsed || typeof parsed !== 'object') continue;
+      evt = parsed as Record<string, unknown>;
+    } catch {
+      // Not JSON (e.g. a stray log line) — skip.
+      continue;
+    }
+
+    switch (evt.event) {
+      case 'walker_app_windows_enumerated':
+        found = true;
+        if (typeof evt.count === 'number') topology.windowCount = evt.count;
+        if (Array.isArray(evt.windows)) {
+          topology.windows = evt.windows.map((w) => {
+            const win = (w ?? {}) as Record<string, unknown>;
+            return {
+              role: String(win.role ?? ''),
+              subrole: String(win.subrole ?? ''),
+              title: String(win.title ?? ''),
+              identifier: String(win.identifier ?? ''),
+            };
+          });
+        }
+        break;
+      case 'walker_overlay_roles_seen':
+        found = true;
+        if (typeof evt.count === 'number') topology.overlayRolesSeen = evt.count;
+        if (Array.isArray(evt.samples)) {
+          topology.overlaySamples = evt.samples.map((s) => {
+            const sample = (s ?? {}) as Record<string, unknown>;
+            return {
+              depth: Number(sample.depth ?? 0),
+              role: String(sample.role ?? ''),
+              label: sample.label == null ? null : String(sample.label),
+            };
+          });
+        }
+        break;
+      case 'walker_winner':
+        found = true;
+        topology.winner = {
+          depth: Number(evt.depth ?? 0),
+          role: String(evt.role ?? ''),
+          label: evt.label == null ? null : String(evt.label),
+          score: Number(evt.score ?? 0),
+          appSemanticsCount: Number(evt.appSemanticsCount ?? 0),
+        };
+        break;
+      case 'walker_winner_none':
+        found = true;
+        topology.winner = null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return found ? topology : undefined;
+}
+
+/**
+ * Opt-in gate (issue #842). The success path is never affected; only a
+ * recoverable dump/query failure triggers the one-shot `--debug`
+ * re-capture, and only when this is set.
+ */
+function axDebugOnFailureEnabled(): boolean {
+  return process.env.OPENSAFARI_AX_DEBUG_ON_FAILURE === '1';
+}
+
 export interface AccessibilityBridgeOptions {
   /**
    * Pre-resolve the bridge path, bypassing the filesystem search.
@@ -194,6 +326,19 @@ export class AccessibilityBridge {
       const stdoutForDiag = error.stdout ?? capturedStdout;
       const stderrForDiag = error.stderr ?? capturedStderr;
 
+      // Issue #842: opt-in self-diagnosis. On a recoverable dump/query
+      // failure, re-invoke once with `--debug` and parse the `walker_*`
+      // topology so the thrown error carries why the AX read came up empty
+      // (sibling window vs in-subtree vs degraded read) without a manual
+      // repro. The success path never reaches here, so stderr volume on a
+      // healthy dump is unchanged. Best-effort: a failed re-capture leaves
+      // topology undefined and never masks the original error.
+      const command = args[0];
+      const topology =
+        axDebugOnFailureEnabled() && (command === 'dump' || command === 'query')
+          ? await this.captureAxTopologyOnFailure(cmd, cmdArgs)
+          : undefined;
+
       // Issue #693 WU1: the bridge writes its structured ErrorJSON
       // (`{ error, code }`) to STDOUT and then `exit(1)`, NOT to stderr —
       // see `outputError()` in `src/native/ax-bridge.swift`. The previous
@@ -213,6 +358,7 @@ export class AccessibilityBridge {
             throw new AccessibilityBridgeError(
               errJson.error,
               typeof errJson.code === 'string' ? errJson.code : 'AX_ERROR',
+              topology,
             );
           }
         } catch (parseErr) {
@@ -235,7 +381,32 @@ export class AccessibilityBridge {
           formatStreamTail('stdout', stdoutForDiag) +
           formatStreamTail('stderr', stderrForDiag),
         'BRIDGE_EXEC_FAILED',
+        topology,
       );
+    }
+  }
+
+  /**
+   * Best-effort `--debug` re-capture for issue #842. Re-invokes the
+   * already-failed command once with `--debug` appended and parses the
+   * `walker_*` topology from stderr. Never throws: the bridge re-invoke
+   * itself usually exits non-zero (the original failure reproduces), so we
+   * read stderr off the rejection and parse it. Returns `undefined` on any
+   * problem so the caller's primary error is never masked.
+   */
+  private async captureAxTopologyOnFailure(
+    cmd: string,
+    cmdArgs: string[],
+  ): Promise<AxTopology | undefined> {
+    try {
+      const debugArgs = cmdArgs.includes('--debug') ? cmdArgs : [...cmdArgs, '--debug'];
+      const result = await execFileAsync(cmd, debugArgs, {
+        timeout: AX_DEBUG_RECAPTURE_TIMEOUT_MS,
+        maxBuffer: 4 * 1024 * 1024,
+      }).catch((e: { stderr?: string }) => ({ stderr: e?.stderr }));
+      return parseWalkerTopology(result.stderr);
+    } catch {
+      return undefined;
     }
   }
 
@@ -338,6 +509,12 @@ export class AccessibilityBridgeError extends Error {
   constructor(
     message: string,
     public readonly code: string,
+    /**
+     * Issue #842: AX walker topology parsed from a best-effort `--debug`
+     * re-capture, present only on recoverable dump/query failures when
+     * `OPENSAFARI_AX_DEBUG_ON_FAILURE=1`. Undefined otherwise.
+     */
+    public readonly topology?: AxTopology,
   ) {
     super(message);
     this.name = 'AccessibilityBridgeError';

--- a/tests/fixtures/ax-bridge-fake/walker-topology.js
+++ b/tests/fixtures/ax-bridge-fake/walker-topology.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Fake ax-bridge-native stand-in for the issue #842 `--debug` topology
+ * re-capture test.
+ *
+ * Behaviour is driven by env vars (inherited from the test process):
+ *
+ *   - FAKE_MODE=success  → emit a valid minimal AXNode dump, exit 0.
+ *   - FAKE_MODE unset    → emit the real binary's failure contract:
+ *                          structured `{ error, code }` ErrorJSON on
+ *                          STDOUT (see `outputError()` in ax-bridge.swift)
+ *                          and exit 1. When `--debug` is present, also
+ *                          emit `walker_*` JSON-line events on STDERR,
+ *                          mirroring the #660 PR C / #691 diagnostics.
+ *
+ * Every invocation appends `debug` or `plain` to `$FAKE_AX_LOG` (when set)
+ * so the test can assert exactly when the wrapper re-invokes with
+ * `--debug` and confirm the success path never does.
+ *
+ * All CLI args are accepted and (mostly) ignored so the test can pass
+ * `dump --device … --max-depth …` unchanged.
+ */
+
+const fs = require('fs');
+
+const argv = process.argv.slice(2);
+const hasDebug = argv.includes('--debug');
+
+const logPath = process.env.FAKE_AX_LOG;
+if (logPath) {
+  try {
+    fs.appendFileSync(logPath, `${hasDebug ? 'debug' : 'plain'}\n`);
+  } catch {
+    // best-effort
+  }
+}
+
+if (process.env.FAKE_MODE === 'success') {
+  process.stdout.write(
+    JSON.stringify({
+      role: 'AXApplication',
+      label: 'FakeApp',
+      traits: [],
+      frame: { x: 0, y: 0, width: 100, height: 100 },
+      visible: true,
+      enabled: true,
+      focused: true,
+      path: '',
+      children: [],
+    }),
+  );
+  process.exit(0);
+}
+
+// Failure path. Under --debug, emit the walker topology on stderr first.
+if (hasDebug) {
+  const lines = [
+    {
+      event: 'walker_app_windows_enumerated',
+      ts: '2026-06-04T00:00:00.000Z',
+      count: 2,
+      windows: [
+        {
+          role: 'AXWindow',
+          subrole: 'AXStandardWindow',
+          title: 'iPhone 17 Pro – iOS 26.4',
+          identifier: '',
+        },
+        { role: 'AXMenuBar', subrole: '', title: '', identifier: '_NS:1311' },
+      ],
+    },
+    { event: 'walker_overlay_roles_seen', ts: '2026-06-04T00:00:00.001Z', count: 0, samples: [] },
+    {
+      event: 'walker_winner',
+      ts: '2026-06-04T00:00:00.002Z',
+      depth: 1,
+      role: 'AXGroup',
+      label: null,
+      score: 5,
+      appSemanticsCount: 0,
+    },
+  ];
+  process.stderr.write(lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+}
+
+// Structured error on stdout + non-zero exit (real binary contract).
+process.stdout.write(
+  JSON.stringify({
+    error: 'No descendant subtree contains any app-semantics role',
+    code: 'DEVICE_CONTENT_ROOT_EMPTY',
+  }),
+);
+process.exit(1);

--- a/tests/unit/ax-bridge-debug-on-failure.test.ts
+++ b/tests/unit/ax-bridge-debug-on-failure.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Issue #842: opt-in `--debug` walker-topology re-capture on a recoverable
+ * AX read failure.
+ *
+ * Two layers:
+ *   1. Pure unit tests for `parseWalkerTopology` (no child process).
+ *   2. Real-child-process integration via a Node fake shim (same pattern
+ *      as `ax-bridge-recovery.fixture.test.ts`) asserting that:
+ *        - a gated failure re-invokes with `--debug` and attaches topology,
+ *        - an ungated failure does not re-invoke and leaves topology undefined,
+ *        - the success path never invokes `--debug`.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  AccessibilityBridge,
+  AccessibilityBridgeError,
+  parseWalkerTopology,
+} from '../../src/native/accessibility-bridge';
+
+describe('parseWalkerTopology', () => {
+  test('parses window enumeration, overlay roles, and winner from --debug stderr', () => {
+    const stderr = [
+      JSON.stringify({ event: 'invocation', command: 'dump' }),
+      'not json — should be ignored',
+      JSON.stringify({
+        event: 'walker_app_windows_enumerated',
+        count: 2,
+        windows: [
+          { role: 'AXWindow', subrole: 'AXStandardWindow', title: 'iPhone 17 Pro – iOS 26.4', identifier: '' },
+          { role: 'AXMenuBar', subrole: '', title: '', identifier: '_NS:1311' },
+        ],
+      }),
+      JSON.stringify({ event: 'walker_overlay_roles_seen', count: 0, samples: [] }),
+      JSON.stringify({ event: 'walker_winner', depth: 1, role: 'AXGroup', label: null, score: 5, appSemanticsCount: 0 }),
+    ].join('\n');
+
+    const topology = parseWalkerTopology(stderr);
+
+    expect(topology).toBeDefined();
+    expect(topology!.windowCount).toBe(2);
+    expect(topology!.windows).toHaveLength(2);
+    expect(topology!.windows![0]).toMatchObject({ role: 'AXWindow', subrole: 'AXStandardWindow' });
+    expect(topology!.overlayRolesSeen).toBe(0);
+    expect(topology!.overlaySamples).toEqual([]);
+    expect(topology!.winner).toMatchObject({ role: 'AXGroup', score: 5, appSemanticsCount: 0, label: null });
+  });
+
+  test('returns undefined when no walker_* events are present', () => {
+    const stderr = [
+      JSON.stringify({ event: 'invocation', command: 'dump' }),
+      JSON.stringify({ event: 'ax_permission_check_done', trusted: true }),
+    ].join('\n');
+    expect(parseWalkerTopology(stderr)).toBeUndefined();
+  });
+
+  test('returns undefined for empty / missing stderr', () => {
+    expect(parseWalkerTopology('')).toBeUndefined();
+    expect(parseWalkerTopology(undefined)).toBeUndefined();
+  });
+
+  test('represents walker_winner_none as an explicit null winner', () => {
+    const stderr = JSON.stringify({ event: 'walker_winner_none' });
+    const topology = parseWalkerTopology(stderr);
+    expect(topology).toBeDefined();
+    expect(topology!.winner).toBeNull();
+  });
+});
+
+const FIXTURE_PATH = path.resolve(__dirname, '..', 'fixtures', 'ax-bridge-fake', 'walker-topology.js');
+
+// Bake the child-read env (FAKE_MODE / FAKE_AX_LOG) into the shim itself —
+// same approach as ax-bridge-recovery.fixture.test.ts — so the test does
+// not depend on process.env propagating through execFile to the grandchild.
+// The parent-read gate (OPENSAFARI_AX_DEBUG_ON_FAILURE) is still set via
+// process.env because the bridge reads it in-process.
+function createShim(opts: { mode?: 'success'; logPath: string }): string {
+  const shim = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'ax-debug-on-failure-')),
+    'ax-bridge-native',
+  );
+  const envAssignments = [
+    opts.mode ? `FAKE_MODE=${JSON.stringify(opts.mode)}` : '',
+    `FAKE_AX_LOG=${JSON.stringify(opts.logPath)}`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const contents = `#!/usr/bin/env bash\n${envAssignments} exec "${process.execPath}" ${JSON.stringify(FIXTURE_PATH)} "$@"\n`;
+  fs.writeFileSync(shim, contents, { mode: 0o755 });
+  return shim;
+}
+
+function readLog(logPath: string): string[] {
+  try {
+    return fs
+      .readFileSync(logPath, 'utf-8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+describe('AccessibilityBridge — #842 --debug topology on failure', () => {
+  const createdDirs: string[] = [];
+  let logPath: string;
+  const savedGate = process.env.OPENSAFARI_AX_DEBUG_ON_FAILURE;
+
+  function makeBridge(mode?: 'success'): AccessibilityBridge {
+    const shimPath = createShim({ mode, logPath });
+    createdDirs.push(path.dirname(shimPath));
+    return new AccessibilityBridge({ bridgePath: shimPath });
+  }
+
+  beforeEach(() => {
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ax-debug-on-failure-log-'));
+    createdDirs.push(logDir);
+    logPath = path.join(logDir, 'log.txt');
+    delete process.env.OPENSAFARI_AX_DEBUG_ON_FAILURE;
+  });
+
+  afterEach(() => {
+    for (const dir of createdDirs.splice(0)) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+    if (savedGate === undefined) delete process.env.OPENSAFARI_AX_DEBUG_ON_FAILURE;
+    else process.env.OPENSAFARI_AX_DEBUG_ON_FAILURE = savedGate;
+  });
+
+  test('gated failure re-invokes with --debug and attaches parsed topology', async () => {
+    process.env.OPENSAFARI_AX_DEBUG_ON_FAILURE = '1';
+    const bridge = makeBridge();
+
+    const err = await bridge.dumpTree({ deviceId: 'FIXTURE-DEVICE' }).then(
+      () => null,
+      (e) => e as AccessibilityBridgeError,
+    );
+
+    expect(err).toBeInstanceOf(AccessibilityBridgeError);
+    expect(err!.code).toBe('DEVICE_CONTENT_ROOT_EMPTY');
+    expect(err!.topology).toBeDefined();
+    expect(err!.topology!.windowCount).toBe(2);
+    expect(err!.topology!.overlayRolesSeen).toBe(0);
+    expect(err!.topology!.winner).toMatchObject({ appSemanticsCount: 0 });
+
+    // Exactly two spawns: the original (plain) and the --debug re-capture.
+    expect(readLog(logPath)).toEqual(['plain', 'debug']);
+  });
+
+  test('ungated failure does not re-invoke and leaves topology undefined', async () => {
+    // OPENSAFARI_AX_DEBUG_ON_FAILURE intentionally unset.
+    const bridge = makeBridge();
+
+    const err = await bridge.dumpTree({ deviceId: 'FIXTURE-DEVICE' }).then(
+      () => null,
+      (e) => e as AccessibilityBridgeError,
+    );
+
+    expect(err).toBeInstanceOf(AccessibilityBridgeError);
+    expect(err!.code).toBe('DEVICE_CONTENT_ROOT_EMPTY');
+    expect(err!.topology).toBeUndefined();
+    expect(readLog(logPath)).toEqual(['plain']);
+  });
+
+  test('success path never invokes --debug even when gated', async () => {
+    process.env.OPENSAFARI_AX_DEBUG_ON_FAILURE = '1';
+    const bridge = makeBridge('success');
+
+    const tree = await bridge.dumpTree({ deviceId: 'FIXTURE-DEVICE' });
+
+    expect(tree.label).toBe('FakeApp');
+    expect(readLog(logPath)).toEqual(['plain']);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the `#660 PR C` / `#691` `--debug` walker diagnostics into the live AX path. When a `dump`/`query` fails on a recoverable path (`DEVICE_CONTENT_ROOT_EMPTY` / `BRIDGE_EXEC_FAILED`) and `OPENSAFARI_AX_DEBUG_ON_FAILURE=1` is set, `accessibility-bridge.ts` re-invokes the failing command **once** with `--debug`, parses the `walker_*` JSON-line stderr events the Swift bridge already emits, and attaches a compact `AxTopology` to the thrown `AccessibilityBridgeError`.

Closes #842.

## Why

The `--debug` walker diagnostics shipped as a *manual-capture* aid — the wrapper builds dump args as `['dump','--device',id,'--max-depth',N]` and **never passed `--debug`**, so the topology evidence never reached the live `ax-scan` failure path. This was surfaced while re-examining #660: a SpringBoard permission sheet renders **in-subtree** of the single device window (`windowCount: 2`, `overlayRolesSeen: 0`), so a failed read can only be diagnosed (sibling-window vs in-subtree vs degraded read) with this topology. The Swift `--debug` comment explicitly names `accessibility-bridge.ts` as the intended consumer; this PR completes that intent.

## Behavior

- **Opt-in + failure-only.** Success path never passes `--debug`; a healthy `dump` produces no extra stderr and stdout payload is byte-unchanged.
- **Best-effort.** A failed re-capture leaves `topology` undefined and never masks the original error.
- Gated to `dump`/`query` (the commands that run the window/content-root walk).

```jsonc
// AccessibilityBridgeError.topology
{ "windowCount": 2,
  "windows": [ { "role": "AXWindow", "subrole": "AXStandardWindow", … } ],
  "overlayRolesSeen": 0,
  "winner": { "role": "AXGroup", "score": 5, "appSemanticsCount": 0 } }
```

## Testing

- `npx jest ax-bridge-debug-on-failure` — 7 passing (4 pure-parser, 3 real-child-process fixture: gated re-invoke, ungated no-op, success-path-no-debug)
- `npm test` — **212 suites / 2924 tests** green
- `npm run build:src` — green
- `npm run lint --quiet` (changed files) — clean

## Not tested

- Live simulator failure path (the env flag is exercised via the fixture child process, not a real degraded AX server).

## Related

- Follow-up from #660 root-cause re-examination
- Diagnostics origin: #691 (`walker_*` events), #685 (`--debug` flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)