### PR TITLE
fix(reliability): do not exit the MCP server on unhandled promise rejections

### DIFF
--- a/src/reliability/graceful-shutdown.ts
+++ b/src/reliability/graceful-shutdown.ts
@@ -41,12 +41,17 @@ export function setupGracefulShutdown(pool: SimulatorPool): void {
       1,
       error instanceof Error ? error.message : String(error),
     ));
-  process.on('unhandledRejection', (reason) =>
-    void shutdown(
-      'UNHANDLED_REJECTION',
-      1,
-      reason instanceof Error ? reason.message : String(reason),
-    ));
+  // Unhandled rejections must NOT kill the server: a rejection aborts one
+  // isolated async chain, while exiting here tears down the MCP transport and
+  // every simulator. Keep this listener installed even though it only logs —
+  // without it, Node >= 15 crashes the process on any unhandled rejection.
+  process.on('unhandledRejection', (reason) => {
+    const detail =
+      reason instanceof Error ? reason.stack ?? reason.message : String(reason);
+    console.error(
+      `[OpenSafari] Unhandled rejection (continuing): ${detail}`,
+    );
+  });
 }
 
 export function __resetGracefulShutdownForTests(): void {

--- a/tests/unit/graceful-shutdown.test.ts
+++ b/tests/unit/graceful-shutdown.test.ts
@@ -44,7 +44,7 @@ describe('setupGracefulShutdown', () => {
     expect(process.listeners('unhandledRejection').length).toBeGreaterThan(counts.unhandledRejection);
   });
 
-  test('logs structured shutdown reason and exits 1 for unhandled rejections', async () => {
+  test('logs unhandled rejections and keeps the process alive', async () => {
     const module = await import('../../src/reliability/graceful-shutdown');
     const pool = { shutdownAll: jest.fn().mockResolvedValue(undefined) } as any;
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -55,14 +55,36 @@ describe('setupGracefulShutdown', () => {
     handler(new Error('boom'));
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(pool.shutdownAll).toHaveBeenCalledTimes(1);
+    // One leaked rejection must not tear down the MCP server or simulators.
+    expect(pool.shutdownAll).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"reason":"UNHANDLED_REJECTION"'),
+      expect.stringContaining('Unhandled rejection (continuing)'),
     );
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"detail":"boom"'),
+      expect.stringContaining('boom'),
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  test('logs non-Error rejection reasons and keeps the process alive', async () => {
+    const module = await import('../../src/reliability/graceful-shutdown');
+    const pool = { shutdownAll: jest.fn().mockResolvedValue(undefined) } as any;
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    module.setupGracefulShutdown(pool);
+    const handler = process.listeners('unhandledRejection').at(-1) as (reason: unknown) => void;
+    handler('string-reason');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(pool.shutdownAll).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('string-reason'),
+    );
 
     errorSpy.mockRestore();
     exitSpy.mockRestore();


### PR DESCRIPTION
Closes #845

## Summary

`setupGracefulShutdown` treated `unhandledRejection` like SIGTERM: `pool.shutdownAll()` → `process.exit(1)` (src/reliability/graceful-shutdown.ts:44-49). One leaked rejection anywhere in the 53k-line codebase killed the MCP server **and** shut down all simulators — the single most likely cause of "the opensafari MCP server keeps disconnecting".

- `unhandledRejection` now logs `[OpenSafari] Unhandled rejection (continuing): <stack>` to stderr and keeps running.
- The listener stays installed (load-bearing: Node ≥ 15 crashes by default on unhandled rejections without one).
- `SIGTERM` / `SIGINT` / `uncaughtException` paths unchanged (fail-fast remains correct for corrupted sync state).

## Verification

- `tests/unit/graceful-shutdown.test.ts` — the old "exits 1 for unhandled rejections" test is inverted: asserts no `process.exit`, no `pool.shutdownAll()`, structured log emitted; plus a non-Error-reason case. 4/4 pass.
- `npx tsc --noEmit` clean.

## Notes

- Known leak candidates (`webkit/client.ts:87,316` fire-and-forget `handleDisconnect()`) are hardened separately in #846 — this PR fixes the blast radius, that one fixes the sources.
- Follow-up candidate (out of scope): enable `@typescript-eslint/no-floating-promises` to catch this bug class at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)