### PR TITLE
[codex] Support TestFlight and StoreKit button semantics

### DIFF
--- a/src/native/system-button-catalog.ts
+++ b/src/native/system-button-catalog.ts
@@ -20,6 +20,13 @@ export type LocalizedButtonEntry = Record<SupportedLocale, string>;
 export type SemanticButtonKey =
   | 'storekit.signIn'
   | 'storekit.cancel'
+  | 'storekit.confirm'
+  | 'storekit.buy'
+  | 'storekit.subscribe'
+  | 'testflight.install'
+  | 'testflight.update'
+  | 'testflight.open'
+  | 'testflight.signIn'
   | 'alert.ok'
   | 'alert.cancel'
   | 'permission.allow'
@@ -48,6 +55,48 @@ export const SYSTEM_BUTTON_CATALOG: Record<SemanticButtonKey, LocalizedButtonEnt
     ko: '취소',
     ja: 'キャンセル',
     'zh-Hans': '取消',
+  },
+  'storekit.confirm': {
+    en: 'Confirm',
+    ko: '확인',
+    ja: '確認',
+    'zh-Hans': '确认',
+  },
+  'storekit.buy': {
+    en: 'Buy',
+    ko: '구입',
+    ja: '購入',
+    'zh-Hans': '购买',
+  },
+  'storekit.subscribe': {
+    en: 'Subscribe',
+    ko: '구독',
+    ja: '登録',
+    'zh-Hans': '订阅',
+  },
+  'testflight.install': {
+    en: 'Install',
+    ko: '설치',
+    ja: 'インストール',
+    'zh-Hans': '安装',
+  },
+  'testflight.update': {
+    en: 'Update',
+    ko: '업데이트',
+    ja: 'アップデート',
+    'zh-Hans': '更新',
+  },
+  'testflight.open': {
+    en: 'Open',
+    ko: '열기',
+    ja: '開く',
+    'zh-Hans': '打开',
+  },
+  'testflight.signIn': {
+    en: 'Sign In',
+    ko: '로그인',
+    ja: 'サインイン',
+    'zh-Hans': '登录',
   },
   'alert.ok': {
     en: 'OK',

--- a/tests/unit/system-button-catalog.test.ts
+++ b/tests/unit/system-button-catalog.test.ts
@@ -1,0 +1,58 @@
+import {
+  resolveSemanticLabel,
+  SYSTEM_BUTTON_CATALOG,
+  SemanticButtonKey,
+  SupportedLocale,
+} from '../../src/native/system-button-catalog';
+
+const newSemanticKeys: SemanticButtonKey[] = [
+  'storekit.confirm',
+  'storekit.buy',
+  'storekit.subscribe',
+  'testflight.install',
+  'testflight.update',
+  'testflight.open',
+  'testflight.signIn',
+];
+
+const supportedLocales: SupportedLocale[] = ['en', 'ko', 'ja', 'zh-Hans'];
+
+const expectedEnglishLabels = {
+  'storekit.confirm': 'Confirm',
+  'storekit.buy': 'Buy',
+  'storekit.subscribe': 'Subscribe',
+  'testflight.install': 'Install',
+  'testflight.update': 'Update',
+  'testflight.open': 'Open',
+  'testflight.signIn': 'Sign In',
+  'storekit.cancel': 'Cancel',
+} satisfies Partial<Record<SemanticButtonKey, string>>;
+
+describe('system button catalog', () => {
+  test('resolves StoreKit and TestFlight labels for every supported locale', () => {
+    for (const key of newSemanticKeys) {
+      for (const locale of supportedLocales) {
+        expect(resolveSemanticLabel(key, locale)).toBe(
+          SYSTEM_BUTTON_CATALOG[key][locale],
+        );
+        expect(resolveSemanticLabel(key, locale)).toEqual(expect.any(String));
+        expect(resolveSemanticLabel(key, locale).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test('uses the requested English StoreKit and TestFlight button labels', () => {
+    for (const [key, label] of Object.entries(expectedEnglishLabels)) {
+      expect(resolveSemanticLabel(key as SemanticButtonKey, 'en')).toBe(label);
+    }
+  });
+
+  test('falls back to English for unsupported locales', () => {
+    const keys = [...newSemanticKeys, 'storekit.cancel'] as SemanticButtonKey[];
+    for (const key of keys) {
+      expect(resolveSemanticLabel(key, 'fr-FR')).toBe(
+        SYSTEM_BUTTON_CATALOG[key].en,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Extend the system button catalog with minimal StoreKit purchase labels and TestFlight action labels.
- Add focused unit coverage proving the new semantic keys resolve for supported locales and fall back to English for unknown locales.

## Why
PR C from `.omx/plans/testflight-iap-automation-plan.md` needs catalog-level label support before higher-level TestFlight/IAP automation can classify or handle these buttons safely.

## Scope
- Added semantic keys for `storekit.confirm`, `storekit.buy`, `storekit.subscribe`, `testflight.install`, `testflight.update`, `testflight.open`, and `testflight.signIn`.
- Preserved the existing `en` / `ko` / `ja` / `zh-Hans` catalog shape.
- Did not add a localization framework, dependency, network lookup, classifier, or tool changes.

## Validation
- `npx jest --config jest.config.js tests/unit/system-button-catalog.test.ts tests/unit/localized-button-matcher.test.ts --runInBand`
- `npx tsc --noEmit`
- `npx eslint src/native/system-button-catalog.ts tests/unit/system-button-catalog.test.ts`
- `git diff --check origin/main...HEAD`
- `npm test -- --runInBand` — 217 suites / 2954 tests passed
