### PR TITLE
fix(mcp): default tool tier to 1 and fall back unassigned tools to tier 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,13 +438,17 @@ curl -H "Authorization: Bearer $OPENSAFARI_HTTP_TOKEN" \
 
 ### Tool Tiers
 
-Tools are organized into 3 tiers for progressive disclosure:
+Tools are organized into 3 tiers for progressive disclosure. The default surface is **Tier 1** (12 tools, ~4.5 KB of schema); higher tiers are opt-in so the `tools/list` payload stays small for MCP clients that load every tool schema into model context.
 
 | Tier | Tools | Access |
 |------|-------|--------|
-| **Tier 1** | navigate, screenshot, click, type, scroll, read_page, query_dom, javascript, cookies, device_boot, device_shutdown, device_list | Default |
-| **Tier 2** | inspect, wait_for, press, swipe, long_press, batch_navigate, batch_screenshot, cross_viewport_compare | `setTier(2)` |
-| **Tier 3** | auth_save, auth_restore, auth_list, qa_audit, qa_* detectors, workflow_init, appearance_toggle | `--all-tools` |
+| **Tier 1** | navigate, screenshot, click, type, scroll, read_page, query_dom, javascript, cookies, device_boot, device_shutdown, diagnose | Default |
+| **Tier 2** | inspect, wait_for, press, swipe, long_press, device_list, app_* native tools, flutter_* tools, qa_* detectors, network_* tools | `OPENSAFARI_TOOL_TIER=2` or `setTier(2)` |
+| **Tier 3** | auth_save, auth_restore, auth_list, batch_*, workflow_*, qa_full_audit, cross_viewport_compare | `--all-tools` or `OPENSAFARI_TOOL_TIER=3` |
+
+Every registered tool must have an explicit entry in `src/config/tool-tiers.ts`; tools without one fall back to Tier 3 (enforced by `tests/unit/tool-tier-drift.test.ts`).
+
+> **Migration note (0.7.x):** earlier releases exposed Tier 2 (132 tools, ~22k tokens of schema) by default. If you relied on Tier 2 tools being listed without configuration, set `OPENSAFARI_TOOL_TIER=2` in the server environment or pass `--all-tools`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -457,17 +457,18 @@ Every registered tool must have an explicit entry in `src/config/tool-tiers.ts`;
 ```typescript
 import { createServer } from 'opensafari-mcp';
 
-// Create and start the MCP server
-const server = createServer({
-  tier: 3,          // expose all tool tiers
-  auditLog: true,   // enable tool call logging
-});
+// Start with the default Tier 1 tool surface over stdio
+await createServer();
 
-// Start with stdio transport (default)
-await server.start();
+// Expose all tool tiers immediately (same as opensafari serve --all-tools)
+await createServer({ allTools: true });
 
 // Or start with HTTP transport
-await server.start({ transport: 'http', port: 3100, authToken: process.env.OPENSAFARI_HTTP_TOKEN });
+await createServer({
+  transport: 'http',
+  port: 3100,
+  authToken: process.env.OPENSAFARI_HTTP_TOKEN,
+});
 ```
 
 ### WebKitClient

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -178,8 +178,44 @@ export const TOOL_TIERS: Record<string, number> = {
 
   // Tier 1: Diagnostics
   diagnose: 1,
+
+  // Tier 2: QA sessions
+  qa_session_create: 2,
+  qa_session_destroy: 2,
+  qa_session_list: 2,
+
+  // Tier 2: Native auth & OTP
+  auth_save_native: 2,
+  auth_restore_native: 2,
+  auth_list_native: 2,
+  auth_delete_native: 2,
+  auth_otp_fetch: 2,
+
+  // Tier 2: Device network conditioning
+  device_network_set: 2,
+  device_network_get: 2,
+
+  // Tier 2: Native app context & navigation helpers
+  app_context: 2,
+  app_state_snapshot: 2,
+  app_list_routes: 2,
+  app_notes_paste_and_tap_url: 2,
+  app_dismiss_overlay: 2,
+  app_biometric: 2,
+  app_wait_for: 2,
+  app_pop_until: 2,
+  app_goto_screen: 2,
+
+  // Tier 2: Flutter route inspection
+  flutter_get_route: 2,
+
+  // Tier 2: Diagnostics bundles
+  debug_bundle_collect: 2,
 };
 
 export function getToolTier(toolName: string): number {
-  return TOOL_TIERS[toolName] ?? 2;
+  // Unassigned tools fall back to tier 3 so a missing TOOL_TIERS entry can
+  // never silently expand the default tools/list surface. Every registered
+  // tool must have an explicit entry (enforced by tool-tier-drift.test.ts).
+  return TOOL_TIERS[toolName] ?? 3;
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -124,7 +124,9 @@ export interface MCPServerOptions {
 export class MCPServer {
   private tools: Map<string, RegisteredTool> = new Map();
   private transport: MCPTransport | null = null;
-  private currentTier: number = 2;
+  // Tier 1 is the default surface (matches README "Tool Tiers" table).
+  // Raise via setTier(), OPENSAFARI_TOOL_TIER, or --all-tools.
+  private currentTier: number = 1;
   private auditLogEnabled = false;
   private httpHighRiskToolsEnabled = false;
 

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -91,12 +91,12 @@ describe('Edge cases: AuthManager restore nonexistent profile', () => {
 });
 
 describe('Edge cases: Tool tier defaults', () => {
-  test('unknown tool returns default tier 2', () => {
-    expect(getToolTier('completely_unknown_tool')).toBe(2);
+  test('unknown tool falls back to tier 3 (never the default surface)', () => {
+    expect(getToolTier('completely_unknown_tool')).toBe(3);
   });
 
-  test('empty string tool returns default tier 2', () => {
-    expect(getToolTier('')).toBe(2);
+  test('empty string tool falls back to tier 3', () => {
+    expect(getToolTier('')).toBe(3);
   });
 
   test('known tools return expected tiers', () => {

--- a/tests/integration/smoke.test.ts
+++ b/tests/integration/smoke.test.ts
@@ -83,8 +83,8 @@ describe('Smoke: Tool tier mapping', () => {
     expect(getToolTier('workflow_init')).toBe(3);
   });
 
-  test('unknown tool returns default tier (2)', () => {
-    expect(getToolTier('nonexistent_tool_xyz')).toBe(2);
+  test('unknown tool falls back to tier 3 (never the default surface)', () => {
+    expect(getToolTier('nonexistent_tool_xyz')).toBe(3);
   });
 
   test('all TOOL_TIERS entries are between 1 and 3', () => {

--- a/tests/unit/mcp-server.test.ts
+++ b/tests/unit/mcp-server.test.ts
@@ -104,7 +104,7 @@ describe('MCPServer — JSON-RPC protocol', () => {
   });
 
   test('tools/list respects tier filtering', async () => {
-    // Unrecognized tool names default to tier 2; setting tier to 0 should hide all
+    // Unrecognized tool names fall back to tier 3; setting tier to 0 should hide all
     server.setTier(0);
     const res = await mcpPost(PORT, { jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} });
     const result = res.body.result as Record<string, unknown>;

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -55,9 +55,9 @@ describe('tool registry — defineToolEntry', () => {
     expect(entry._cachedHandler).toBeUndefined();
   });
 
-  test('tier is assigned from tool-tiers config (defaults to 2 for unknown)', () => {
+  test('tier is assigned from tool-tiers config (falls back to 3 for unknown)', () => {
     defineToolEntry(makeDefinition(TOOL_NAME), async () => async () => ECHO_RESULT);
-    expect(toolRegistry.get(TOOL_NAME)!.tier).toBe(2);
+    expect(toolRegistry.get(TOOL_NAME)!.tier).toBe(3);
   });
 
   test('well-known tool gets correct tier (navigate = 1)', () => {
@@ -209,7 +209,7 @@ describe('MCPServer.registerLazyTool', () => {
   });
 
   test('tier filtering excludes lazy tool when tier is too low', () => {
-    // LAZY_TOOL defaults to tier 2
+    // LAZY_TOOL has no TOOL_TIERS entry, so it falls back to tier 3
     const def = makeDefinition(LAZY_TOOL);
     defineToolEntry(def, async (): Promise<ToolHandler> => async () => ECHO_RESULT);
 
@@ -218,9 +218,9 @@ describe('MCPServer.registerLazyTool', () => {
     server.registerLazyTool(def);
 
     // getRegisteredTools returns all; filtering happens in handleToolsList.
-    // Simulate via the private map by checking that the entry's tier is 2.
+    // Simulate via the private map by checking that the entry's tier is 3.
     const entry = toolRegistry.get(LAZY_TOOL)!;
-    expect(entry.tier).toBe(2);
+    expect(entry.tier).toBe(3);
     // The server still holds the tool; it would be hidden at list time.
   });
 

--- a/tests/unit/tool-tier-drift.test.ts
+++ b/tests/unit/tool-tier-drift.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tool tier drift prevention.
+ *
+ * Every registered tool must have an explicit TOOL_TIERS entry. The
+ * getToolTier() fallback is tier 3, so a missing entry hides a tool from the
+ * default surface instead of exposing it — but relying on the fallback is
+ * still a bug: tier assignment is a deliberate, reviewed decision.
+ */
+import { MCPServer } from '../../src/mcp-server';
+import { registerAllTools } from '../../src/tools';
+import { TOOL_TIERS, getToolTier } from '../../src/config/tool-tiers';
+
+describe('Tool tier drift prevention', () => {
+  let server: MCPServer;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerAllTools(server);
+  });
+
+  test('every registered tool has an explicit TOOL_TIERS entry', () => {
+    const missing = server
+      .getRegisteredTools()
+      .filter((name) => !(name in TOOL_TIERS));
+    // If this fails, add an explicit tier for each listed tool in
+    // src/config/tool-tiers.ts — new tools must opt in to a surface.
+    expect(missing).toEqual([]);
+  });
+
+  test('default tier is 1 (minimal tools/list surface)', () => {
+    expect(new MCPServer().getTier()).toBe(1);
+  });
+
+  test('unassigned tools fall back to tier 3, not the default surface', () => {
+    expect(getToolTier('some_future_unassigned_tool')).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #844

## Summary

The default `tools/list` surface exposed **132 tools / 88,692 bytes (~22k tokens)** of schema per MCP session because `currentTier` defaulted to 2 and `getToolTier()` assigned tier 2 to any tool missing a `TOOL_TIERS` entry (21 tools relied on that fallback). README has always documented Tier 1 as the default.

- `MCPServer.currentTier` default `2` → `1`
- 21 previously-unlisted tools get explicit tier 2 entries (opt-in Tier 2 surface unchanged)
- `getToolTier()` fallback `?? 2` → `?? 3` — a forgotten tier assignment now hides a tool from the default surface instead of silently exposing it
- New drift-prevention test (`tests/unit/tool-tier-drift.test.ts`): every registered tool must have an explicit `TOOL_TIERS` entry; default tier pinned to 1
- README tier table corrected to match `TOOL_TIERS` (it listed `device_list` as Tier 1 and `batch_*`/`qa_*` in the wrong tiers); migration note added

## Measurements (registerAllTools → JSON.stringify(tools/list))

| Surface | Before | After |
|---|---|---|
| Default | 132 tools / 88,692 B (~22k tokens) | **12 tools / 4,544 B (~1k tokens)** |
| `OPENSAFARI_TOOL_TIER=2` | 132 / 88,692 B | 132 / 88,692 B (unchanged) |
| `--all-tools` (tier 3) | 155 / 103,220 B | 155 / 103,220 B (unchanged) |

## Migration

Users who relied on Tier 2 tools being listed by default: set `OPENSAFARI_TOOL_TIER=2` or pass `--all-tools` (documented in README).

## Verification

- `npx jest tests/unit tests/integration` — 211 suites / 2915 tests pass
- `npx tsc --noEmit` clean
- Default surface re-measured after the change: exactly the 12 Tier-1 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)