### PR TITLE
fix(observability): bound long-session resource growth in HAR, log collectors, and watchdog timers

### DIFF
--- a/src/network/har-collector.ts
+++ b/src/network/har-collector.ts
@@ -15,6 +15,13 @@ export interface HarCollectorOptions {
   captureBody?: boolean;
   /** Maximum response body size in bytes (default: 1MB). Bodies exceeding this are skipped. */
   maxBodySize?: number;
+  /**
+   * Maximum number of stored entries (default: 2000). Requests beyond the cap
+   * are counted as dropped instead of stored, so a long recording on a chatty
+   * page cannot grow without bound. Existing entries are never evicted — HAR
+   * consumers expect a stable prefix with intact request/response pairing.
+   */
+  maxEntries?: number;
 }
 
 interface PendingRequest {
@@ -50,6 +57,8 @@ export class HarCollector {
   private client: WebKitClient;
   private captureBody: boolean;
   private maxBodySize: number;
+  private maxEntries: number;
+  private droppedEntries = 0;
   private requestListener: ((params: any) => void) | null = null;
   private responseListener: ((params: any) => void) | null = null;
   private startTime = 0;
@@ -58,6 +67,7 @@ export class HarCollector {
     this.client = client;
     this.captureBody = options?.captureBody ?? false;
     this.maxBodySize = options?.maxBodySize ?? 1024 * 1024; // 1MB
+    this.maxEntries = options?.maxEntries ?? 2000;
   }
 
   async start(): Promise<void> {
@@ -65,6 +75,7 @@ export class HarCollector {
     this.recording = true;
     this.startTime = Date.now();
     this.entries.clear();
+    this.droppedEntries = 0;
     this.pages = [{
       id: 'page_0',
       title: 'Page',
@@ -78,6 +89,11 @@ export class HarCollector {
       const req = params.request;
       if (!req) return;
       const requestId = params.requestId;
+
+      if (this.entries.size >= this.maxEntries) {
+        this.droppedEntries++;
+        return;
+      }
 
       const queryString: Array<{ name: string; value: string }> = [];
       try {
@@ -138,6 +154,13 @@ export class HarCollector {
       };
 
       if (this.captureBody && /^(text\/|application\/json)/.test(mimeType)) {
+        // Skip the RPC entirely when the response is already known to exceed
+        // the cap — fetching first and checking later would transfer the full
+        // body over the protocol just to throw it away.
+        const knownSize = resp.encodedDataLength;
+        if (typeof knownSize === 'number' && knownSize > this.maxBodySize) {
+          return;
+        }
         try {
           const result = await this.client.send<{ body: string; base64Encoded?: boolean }>(
             'Network.getResponseBody',
@@ -159,6 +182,12 @@ export class HarCollector {
 
   stop(): void {
     this.recording = false;
+    if (this.droppedEntries > 0) {
+      console.error(
+        `[HarCollector] Dropped ${this.droppedEntries} request(s) beyond maxEntries=${this.maxEntries}; ` +
+        `raise the maxEntries option to record more`,
+      );
+    }
     if (this.requestListener) {
       this.client.removeListener('Network.requestWillBeSent', this.requestListener);
       this.requestListener = null;
@@ -245,6 +274,11 @@ export class HarCollector {
 
   getEntryCount(): number {
     return this.entries.size;
+  }
+
+  /** Requests not stored because the maxEntries cap was reached. */
+  getDroppedCount(): number {
+    return this.droppedEntries;
   }
 
   clear(): void {

--- a/src/reliability/crash-watcher.ts
+++ b/src/reliability/crash-watcher.ts
@@ -26,6 +26,8 @@ export class SimulatorCrashWatcher extends EventEmitter {
     }
 
     this.interval = setInterval(() => this.check(), checkIntervalMs);
+    // Watchdogs must never be the thing keeping the process alive.
+    this.interval.unref();
   }
 
   stop(): void {

--- a/src/simulator/pool.ts
+++ b/src/simulator/pool.ts
@@ -331,6 +331,8 @@ export class SimulatorPool extends EventEmitter {
         }
       }
     }, DEFAULT_IDLE_CHECK_INTERVAL_MS);
+    // Monitors must never be the thing keeping the process alive.
+    this.idleCheckInterval.unref();
   }
 
   stopIdleMonitor(): void {
@@ -357,6 +359,8 @@ export class SimulatorPool extends EventEmitter {
         }
       }
     }, DEFAULT_RESOURCE_CHECK_INTERVAL_MS);
+    // Monitors must never be the thing keeping the process alive.
+    this.resourceCheckInterval.unref();
   }
 
   stopResourceMonitor(): void {

--- a/src/tools/console-log.ts
+++ b/src/tools/console-log.ts
@@ -1,5 +1,5 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { BufferedEventCollector, CollectedEvent } from '../utils/buffered-event-collector';
+import { BufferedEventCollector, CollectedEvent, getOrCreateSessionCollector } from '../utils/buffered-event-collector';
 
 export interface ConsoleEntry extends CollectedEvent {
   level: string;
@@ -10,9 +10,7 @@ const collectors = new Map<string, BufferedEventCollector<ConsoleEntry>>();
 let attachedClient: unknown = null;
 
 function getOrCreateCollector(sid: string): BufferedEventCollector<ConsoleEntry> {
-  let c = collectors.get(sid);
-  if (!c) { c = new BufferedEventCollector<ConsoleEntry>(500); collectors.set(sid, c); }
-  return c;
+  return getOrCreateSessionCollector(collectors, sid);
 }
 
 export function registerConsoleLogTool(server: MCPServer): void {

--- a/src/tools/error-log.ts
+++ b/src/tools/error-log.ts
@@ -1,5 +1,5 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { BufferedEventCollector, CollectedEvent } from '../utils/buffered-event-collector';
+import { BufferedEventCollector, CollectedEvent, getOrCreateSessionCollector } from '../utils/buffered-event-collector';
 
 export interface ErrorEntry extends CollectedEvent {
   message: string;
@@ -13,9 +13,7 @@ const collectors = new Map<string, BufferedEventCollector<ErrorEntry>>();
 let attachedClient: unknown = null;
 
 function getOrCreateCollector(sid: string): BufferedEventCollector<ErrorEntry> {
-  let c = collectors.get(sid);
-  if (!c) { c = new BufferedEventCollector<ErrorEntry>(500); collectors.set(sid, c); }
-  return c;
+  return getOrCreateSessionCollector(collectors, sid);
 }
 
 export function registerErrorLogTool(server: MCPServer): void {

--- a/src/tools/network-log.ts
+++ b/src/tools/network-log.ts
@@ -1,5 +1,5 @@
 import { MCPServer, getWebKitClient } from '../mcp-server';
-import { BufferedEventCollector, CollectedEvent } from '../utils/buffered-event-collector';
+import { BufferedEventCollector, CollectedEvent, getOrCreateSessionCollector } from '../utils/buffered-event-collector';
 import { ErrorCode, respondWithStructuredError } from '../errors';
 
 export interface NetworkEntry extends CollectedEvent {
@@ -13,9 +13,7 @@ const collectors = new Map<string, BufferedEventCollector<NetworkEntry>>();
 let attachedClient: unknown = null;
 
 function getOrCreateCollector(sid: string): BufferedEventCollector<NetworkEntry> {
-  let c = collectors.get(sid);
-  if (!c) { c = new BufferedEventCollector<NetworkEntry>(500); collectors.set(sid, c); }
-  return c;
+  return getOrCreateSessionCollector(collectors, sid);
 }
 
 export function registerNetworkLogTool(server: MCPServer): void {

--- a/src/utils/buffered-event-collector.ts
+++ b/src/utils/buffered-event-collector.ts
@@ -23,3 +23,34 @@ export class BufferedEventCollector<T extends CollectedEvent = CollectedEvent> {
   clear(): void { this.buffer = []; }
   get size(): number { return this.buffer.length; }
 }
+
+/** Upper bound on per-session collector maps held by log tools. */
+export const MAX_SESSION_COLLECTORS = 32;
+
+/**
+ * Get or create a session's collector in a bounded map.
+ *
+ * Session collectors are deliberately NOT deleted on `stop` (the
+ * `stop -> get` sequence must keep working), so the map is bounded instead:
+ * when full, the least-recently-used session is evicted. Map insertion order
+ * provides the LRU order; access refreshes a session's position.
+ */
+export function getOrCreateSessionCollector<T extends CollectedEvent>(
+  collectors: Map<string, BufferedEventCollector<T>>,
+  sessionId: string,
+  bufferSize = 500,
+): BufferedEventCollector<T> {
+  const existing = collectors.get(sessionId);
+  if (existing) {
+    collectors.delete(sessionId);
+    collectors.set(sessionId, existing);
+    return existing;
+  }
+  if (collectors.size >= MAX_SESSION_COLLECTORS) {
+    const oldest = collectors.keys().next().value;
+    if (oldest !== undefined) collectors.delete(oldest);
+  }
+  const created = new BufferedEventCollector<T>(bufferSize);
+  collectors.set(sessionId, created);
+  return created;
+}

--- a/src/watchdog/simulator-monitor.ts
+++ b/src/watchdog/simulator-monitor.ts
@@ -21,6 +21,8 @@ export class SimulatorMonitor extends EventEmitter {
   start(): void {
     if (this.interval) return;
     this.interval = setInterval(() => this.check(), this.checkIntervalMs);
+    // Watchdogs must never be the thing keeping the process alive.
+    this.interval.unref();
   }
 
   stop(): void {

--- a/tests/unit/long-session-hygiene.test.ts
+++ b/tests/unit/long-session-hygiene.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Long-session hygiene (issue #848):
+ * - HAR collector entry cap + body-size precheck before the RPC fetch
+ * - bounded per-session log collector maps (LRU eviction)
+ * - watchdog/pool monitor timers are unref()'d
+ */
+import { EventEmitter } from 'events';
+import { HarCollector } from '../../src/network/har-collector';
+import {
+  BufferedEventCollector,
+  CollectedEvent,
+  MAX_SESSION_COLLECTORS,
+  getOrCreateSessionCollector,
+} from '../../src/utils/buffered-event-collector';
+import { SimulatorPool } from '../../src/simulator/pool';
+import { SimulatorCrashWatcher } from '../../src/reliability/crash-watcher';
+import { SimulatorMonitor } from '../../src/watchdog/simulator-monitor';
+
+class MockWebKitClient extends EventEmitter {
+  public sendCalls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  async enableDomain(_domain: string): Promise<void> {}
+  async send<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
+    this.sendCalls.push({ method, params });
+    if (method === 'Network.getResponseBody') {
+      return { body: '{"key":"value"}', base64Encoded: false } as T;
+    }
+    return {} as T;
+  }
+}
+
+function simulateRequest(client: MockWebKitClient, requestId: string): void {
+  client.emit('Network.requestWillBeSent', {
+    requestId,
+    timestamp: Date.now() / 1000,
+    request: { url: `https://example.com/${requestId}`, method: 'GET', headers: {} },
+  });
+}
+
+function simulateResponse(
+  client: MockWebKitClient,
+  requestId: string,
+  encodedDataLength: number,
+): void {
+  client.emit('Network.responseReceived', {
+    requestId,
+    timestamp: Date.now() / 1000,
+    response: {
+      url: `https://example.com/${requestId}`,
+      status: 200,
+      statusText: 'OK',
+      mimeType: 'application/json',
+      headers: { 'Content-Type': 'application/json' },
+      encodedDataLength,
+    },
+  });
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('HarCollector entry cap', () => {
+  test('stops storing entries at maxEntries and counts the dropped rest', async () => {
+    const client = new MockWebKitClient();
+    const collector = new HarCollector(client as any, { maxEntries: 3 });
+    await collector.start();
+
+    for (let i = 0; i < 5; i++) simulateRequest(client, `req-${i}`);
+
+    expect(collector.getEntryCount()).toBe(3);
+    expect(collector.getDroppedCount()).toBe(2);
+    collector.stop();
+  });
+
+  test('logs the dropped count on stop', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const client = new MockWebKitClient();
+    const collector = new HarCollector(client as any, { maxEntries: 1 });
+    await collector.start();
+
+    simulateRequest(client, 'req-0');
+    simulateRequest(client, 'req-1');
+    collector.stop();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Dropped 1 request(s) beyond maxEntries=1'),
+    );
+    errorSpy.mockRestore();
+  });
+
+  test('a new start() resets the dropped counter', async () => {
+    const client = new MockWebKitClient();
+    const collector = new HarCollector(client as any, { maxEntries: 1 });
+    await collector.start();
+    simulateRequest(client, 'req-0');
+    simulateRequest(client, 'req-1');
+    collector.stop();
+
+    await collector.start();
+    expect(collector.getDroppedCount()).toBe(0);
+    collector.stop();
+  });
+});
+
+describe('HarCollector body-size precheck', () => {
+  test('skips the getResponseBody RPC when encodedDataLength exceeds maxBodySize', async () => {
+    const client = new MockWebKitClient();
+    const collector = new HarCollector(client as any, { captureBody: true, maxBodySize: 10 });
+    await collector.start();
+
+    simulateRequest(client, 'req-big');
+    simulateResponse(client, 'req-big', 1_000_000);
+    await flush();
+
+    const bodyFetches = client.sendCalls.filter((c) => c.method === 'Network.getResponseBody');
+    expect(bodyFetches).toHaveLength(0);
+    collector.stop();
+  });
+
+  test('still fetches the body when the size fits', async () => {
+    const client = new MockWebKitClient();
+    const collector = new HarCollector(client as any, { captureBody: true, maxBodySize: 1024 });
+    await collector.start();
+
+    simulateRequest(client, 'req-small');
+    simulateResponse(client, 'req-small', 64);
+    await flush();
+
+    const bodyFetches = client.sendCalls.filter((c) => c.method === 'Network.getResponseBody');
+    expect(bodyFetches).toHaveLength(1);
+    collector.stop();
+  });
+});
+
+describe('getOrCreateSessionCollector LRU bound', () => {
+  type Entry = CollectedEvent & { message: string };
+
+  test('evicts the least-recently-used session beyond the cap', () => {
+    const map = new Map<string, BufferedEventCollector<Entry>>();
+    for (let i = 0; i < MAX_SESSION_COLLECTORS; i++) {
+      getOrCreateSessionCollector(map, `session-${i}`);
+    }
+    // Touch session-0 so it becomes most-recently-used.
+    getOrCreateSessionCollector(map, 'session-0');
+
+    getOrCreateSessionCollector(map, 'session-new');
+
+    expect(map.size).toBe(MAX_SESSION_COLLECTORS);
+    expect(map.has('session-0')).toBe(true); // refreshed, not evicted
+    expect(map.has('session-1')).toBe(false); // oldest untouched -> evicted
+    expect(map.has('session-new')).toBe(true);
+  });
+
+  test('stop -> get keeps working (collectors are not deleted on stop)', () => {
+    const map = new Map<string, BufferedEventCollector<Entry>>();
+    const collector = getOrCreateSessionCollector(map, 'session-a');
+    collector.start();
+    collector.push({ timestamp: Date.now(), message: 'hello' });
+    collector.stop();
+
+    const again = getOrCreateSessionCollector(map, 'session-a');
+    expect(again).toBe(collector);
+    expect(again.get()).toHaveLength(1);
+  });
+});
+
+describe('monitor timers are unref()d', () => {
+  test('SimulatorCrashWatcher interval does not hold the event loop', () => {
+    const pool = new SimulatorPool({ max: 1 });
+    const watcher = new SimulatorCrashWatcher(pool);
+    watcher.start(10_000);
+    const interval = (watcher as unknown as { interval: NodeJS.Timeout }).interval;
+    expect(interval.hasRef()).toBe(false);
+    watcher.stop();
+  });
+
+  test('SimulatorMonitor interval does not hold the event loop', () => {
+    const monitor = new SimulatorMonitor();
+    monitor.start();
+    const interval = (monitor as unknown as { interval: NodeJS.Timeout }).interval;
+    expect(interval.hasRef()).toBe(false);
+    monitor.stop();
+  });
+
+  test('SimulatorPool idle and resource monitor intervals do not hold the event loop', () => {
+    const pool = new SimulatorPool({ max: 1 });
+    pool.startIdleMonitor();
+    pool.startResourceMonitor();
+    const idle = (pool as unknown as { idleCheckInterval: NodeJS.Timeout }).idleCheckInterval;
+    const resource = (pool as unknown as { resourceCheckInterval: NodeJS.Timeout }).resourceCheckInterval;
+    expect(idle.hasRef()).toBe(false);
+    expect(resource.hasRef()).toBe(false);
+    pool.stopIdleMonitor();
+    pool.stopResourceMonitor();
+  });
+});

--- a/tests/unit/long-session-hygiene.test.ts
+++ b/tests/unit/long-session-hygiene.test.ts
@@ -59,6 +59,7 @@ const flush = () => new Promise((resolve) => setImmediate(resolve));
 
 describe('HarCollector entry cap', () => {
   test('stops storing entries at maxEntries and counts the dropped rest', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const client = new MockWebKitClient();
     const collector = new HarCollector(client as any, { maxEntries: 3 });
     await collector.start();
@@ -68,6 +69,10 @@ describe('HarCollector entry cap', () => {
     expect(collector.getEntryCount()).toBe(3);
     expect(collector.getDroppedCount()).toBe(2);
     collector.stop();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Dropped 2 request(s) beyond maxEntries=3'),
+    );
+    errorSpy.mockRestore();
   });
 
   test('logs the dropped count on stop', async () => {
@@ -87,6 +92,7 @@ describe('HarCollector entry cap', () => {
   });
 
   test('a new start() resets the dropped counter', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const client = new MockWebKitClient();
     const collector = new HarCollector(client as any, { maxEntries: 1 });
     await collector.start();
@@ -97,6 +103,7 @@ describe('HarCollector entry cap', () => {
     await collector.start();
     expect(collector.getDroppedCount()).toBe(0);
     collector.stop();
+    errorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Closes #848

## Summary

Bounds the three remaining unbounded-growth / lingering-resource paths for long-running MCP sessions. (Scope corrected from the original analysis during verification: the per-buffer caps were already in place at 500 entries — the leaks were the HAR entry map, the collector *map*, and non-unref'd timers.)

### HAR collector (`src/network/har-collector.ts`)
- `maxEntries` option (default **2000**): requests beyond the cap are counted as dropped instead of stored; the dropped count is logged on `stop()` and exposed via `getDroppedCount()`. Existing entries are never evicted (HAR consumers expect a stable prefix with intact request/response pairing).
- Body precheck: when `captureBody` is on and `encodedDataLength` already exceeds `maxBodySize`, the `Network.getResponseBody` RPC is skipped entirely — previously the full body was transferred over the protocol just to be discarded. The post-fetch length check stays (encodedDataLength can be absent/-1).

### Log collector maps (`console_log` / `error_log` / `network_log`)
- New shared `getOrCreateSessionCollector` helper bounds each per-session map at **32 sessions** with LRU eviction (Map insertion order; access refreshes position). Collectors are intentionally NOT deleted on `stop` — the `stop → get` sequence keeps working.

### Watchdog timers
- `unref()` on the crash watcher (10s), simulator monitor, and pool idle/resource intervals, matching `event-loop-monitor` and `zombie-cleanup` which already did this. Same intervals, same checks — the timers just can no longer hold an exiting process open.

## Verification

- New `tests/unit/long-session-hygiene.test.ts` (10 tests): entry cap + dropped count + reset on restart + stop-log; RPC skipped for oversized bodies / still issued for fitting bodies; LRU eviction + access refresh + `stop → get`; `hasRef() === false` for all four intervals.
- Full `npx jest tests/unit tests/integration`: 211 suites / 2922 tests pass.
- `npx tsc --noEmit` clean.

Out of scope per issue: async rewrite of `metrics/heap-snapshot-diff.ts`, monitor idle-stop redesign, MCP session-lifecycle plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)