### PR TITLE
fix(webkit): tolerate transient heartbeat failures and stop implicit reload on reconnect

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -13,6 +13,13 @@ export const DEFAULT_MAX_SIMULATORS = 3;
 export const DEFAULT_WEBKIT_CONNECT_TIMEOUT_MS = 10000;
 export const DEFAULT_WEBKIT_SEND_TIMEOUT_MS = 15000;
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000;
+/**
+ * Consecutive heartbeat failures tolerated before tearing down the connection.
+ * A single failed probe is routinely benign (page JS busy past the send
+ * timeout, active target briefly absent during navigation), so reconnecting
+ * on the first failure amplifies transient slowness into a full teardown.
+ */
+export const DEFAULT_HEARTBEAT_FAILURE_THRESHOLD = 3;
 export const DEFAULT_RECONNECT_MAX_ATTEMPTS = 10;
 export const DEFAULT_RECONNECT_BASE_DELAY_MS = 1000;
 export const DEFAULT_RECONNECT_MAX_DELAY_MS = 30000;

--- a/src/webkit/client.ts
+++ b/src/webkit/client.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_WEBKIT_CONNECT_TIMEOUT_MS,
   DEFAULT_WEBKIT_SEND_TIMEOUT_MS,
   DEFAULT_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_HEARTBEAT_FAILURE_THRESHOLD,
   DEFAULT_RECONNECT_MAX_ATTEMPTS,
   DEFAULT_RECONNECT_BASE_DELAY_MS,
   DEFAULT_RECONNECT_MAX_DELAY_MS,
@@ -46,6 +47,13 @@ export interface WebKitClientOptions {
   connectTimeout?: number;
   sendTimeout?: number;
   heartbeatInterval?: number;
+  /** Consecutive heartbeat failures before reconnecting. Default 3. */
+  heartbeatFailureThreshold?: number;
+  /**
+   * Re-navigate to the last URL after a successful reconnect. Default false:
+   * an implicit reload destroys page state the caller did not ask to lose.
+   */
+  renavigateOnReconnect?: boolean;
 }
 
 export interface WebKitTarget {
@@ -62,6 +70,7 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
   private innerMessageId = 0;
   private connected = false;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatFailures = 0;
   private lastUrl: string = '';
   private reconnecting = false;
   readonly backendType = 'safari' as const;
@@ -84,7 +93,11 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
     this.transport.on('transport:close', () => {
       if (this.connected && !this.reconnecting) {
         this.connected = false;
-        this.handleDisconnect();
+        // Fire-and-forget: handleDisconnect never intentionally rejects, but
+        // an unhandled rejection here would escalate to the process level.
+        void this.handleDisconnect().catch((err) => {
+          console.error(`[WebKitClient] Disconnect handling failed: ${err}`);
+        });
       }
     });
     this.transport.on('transport:error', (_err: Error) => {
@@ -309,11 +322,28 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
   private startHeartbeat(): void {
     const interval =
       this.options.heartbeatInterval ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    const threshold =
+      this.options.heartbeatFailureThreshold ?? DEFAULT_HEARTBEAT_FAILURE_THRESHOLD;
+    this.heartbeatFailures = 0;
     this.heartbeatTimer = setInterval(async () => {
       try {
         await this.send('Runtime.evaluate', { expression: '1' });
+        this.heartbeatFailures = 0;
       } catch {
-        this.handleDisconnect();
+        // A single failed probe is not a dead connection: page JS can be busy
+        // past the send timeout, and the active target is briefly absent
+        // during navigation. Only sustained failure tears the connection down.
+        this.heartbeatFailures++;
+        if (this.heartbeatFailures < threshold) {
+          console.error(
+            `[WebKitClient] Heartbeat failure ${this.heartbeatFailures}/${threshold} (tolerated)`,
+          );
+          return;
+        }
+        this.heartbeatFailures = 0;
+        void this.handleDisconnect().catch((err) => {
+          console.error(`[WebKitClient] Disconnect handling failed: ${err}`);
+        });
       }
     }, interval);
   }
@@ -334,8 +364,14 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
 
     // Tear down the transport so any stale pending requests are rejected
     // before reconnecting, then reset target-session state owned by the
-    // extracted TargetSessionManager.
-    await this.transport.disconnect();
+    // extracted TargetSessionManager. Teardown failures must not escape:
+    // this method runs fire-and-forget from event handlers, and a rejection
+    // would leave the client stuck with `reconnecting = true`.
+    try {
+      await this.transport.disconnect();
+    } catch (err) {
+      console.error(`[WebKitClient] Transport teardown failed (continuing): ${err}`);
+    }
     this.targetSession.resetTargets();
 
     this.stopHeartbeat();
@@ -369,8 +405,9 @@ export class WebKitClient extends EventEmitter implements BrowserBackend {
           await this.enableDomain(domain);
         }
 
-        // Re-navigate to last URL
-        if (this.lastUrl) {
+        // Re-navigate to the last URL only when explicitly requested — an
+        // implicit reload destroys page state the caller did not ask to lose.
+        if (this.options.renavigateOnReconnect && this.lastUrl) {
           await this.navigate({ url: this.lastUrl });
         }
 

--- a/tests/unit/webkit-client-heartbeat.test.ts
+++ b/tests/unit/webkit-client-heartbeat.test.ts
@@ -1,0 +1,150 @@
+/**
+ * WebKitClient heartbeat policy.
+ *
+ * A single failed probe must not tear down the connection: page JS can be
+ * busy past the send timeout, and the active target is briefly absent during
+ * navigation. Disconnect handling fires only after N consecutive failures,
+ * and reconnect must not implicitly reload the page unless opted in.
+ */
+import { WebKitClient, WebKitClientOptions } from '../../src/webkit/client';
+
+const HEARTBEAT_MS = 1_000;
+
+function makeClient(options?: Partial<WebKitClientOptions>): WebKitClient {
+  return new WebKitClient({
+    host: 'localhost',
+    port: 59999,
+    heartbeatInterval: HEARTBEAT_MS,
+    ...options,
+  });
+}
+
+function startHeartbeat(client: WebKitClient): void {
+  (client as unknown as { startHeartbeat(): void }).startHeartbeat();
+}
+
+function stopHeartbeat(client: WebKitClient): void {
+  (client as unknown as { stopHeartbeat(): void }).stopHeartbeat();
+}
+
+describe('WebKitClient heartbeat failure threshold', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('failures below the threshold do not disconnect', async () => {
+    const client = makeClient();
+    jest.spyOn(client, 'send').mockRejectedValue(new Error('probe timeout'));
+    const disconnectSpy = jest.fn().mockResolvedValue(undefined);
+    (client as any).handleDisconnect = disconnectSpy;
+
+    startHeartbeat(client);
+    await jest.advanceTimersByTimeAsync(HEARTBEAT_MS * 2); // 2 failures < 3
+    stopHeartbeat(client);
+
+    expect(disconnectSpy).not.toHaveBeenCalled();
+  });
+
+  test('reaching the threshold disconnects exactly once', async () => {
+    const client = makeClient();
+    jest.spyOn(client, 'send').mockRejectedValue(new Error('probe timeout'));
+    const disconnectSpy = jest.fn().mockResolvedValue(undefined);
+    (client as any).handleDisconnect = disconnectSpy;
+
+    startHeartbeat(client);
+    await jest.advanceTimersByTimeAsync(HEARTBEAT_MS * 3); // 3 consecutive failures
+    stopHeartbeat(client);
+
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('a successful probe resets the consecutive-failure counter', async () => {
+    const client = makeClient();
+    const sendSpy = jest
+      .spyOn(client, 'send')
+      .mockRejectedValueOnce(new Error('fail 1'))
+      .mockRejectedValueOnce(new Error('fail 2'))
+      .mockResolvedValueOnce(1 as never)
+      .mockRejectedValueOnce(new Error('fail 3'))
+      .mockRejectedValueOnce(new Error('fail 4'));
+    const disconnectSpy = jest.fn().mockResolvedValue(undefined);
+    (client as any).handleDisconnect = disconnectSpy;
+
+    startHeartbeat(client);
+    await jest.advanceTimersByTimeAsync(HEARTBEAT_MS * 5); // fail,fail,ok,fail,fail
+    stopHeartbeat(client);
+
+    expect(sendSpy).toHaveBeenCalledTimes(5);
+    expect(disconnectSpy).not.toHaveBeenCalled();
+  });
+
+  test('heartbeatFailureThreshold option overrides the default', async () => {
+    const client = makeClient({ heartbeatFailureThreshold: 1 });
+    jest.spyOn(client, 'send').mockRejectedValue(new Error('probe timeout'));
+    const disconnectSpy = jest.fn().mockResolvedValue(undefined);
+    (client as any).handleDisconnect = disconnectSpy;
+
+    startHeartbeat(client);
+    await jest.advanceTimersByTimeAsync(HEARTBEAT_MS);
+    stopHeartbeat(client);
+
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WebKitClient reconnect re-navigation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  async function runHandleDisconnect(client: WebKitClient): Promise<void> {
+    jest.spyOn(client, 'connect').mockResolvedValue(undefined);
+    const promise = (client as any).handleDisconnect() as Promise<void>;
+    // Skip past the first reconnect backoff delay (base 1s + jitter).
+    await jest.advanceTimersByTimeAsync(5_000);
+    await promise;
+  }
+
+  test('does not re-navigate by default', async () => {
+    const client = makeClient();
+    (client as any).lastUrl = 'https://example.com/state';
+    const navigateSpy = jest.spyOn(client, 'navigate').mockResolvedValue({} as never);
+
+    await runHandleDisconnect(client);
+
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  test('re-navigates when renavigateOnReconnect is enabled', async () => {
+    const client = makeClient({ renavigateOnReconnect: true });
+    (client as any).lastUrl = 'https://example.com/state';
+    const navigateSpy = jest.spyOn(client, 'navigate').mockResolvedValue({} as never);
+
+    await runHandleDisconnect(client);
+
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(navigateSpy).toHaveBeenCalledWith({ url: 'https://example.com/state' });
+  });
+
+  test('handleDisconnect resolves even when transport teardown rejects', async () => {
+    const client = makeClient();
+    const transport = (client as any).transport;
+    jest.spyOn(transport, 'disconnect').mockRejectedValue(new Error('teardown boom'));
+    jest.spyOn(client, 'connect').mockResolvedValue(undefined);
+
+    const promise = (client as any).handleDisconnect() as Promise<void>;
+    await jest.advanceTimersByTimeAsync(5_000);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/webkit-client-heartbeat.test.ts
+++ b/tests/unit/webkit-client-heartbeat.test.ts
@@ -28,12 +28,16 @@ function stopHeartbeat(client: WebKitClient): void {
 }
 
 describe('WebKitClient heartbeat failure threshold', () => {
+  let errorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.useFakeTimers();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    errorSpy.mockRestore();
     jest.restoreAllMocks();
   });
 
@@ -98,12 +102,16 @@ describe('WebKitClient heartbeat failure threshold', () => {
 });
 
 describe('WebKitClient reconnect re-navigation', () => {
+  let errorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.useFakeTimers();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    errorSpy.mockRestore();
     jest.restoreAllMocks();
   });
 
@@ -146,5 +154,8 @@ describe('WebKitClient reconnect re-navigation', () => {
     await jest.advanceTimersByTimeAsync(5_000);
 
     await expect(promise).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Transport teardown failed (continuing): Error: teardown boom'),
+    );
   });
 });


### PR DESCRIPTION
Closes #846

## Summary

The heartbeat (`Runtime.evaluate('1')` every 30s through the normal `send()` path) treated **one** failed probe as a dead connection: full WebSocket teardown → reconnect loop → unconditional `navigate(lastUrl)`. Busy page JS past the 15s send timeout, or the active target being briefly absent during navigation (`send()` throws `ConnectionError`), was enough to reload the page out from under the user. This is the main mechanism behind "the WebKit connection keeps dropping / the page keeps reloading".

- **Failure threshold**: disconnect only after 3 consecutive heartbeat failures (`DEFAULT_HEARTBEAT_FAILURE_THRESHOLD`, overridable via `heartbeatFailureThreshold`); counter resets on success and on heartbeat start. Tolerated failures are logged.
- **Re-navigate is opt-in**: `renavigateOnReconnect` (default `false`). Reconnect still restores enabled domains and target-session state; it just no longer reloads the page implicitly. All 9 internal `new WebKitClient(...)` sites were audited — none relied on the implicit reload.
- **No more escaping rejections**: `handleDisconnect()`'s teardown awaits are wrapped in try/catch, and both fire-and-forget call sites (`transport:close` handler, heartbeat catch) attach `.catch()`. Combined with #850, a transport hiccup can no longer kill the MCP server.

Genuine socket loss is still detected immediately via `transport:close`; the threshold only delays reaction to *silent* hangs (worst case 3× heartbeat interval).

Out of scope (documented decision): switching to WebSocket ping/pong — pings terminate at ios_webkit_debug_proxy, not the device, so `Runtime.evaluate` remains the only end-to-end probe.

## Verification

- New `tests/unit/webkit-client-heartbeat.test.ts` (7 tests): below-threshold tolerance, threshold disconnect exactly once, counter reset on success, threshold option override, no re-navigate by default, re-navigate when opted in, `handleDisconnect()` resolves when teardown rejects.
- Full `npx jest tests/unit tests/integration`: 211 suites / 2919 tests pass.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)