### PR TITLE
Scope the Omofictions path guard to its own QA lane

### DIFF
--- a/.github/workflows/omofictions-qa.yml
+++ b/.github/workflows/omofictions-qa.yml
@@ -28,13 +28,15 @@ on:
         default: false
   pull_request:
     # Path-guard job only. It enforces #44 Clarification 5 mechanically on
-    # every PR that touches this workflow or its scripts/docs. The full QA
-    # run never fires on PRs — that would require a build artefact that is
-    # not guaranteed to be available.
+    # PRs that touch the Omofictions-specific workflow contract. Other QA
+    # utilities under scripts/qa or docs/qa are independent product surfaces
+    # and must not be classified as Omofictions QA-lane changes. The full QA
+    # run never fires on PRs — that would require a build artefact that is not
+    # guaranteed to be available.
     paths:
       - '.github/workflows/omofictions-qa.yml'
-      - 'scripts/qa/**'
-      - 'docs/qa/**'
+      - 'scripts/qa/omofictions-*'
+      - 'docs/qa/omofictions-app.md'
 
 jobs:
   # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Narrow the Omofictions private-route workflow's pull-request path filter from all `scripts/qa/**` and `docs/qa/**` files to the Omofictions-owned script and document paths only.

## Why

The existing trigger classified unrelated QA utilities, including the App Store Connect readiness classifier, as Omofictions QA-lane work. Its path guard then rejected otherwise valid runtime PRs because they also touched `src/**` or `tests/**`.

The #44 ownership boundary remains intact for PRs that actually modify the Omofictions workflow contract.

## Validation

- Ruby YAML parse passed
- `git diff --check` passed
